### PR TITLE
feat: semantic find_references — filter by symbol kind to eliminate false positives

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1843,7 +1843,12 @@ fn symbol_kind_at(source: &str, position: Position, word: &str) -> Option<Symbol
     }
 
     // If the word starts with an uppercase letter it is likely a class/interface/enum name.
-    if word.chars().next().map(|c| c.is_uppercase()).unwrap_or(false) {
+    if word
+        .chars()
+        .next()
+        .map(|c| c.is_uppercase())
+        .unwrap_or(false)
+    {
         return Some(SymbolKind::Class);
     }
 

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -37,7 +37,7 @@ use crate::on_type_format::on_type_format;
 use crate::organize_imports::organize_imports_action;
 use crate::phpdoc_action::phpdoc_actions;
 use crate::phpstorm_meta::PhpStormMeta;
-use crate::references::find_references;
+use crate::references::{SymbolKind, find_references};
 use crate::rename::{prepare_rename, rename, rename_property, rename_variable};
 use crate::selection_range::selection_ranges;
 use crate::semantic_diagnostics::{
@@ -690,9 +690,10 @@ impl LanguageServer for Backend {
             Some(w) => w,
             None => return Ok(None),
         };
+        let kind = symbol_kind_at(&source, position, &word);
         let all_docs = self.docs.all_docs();
         let include_declaration = params.context.include_declaration;
-        let locations = find_references(&word, &all_docs, include_declaration);
+        let locations = find_references(&word, &all_docs, include_declaration, kind);
         Ok(if locations.is_empty() {
             None
         } else {
@@ -1787,6 +1788,67 @@ fn is_after_arrow(source: &str, position: Position) -> bool {
         char_idx -= 1;
     }
     char_idx >= 2 && chars[char_idx - 1] == '>' && chars[char_idx - 2] == '-'
+}
+
+/// Classify the symbol at `position` so `find_references` can use the right walker.
+///
+/// Heuristics (in priority order):
+/// 1. Preceded by `->` or `?->` → `Method`
+/// 2. Preceded by `::` → `Method` (static)
+/// 3. Word starts with `$` → variable (returns `None`; variables are handled separately)
+/// 4. First character is uppercase AND not preceded by `->` or `::` → `Class`
+/// 5. Otherwise → `Function`
+///
+/// Falls back to `None` when the context cannot be determined.
+fn symbol_kind_at(source: &str, position: Position, word: &str) -> Option<SymbolKind> {
+    if word.starts_with('$') {
+        return None; // variables handled elsewhere
+    }
+    let line = source.lines().nth(position.line as usize)?;
+    let chars: Vec<char> = line.chars().collect();
+
+    // Convert UTF-16 column to char index.
+    let col = position.character as usize;
+    let mut utf16_col = 0usize;
+    let mut char_idx = 0usize;
+    for ch in &chars {
+        if utf16_col >= col {
+            break;
+        }
+        utf16_col += ch.len_utf16();
+        char_idx += 1;
+    }
+
+    // Walk left past identifier characters to find the first character before the word.
+    let is_word_char = |c: char| c.is_alphanumeric() || c == '_';
+    while char_idx > 0 && is_word_char(chars[char_idx - 1]) {
+        char_idx -= 1;
+    }
+
+    // Check for `->` or `?->`
+    if char_idx >= 2 && chars[char_idx - 1] == '>' && chars[char_idx - 2] == '-' {
+        return Some(SymbolKind::Method);
+    }
+    if char_idx >= 3
+        && chars[char_idx - 1] == '>'
+        && chars[char_idx - 2] == '-'
+        && chars[char_idx - 3] == '?'
+    {
+        return Some(SymbolKind::Method);
+    }
+
+    // Check for `::`
+    if char_idx >= 2 && chars[char_idx - 1] == ':' && chars[char_idx - 2] == ':' {
+        return Some(SymbolKind::Method);
+    }
+
+    // If the word starts with an uppercase letter it is likely a class/interface/enum name.
+    if word.chars().next().map(|c| c.is_uppercase()).unwrap_or(false) {
+        return Some(SymbolKind::Class);
+    }
+
+    // Otherwise treat as a free function.
+    Some(SymbolKind::Function)
 }
 
 impl Backend {

--- a/src/call_hierarchy.rs
+++ b/src/call_hierarchy.rs
@@ -28,7 +28,7 @@ pub fn incoming_calls(
     item: &CallHierarchyItem,
     all_docs: &[(Url, Arc<ParsedDoc>)],
 ) -> Vec<CallHierarchyIncomingCall> {
-    let call_sites = find_references(&item.name, all_docs, false);
+    let call_sites = find_references(&item.name, all_docs, false, None);
     let mut result: Vec<CallHierarchyIncomingCall> = Vec::new();
 
     for loc in call_sites {

--- a/src/code_lens.rs
+++ b/src/code_lens.rs
@@ -117,7 +117,7 @@ fn ref_count_lens(
     name: &str,
     all_docs: &[(Url, Arc<ParsedDoc>)],
 ) -> CodeLens {
-    let count = find_references(name, all_docs, false).len();
+    let count = find_references(name, all_docs, false, None).len();
     let label = match count {
         0 => "0 references".to_string(),
         1 => "1 reference".to_string(),

--- a/src/organize_imports.rs
+++ b/src/organize_imports.rs
@@ -221,9 +221,10 @@ fn is_used(u: &UseStatement, body: &str) -> bool {
     while let Some(pos) = body[start..].find(short.as_str()) {
         let abs = start + pos;
         let before_ok = abs == 0
-            || !body.as_bytes().get(abs - 1).is_some_and(|b| {
-                b.is_ascii_alphanumeric() || *b == b'_' || *b == b'\\'
-            });
+            || !body
+                .as_bytes()
+                .get(abs - 1)
+                .is_some_and(|b| b.is_ascii_alphanumeric() || *b == b'_' || *b == b'\\');
         let after_ok = body
             .as_bytes()
             .get(abs + short.len())

--- a/src/references.rs
+++ b/src/references.rs
@@ -4,26 +4,46 @@ use php_ast::{ClassMemberKind, EnumMemberKind, NamespaceBody, Span, Stmt, StmtKi
 use tower_lsp::lsp_types::{Location, Position, Range, Url};
 
 use crate::ast::{ParsedDoc, offset_to_position};
-use crate::walk::{refs_in_stmts, refs_in_stmts_with_use};
+use crate::walk::{
+    class_refs_in_stmts, function_refs_in_stmts, method_refs_in_stmts, refs_in_stmts,
+    refs_in_stmts_with_use,
+};
+
+/// What kind of symbol the cursor is on.  Used to dispatch to the
+/// appropriate semantic walker so that, e.g., searching for `get` as a
+/// *method* doesn't return free-function calls named `get`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SymbolKind {
+    /// A free (top-level) function.
+    Function,
+    /// An instance or static method (`->name`, `?->name`, `::name`).
+    Method,
+    /// A class, interface, trait, or enum name used as a type.
+    Class,
+}
 
 /// Find all locations where `word` is referenced across the given documents.
 /// If `include_declaration` is true, also includes the declaration site.
+/// Pass `kind` to restrict results to a particular symbol category; `None`
+/// falls back to the original word-based walker (better some results than none).
 pub fn find_references(
     word: &str,
     all_docs: &[(Url, Arc<ParsedDoc>)],
     include_declaration: bool,
+    kind: Option<SymbolKind>,
 ) -> Vec<Location> {
-    find_references_inner(word, all_docs, include_declaration, false)
+    find_references_inner(word, all_docs, include_declaration, false, kind)
 }
 
 /// Like `find_references` but also includes `use` statement spans.
 /// Used by rename so that `use Foo;` statements are also updated.
+/// Always uses the general walker (rename must update all occurrence kinds).
 pub fn find_references_with_use(
     word: &str,
     all_docs: &[(Url, Arc<ParsedDoc>)],
     include_declaration: bool,
 ) -> Vec<Location> {
-    find_references_inner(word, all_docs, include_declaration, true)
+    find_references_inner(word, all_docs, include_declaration, true, None)
 }
 
 fn find_references_inner(
@@ -31,6 +51,7 @@ fn find_references_inner(
     all_docs: &[(Url, Arc<ParsedDoc>)],
     include_declaration: bool,
     include_use: bool,
+    kind: Option<SymbolKind>,
 ) -> Vec<Location> {
     let mut locations = Vec::new();
 
@@ -39,9 +60,15 @@ fn find_references_inner(
         let stmts = &doc.program().stmts;
         let mut spans = Vec::new();
         if include_use {
+            // Rename path: always use the general walker so `use` imports are included.
             refs_in_stmts_with_use(stmts, word, &mut spans);
         } else {
-            refs_in_stmts(stmts, word, &mut spans);
+            match kind {
+                Some(SymbolKind::Function) => function_refs_in_stmts(stmts, word, &mut spans),
+                Some(SymbolKind::Method) => method_refs_in_stmts(stmts, word, &mut spans),
+                Some(SymbolKind::Class) => class_refs_in_stmts(stmts, word, &mut spans),
+                None => refs_in_stmts(stmts, word, &mut spans),
+            }
         }
 
         if !include_declaration {
@@ -168,7 +195,7 @@ mod tests {
     fn finds_function_call_reference() {
         let src = "<?php\nfunction greet() {}\ngreet();\ngreet();";
         let docs = vec![doc("/a.php", src)];
-        let refs = find_references("greet", &docs, false);
+        let refs = find_references("greet", &docs, false, None);
         assert_eq!(refs.len(), 2, "expected 2 call-site refs, got {:?}", refs);
     }
 
@@ -176,8 +203,8 @@ mod tests {
     fn include_declaration_adds_def_site() {
         let src = "<?php\nfunction greet() {}\ngreet();";
         let docs = vec![doc("/a.php", src)];
-        let with_decl = find_references("greet", &docs, true);
-        let without_decl = find_references("greet", &docs, false);
+        let with_decl = find_references("greet", &docs, true, None);
+        let without_decl = find_references("greet", &docs, false, None);
         // Without declaration: only the call site (line 2)
         assert_eq!(
             without_decl.len(),
@@ -200,7 +227,7 @@ mod tests {
     fn finds_new_expression_reference() {
         let src = "<?php\nclass Foo {}\n$x = new Foo();";
         let docs = vec![doc("/a.php", src)];
-        let refs = find_references("Foo", &docs, false);
+        let refs = find_references("Foo", &docs, false, None);
         assert_eq!(
             refs.len(),
             1,
@@ -216,7 +243,7 @@ mod tests {
     fn finds_reference_in_nested_function_call() {
         let src = "<?php\nfunction greet() {}\necho(greet());";
         let docs = vec![doc("/a.php", src)];
-        let refs = find_references("greet", &docs, false);
+        let refs = find_references("greet", &docs, false, None);
         assert_eq!(
             refs.len(),
             1,
@@ -232,7 +259,7 @@ mod tests {
     fn finds_references_across_multiple_docs() {
         let a = doc("/a.php", "<?php\nfunction helper() {}");
         let b = doc("/b.php", "<?php\nhelper();\nhelper();");
-        let refs = find_references("helper", &[a, b], false);
+        let refs = find_references("helper", &[a, b], false, None);
         assert_eq!(refs.len(), 2, "expected 2 cross-file references");
         assert!(refs.iter().all(|r| r.uri.path().ends_with("/b.php")));
     }
@@ -241,7 +268,7 @@ mod tests {
     fn finds_method_call_reference() {
         let src = "<?php\nclass Calc { public function add() {} }\n$c = new Calc();\n$c->add();";
         let docs = vec![doc("/a.php", src)];
-        let refs = find_references("add", &docs, false);
+        let refs = find_references("add", &docs, false, None);
         assert_eq!(
             refs.len(),
             1,
@@ -257,7 +284,7 @@ mod tests {
     fn finds_reference_inside_if_body() {
         let src = "<?php\nfunction check() {}\nif (true) { check(); }";
         let docs = vec![doc("/a.php", src)];
-        let refs = find_references("check", &docs, false);
+        let refs = find_references("check", &docs, false, None);
         assert_eq!(refs.len(), 1, "expected exactly 1 reference inside if body");
         assert_eq!(
             refs[0].range.start.line, 2,
@@ -293,7 +320,7 @@ mod tests {
         // `helper` is called on lines 1 and 2 (0-based); check exact line numbers.
         let src = "<?php\nhelper();\nhelper();\nfunction helper() {}";
         let docs = vec![doc("/a.php", src)];
-        let refs = find_references("helper", &docs, false);
+        let refs = find_references("helper", &docs, false, None);
         assert_eq!(refs.len(), 2, "expected exactly 2 call-site references");
         let mut lines: Vec<u32> = refs.iter().map(|r| r.range.start.line).collect();
         lines.sort_unstable();
@@ -305,7 +332,7 @@ mod tests {
         // When include_declaration=false the declaration line must not appear.
         let src = "<?php\nfunction doWork() {}\ndoWork();\ndoWork();";
         let docs = vec![doc("/a.php", src)];
-        let refs = find_references("doWork", &docs, false);
+        let refs = find_references("doWork", &docs, false, None);
         // Declaration is on line 1; call sites are on lines 2 and 3.
         let lines: Vec<u32> = refs.iter().map(|r| r.range.start.line).collect();
         assert!(
@@ -321,7 +348,7 @@ mod tests {
         // Searching for references to `greet` should NOT include occurrences of `greeting`.
         let src = "<?php\nfunction greet() {}\nfunction greeting() {}\ngreet();\ngreeting();";
         let docs = vec![doc("/a.php", src)];
-        let refs = find_references("greet", &docs, false);
+        let refs = find_references("greet", &docs, false, None);
         // Only `greet()` call site should be included, not `greeting()`.
         for r in &refs {
             // Each reference range should span exactly the length of "greet" (5 chars),
@@ -347,7 +374,7 @@ mod tests {
         // A class constant used as a property default value should be found by find_references.
         let src = "<?php\nclass Foo {\n    public string $status = Status::ACTIVE;\n}";
         let docs = vec![doc("/a.php", src)];
-        let refs = find_references("Status", &docs, false);
+        let refs = find_references("Status", &docs, false, None);
         assert_eq!(
             refs.len(),
             1,
@@ -362,7 +389,7 @@ mod tests {
         // A function call inside an enum method body should be found by find_references.
         let src = "<?php\nfunction helper() {}\nenum Status {\n    public function label(): string { return helper(); }\n}";
         let docs = vec![doc("/a.php", src)];
-        let refs = find_references("helper", &docs, false);
+        let refs = find_references("helper", &docs, false, None);
         assert_eq!(
             refs.len(),
             1,
@@ -377,7 +404,7 @@ mod tests {
         // Function calls in `for` init and update expressions should be found.
         let src = "<?php\nfunction tick() {}\nfor (tick(); $i < 10; tick()) {}";
         let docs = vec![doc("/a.php", src)];
-        let refs = find_references("tick", &docs, false);
+        let refs = find_references("tick", &docs, false, None);
         assert_eq!(
             refs.len(),
             2,
@@ -386,5 +413,90 @@ mod tests {
         );
         // Both are on line 2.
         assert!(refs.iter().all(|r| r.range.start.line == 2));
+    }
+
+    // ── Semantic (kind-aware) tests ───────────────────────────────────────────
+
+    #[test]
+    fn function_kind_skips_method_call_with_same_name() {
+        // When looking for the free function `get`, method calls `$obj->get()` must be excluded.
+        let src = "<?php\nfunction get() {}\nget();\n$obj->get();";
+        let docs = vec![doc("/a.php", src)];
+        let refs = find_references("get", &docs, false, Some(SymbolKind::Function));
+        // Only the free call `get()` on line 2 should appear; not the method call on line 3.
+        assert_eq!(
+            refs.len(),
+            1,
+            "expected 1 free-function ref, got: {:?}",
+            refs
+        );
+        assert_eq!(refs[0].range.start.line, 2);
+    }
+
+    #[test]
+    fn method_kind_skips_free_function_call_with_same_name() {
+        // When looking for the method `add`, the free function call `add()` must be excluded.
+        let src = "<?php\nfunction add() {}\nadd();\n$calc->add();";
+        let docs = vec![doc("/a.php", src)];
+        let refs = find_references("add", &docs, false, Some(SymbolKind::Method));
+        // Only the method call on line 3 should appear.
+        assert_eq!(refs.len(), 1, "expected 1 method ref, got: {:?}", refs);
+        assert_eq!(refs[0].range.start.line, 3);
+    }
+
+    #[test]
+    fn class_kind_finds_new_expression() {
+        // SymbolKind::Class should find `new Foo()` but not a free function call `Foo()`.
+        let src = "<?php\nclass Foo {}\n$x = new Foo();\nFoo();";
+        let docs = vec![doc("/a.php", src)];
+        let refs = find_references("Foo", &docs, false, Some(SymbolKind::Class));
+        // `new Foo()` on line 2 yes; `Foo()` on line 3 should NOT appear as a class ref.
+        let lines: Vec<u32> = refs.iter().map(|r| r.range.start.line).collect();
+        assert!(
+            lines.contains(&2),
+            "expected new Foo() on line 2, got: {:?}",
+            refs
+        );
+        assert!(
+            !lines.contains(&3),
+            "free call Foo() should not appear as class ref, got: {:?}",
+            refs
+        );
+    }
+
+    #[test]
+    fn class_kind_finds_extends_and_implements() {
+        let src = "<?php\nclass Base {}\ninterface Iface {}\nclass Child extends Base implements Iface {}";
+        let docs = vec![doc("/a.php", src)];
+
+        let base_refs = find_references("Base", &docs, false, Some(SymbolKind::Class));
+        let lines_base: Vec<u32> = base_refs.iter().map(|r| r.range.start.line).collect();
+        assert!(
+            lines_base.contains(&3),
+            "expected extends Base on line 3, got: {:?}",
+            base_refs
+        );
+
+        let iface_refs = find_references("Iface", &docs, false, Some(SymbolKind::Class));
+        let lines_iface: Vec<u32> = iface_refs.iter().map(|r| r.range.start.line).collect();
+        assert!(
+            lines_iface.contains(&3),
+            "expected implements Iface on line 3, got: {:?}",
+            iface_refs
+        );
+    }
+
+    #[test]
+    fn class_kind_finds_type_hint() {
+        // SymbolKind::Class should find `Foo` as a parameter type hint.
+        let src = "<?php\nclass Foo {}\nfunction take(Foo $x): void {}";
+        let docs = vec![doc("/a.php", src)];
+        let refs = find_references("Foo", &docs, false, Some(SymbolKind::Class));
+        let lines: Vec<u32> = refs.iter().map(|r| r.range.start.line).collect();
+        assert!(
+            lines.contains(&2),
+            "expected type hint Foo on line 2, got: {:?}",
+            refs
+        );
     }
 }

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -1,8 +1,8 @@
 /// Deep AST walker — collects all spans where `word` appears as a name reference
 /// (function calls, `new Foo`, method calls, bare identifiers, static calls).
 use php_ast::{
-    ClassMemberKind, EnumMemberKind, Expr, ExprKind, NamespaceBody, Span, Stmt, StmtKind,
-    TypeHint, TypeHintKind,
+    ClassMemberKind, EnumMemberKind, Expr, ExprKind, NamespaceBody, Span, Stmt, StmtKind, TypeHint,
+    TypeHintKind,
 };
 
 use crate::ast::str_offset;

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -944,19 +944,19 @@ fn function_refs_in_stmt(stmt: &Stmt<'_, '_>, name: &str, out: &mut Vec<Span>) {
         }
         StmtKind::Trait(t) => {
             for member in t.members.iter() {
-                if let ClassMemberKind::Method(m) = &member.kind {
-                    if let Some(body) = &m.body {
-                        function_refs_in_stmts(body, name, out);
-                    }
+                if let ClassMemberKind::Method(m) = &member.kind
+                    && let Some(body) = &m.body
+                {
+                    function_refs_in_stmts(body, name, out);
                 }
             }
         }
         StmtKind::Enum(e) => {
             for member in e.members.iter() {
-                if let EnumMemberKind::Method(m) = &member.kind {
-                    if let Some(body) = &m.body {
-                        function_refs_in_stmts(body, name, out);
-                    }
+                if let EnumMemberKind::Method(m) = &member.kind
+                    && let Some(body) = &m.body
+                {
+                    function_refs_in_stmts(body, name, out);
                 }
             }
         }
@@ -1161,28 +1161,28 @@ fn method_refs_in_stmt(stmt: &Stmt<'_, '_>, name: &str, out: &mut Vec<Span>) {
         StmtKind::Function(f) => method_refs_in_stmts(&f.body, name, out),
         StmtKind::Class(c) => {
             for member in c.members.iter() {
-                if let ClassMemberKind::Method(m) = &member.kind {
-                    if let Some(body) = &m.body {
-                        method_refs_in_stmts(body, name, out);
-                    }
+                if let ClassMemberKind::Method(m) = &member.kind
+                    && let Some(body) = &m.body
+                {
+                    method_refs_in_stmts(body, name, out);
                 }
             }
         }
         StmtKind::Trait(t) => {
             for member in t.members.iter() {
-                if let ClassMemberKind::Method(m) = &member.kind {
-                    if let Some(body) = &m.body {
-                        method_refs_in_stmts(body, name, out);
-                    }
+                if let ClassMemberKind::Method(m) = &member.kind
+                    && let Some(body) = &m.body
+                {
+                    method_refs_in_stmts(body, name, out);
                 }
             }
         }
         StmtKind::Enum(e) => {
             for member in e.members.iter() {
-                if let EnumMemberKind::Method(m) = &member.kind {
-                    if let Some(body) = &m.body {
-                        method_refs_in_stmts(body, name, out);
-                    }
+                if let EnumMemberKind::Method(m) = &member.kind
+                    && let Some(body) = &m.body
+                {
+                    method_refs_in_stmts(body, name, out);
                 }
             }
         }
@@ -1505,10 +1505,10 @@ fn class_refs_in_stmt(stmt: &Stmt<'_, '_>, class_name: &str, out: &mut Vec<Span>
         }
         StmtKind::Enum(e) => {
             for member in e.members.iter() {
-                if let EnumMemberKind::Method(m) = &member.kind {
-                    if let Some(body) = &m.body {
-                        class_refs_in_stmts(body, class_name, out);
-                    }
+                if let EnumMemberKind::Method(m) = &member.kind
+                    && let Some(body) = &m.body
+                {
+                    class_refs_in_stmts(body, class_name, out);
                 }
             }
         }

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -2,6 +2,7 @@
 /// (function calls, `new Foo`, method calls, bare identifiers, static calls).
 use php_ast::{
     ClassMemberKind, EnumMemberKind, Expr, ExprKind, NamespaceBody, Span, Stmt, StmtKind,
+    TypeHint, TypeHintKind,
 };
 
 use crate::ast::str_offset;
@@ -898,5 +899,864 @@ pub fn refs_in_expr(expr: &Expr<'_, '_>, word: &str, out: &mut Vec<Span>) {
             }
         }
         _ => {}
+    }
+}
+
+// ── Semantic (context-aware) reference walkers ────────────────────────────────
+
+/// Collect spans where `name` is called as a free function (not a method).
+/// Only matches `name(...)` calls where the callee is a bare identifier, not
+/// `$obj->name()` or `Class::name()`.
+pub fn function_refs_in_stmts(stmts: &[Stmt<'_, '_>], name: &str, out: &mut Vec<Span>) {
+    for stmt in stmts {
+        function_refs_in_stmt(stmt, name, out);
+    }
+}
+
+fn function_refs_in_stmt(stmt: &Stmt<'_, '_>, name: &str, out: &mut Vec<Span>) {
+    match &stmt.kind {
+        StmtKind::Expression(e) => function_refs_in_expr(e, name, out),
+        StmtKind::Return(Some(e)) => function_refs_in_expr(e, name, out),
+        StmtKind::Echo(exprs) => {
+            for e in exprs.iter() {
+                function_refs_in_expr(e, name, out);
+            }
+        }
+        StmtKind::Function(f) => {
+            function_refs_in_stmts(&f.body, name, out);
+        }
+        StmtKind::Class(c) => {
+            for member in c.members.iter() {
+                match &member.kind {
+                    ClassMemberKind::Method(m) => {
+                        if let Some(body) = &m.body {
+                            function_refs_in_stmts(body, name, out);
+                        }
+                    }
+                    ClassMemberKind::Property(p) => {
+                        if let Some(default) = &p.default {
+                            function_refs_in_expr(default, name, out);
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+        StmtKind::Trait(t) => {
+            for member in t.members.iter() {
+                if let ClassMemberKind::Method(m) = &member.kind {
+                    if let Some(body) = &m.body {
+                        function_refs_in_stmts(body, name, out);
+                    }
+                }
+            }
+        }
+        StmtKind::Enum(e) => {
+            for member in e.members.iter() {
+                if let EnumMemberKind::Method(m) = &member.kind {
+                    if let Some(body) = &m.body {
+                        function_refs_in_stmts(body, name, out);
+                    }
+                }
+            }
+        }
+        StmtKind::Namespace(ns) => {
+            if let NamespaceBody::Braced(inner) = &ns.body {
+                function_refs_in_stmts(inner, name, out);
+            }
+        }
+        StmtKind::If(i) => {
+            function_refs_in_expr(&i.condition, name, out);
+            function_refs_in_stmt(i.then_branch, name, out);
+            for ei in i.elseif_branches.iter() {
+                function_refs_in_expr(&ei.condition, name, out);
+                function_refs_in_stmt(&ei.body, name, out);
+            }
+            if let Some(e) = &i.else_branch {
+                function_refs_in_stmt(e, name, out);
+            }
+        }
+        StmtKind::While(w) => {
+            function_refs_in_expr(&w.condition, name, out);
+            function_refs_in_stmt(w.body, name, out);
+        }
+        StmtKind::DoWhile(d) => {
+            function_refs_in_stmt(d.body, name, out);
+            function_refs_in_expr(&d.condition, name, out);
+        }
+        StmtKind::Foreach(f) => {
+            function_refs_in_expr(&f.expr, name, out);
+            function_refs_in_stmt(f.body, name, out);
+        }
+        StmtKind::For(f) => {
+            for e in f.init.iter() {
+                function_refs_in_expr(e, name, out);
+            }
+            for cond in f.condition.iter() {
+                function_refs_in_expr(cond, name, out);
+            }
+            for e in f.update.iter() {
+                function_refs_in_expr(e, name, out);
+            }
+            function_refs_in_stmt(f.body, name, out);
+        }
+        StmtKind::TryCatch(t) => {
+            function_refs_in_stmts(&t.body, name, out);
+            for catch in t.catches.iter() {
+                function_refs_in_stmts(&catch.body, name, out);
+            }
+            if let Some(finally) = &t.finally {
+                function_refs_in_stmts(finally, name, out);
+            }
+        }
+        StmtKind::Block(stmts) => function_refs_in_stmts(stmts, name, out),
+        _ => {}
+    }
+}
+
+fn function_refs_in_expr(expr: &Expr<'_, '_>, name: &str, out: &mut Vec<Span>) {
+    match &expr.kind {
+        // The core match: a free function call whose callee is a bare identifier.
+        ExprKind::FunctionCall(f) => {
+            if let ExprKind::Identifier(id) = &f.name.kind
+                && id.as_ref() == name
+            {
+                out.push(f.name.span);
+            }
+            // Still recurse into args and a dynamic callee.
+            function_refs_in_expr(f.name, name, out);
+            for a in f.args.iter() {
+                function_refs_in_expr(&a.value, name, out);
+            }
+        }
+        // Recurse into all expression sub-nodes (but skip method/static call names).
+        ExprKind::MethodCall(m) => {
+            function_refs_in_expr(m.object, name, out);
+            // do NOT check m.method — that is a method name, not a function name
+            for a in m.args.iter() {
+                function_refs_in_expr(&a.value, name, out);
+            }
+        }
+        ExprKind::NullsafeMethodCall(m) => {
+            function_refs_in_expr(m.object, name, out);
+            for a in m.args.iter() {
+                function_refs_in_expr(&a.value, name, out);
+            }
+        }
+        ExprKind::StaticMethodCall(s) => {
+            function_refs_in_expr(s.class, name, out);
+            for a in s.args.iter() {
+                function_refs_in_expr(&a.value, name, out);
+            }
+        }
+        ExprKind::New(n) => {
+            for a in n.args.iter() {
+                function_refs_in_expr(&a.value, name, out);
+            }
+        }
+        ExprKind::Assign(a) => {
+            function_refs_in_expr(a.target, name, out);
+            function_refs_in_expr(a.value, name, out);
+        }
+        ExprKind::Binary(b) => {
+            function_refs_in_expr(b.left, name, out);
+            function_refs_in_expr(b.right, name, out);
+        }
+        ExprKind::UnaryPrefix(u) => function_refs_in_expr(u.operand, name, out),
+        ExprKind::UnaryPostfix(u) => function_refs_in_expr(u.operand, name, out),
+        ExprKind::Ternary(t) => {
+            function_refs_in_expr(t.condition, name, out);
+            if let Some(e) = t.then_expr {
+                function_refs_in_expr(e, name, out);
+            }
+            function_refs_in_expr(t.else_expr, name, out);
+        }
+        ExprKind::NullCoalesce(n) => {
+            function_refs_in_expr(n.left, name, out);
+            function_refs_in_expr(n.right, name, out);
+        }
+        ExprKind::Parenthesized(e) => function_refs_in_expr(e, name, out),
+        ExprKind::ErrorSuppress(e) => function_refs_in_expr(e, name, out),
+        ExprKind::Cast(_, e) => function_refs_in_expr(e, name, out),
+        ExprKind::Clone(e) => function_refs_in_expr(e, name, out),
+        ExprKind::ThrowExpr(e) => function_refs_in_expr(e, name, out),
+        ExprKind::Print(e) => function_refs_in_expr(e, name, out),
+        ExprKind::Empty(e) => function_refs_in_expr(e, name, out),
+        ExprKind::Eval(e) => function_refs_in_expr(e, name, out),
+        ExprKind::Yield(y) => {
+            if let Some(k) = y.key {
+                function_refs_in_expr(k, name, out);
+            }
+            if let Some(v) = y.value {
+                function_refs_in_expr(v, name, out);
+            }
+        }
+        ExprKind::ArrayAccess(a) => {
+            function_refs_in_expr(a.array, name, out);
+            if let Some(idx) = a.index {
+                function_refs_in_expr(idx, name, out);
+            }
+        }
+        ExprKind::PropertyAccess(p) => function_refs_in_expr(p.object, name, out),
+        ExprKind::NullsafePropertyAccess(p) => function_refs_in_expr(p.object, name, out),
+        ExprKind::StaticPropertyAccess(s) => function_refs_in_expr(s.class, name, out),
+        ExprKind::Match(m) => {
+            function_refs_in_expr(m.subject, name, out);
+            for arm in m.arms.iter() {
+                if let Some(conds) = &arm.conditions {
+                    for c in conds.iter() {
+                        function_refs_in_expr(c, name, out);
+                    }
+                }
+                function_refs_in_expr(&arm.body, name, out);
+            }
+        }
+        ExprKind::Array(elements) => {
+            for elem in elements.iter() {
+                if let Some(key) = &elem.key {
+                    function_refs_in_expr(key, name, out);
+                }
+                function_refs_in_expr(&elem.value, name, out);
+            }
+        }
+        ExprKind::Isset(exprs) => {
+            for e in exprs.iter() {
+                function_refs_in_expr(e, name, out);
+            }
+        }
+        ExprKind::Include(_, e) => function_refs_in_expr(e, name, out),
+        ExprKind::Exit(Some(e)) => function_refs_in_expr(e, name, out),
+        ExprKind::Closure(c) => function_refs_in_stmts(&c.body, name, out),
+        ExprKind::ArrowFunction(a) => function_refs_in_expr(a.body, name, out),
+        ExprKind::AnonymousClass(c) => {
+            for member in c.members.iter() {
+                if let ClassMemberKind::Method(m) = &member.kind
+                    && let Some(body) = &m.body
+                {
+                    function_refs_in_stmts(body, name, out);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Collect spans where `name` is used as a method: `->name()`, `?->name()`, `::name()`.
+/// Does NOT match free function calls or class-name identifiers.
+pub fn method_refs_in_stmts(stmts: &[Stmt<'_, '_>], name: &str, out: &mut Vec<Span>) {
+    for stmt in stmts {
+        method_refs_in_stmt(stmt, name, out);
+    }
+}
+
+fn method_refs_in_stmt(stmt: &Stmt<'_, '_>, name: &str, out: &mut Vec<Span>) {
+    match &stmt.kind {
+        StmtKind::Expression(e) => method_refs_in_expr(e, name, out),
+        StmtKind::Return(Some(e)) => method_refs_in_expr(e, name, out),
+        StmtKind::Echo(exprs) => {
+            for e in exprs.iter() {
+                method_refs_in_expr(e, name, out);
+            }
+        }
+        StmtKind::Function(f) => method_refs_in_stmts(&f.body, name, out),
+        StmtKind::Class(c) => {
+            for member in c.members.iter() {
+                if let ClassMemberKind::Method(m) = &member.kind {
+                    if let Some(body) = &m.body {
+                        method_refs_in_stmts(body, name, out);
+                    }
+                }
+            }
+        }
+        StmtKind::Trait(t) => {
+            for member in t.members.iter() {
+                if let ClassMemberKind::Method(m) = &member.kind {
+                    if let Some(body) = &m.body {
+                        method_refs_in_stmts(body, name, out);
+                    }
+                }
+            }
+        }
+        StmtKind::Enum(e) => {
+            for member in e.members.iter() {
+                if let EnumMemberKind::Method(m) = &member.kind {
+                    if let Some(body) = &m.body {
+                        method_refs_in_stmts(body, name, out);
+                    }
+                }
+            }
+        }
+        StmtKind::Namespace(ns) => {
+            if let NamespaceBody::Braced(inner) = &ns.body {
+                method_refs_in_stmts(inner, name, out);
+            }
+        }
+        StmtKind::If(i) => {
+            method_refs_in_expr(&i.condition, name, out);
+            method_refs_in_stmt(i.then_branch, name, out);
+            for ei in i.elseif_branches.iter() {
+                method_refs_in_expr(&ei.condition, name, out);
+                method_refs_in_stmt(&ei.body, name, out);
+            }
+            if let Some(e) = &i.else_branch {
+                method_refs_in_stmt(e, name, out);
+            }
+        }
+        StmtKind::While(w) => {
+            method_refs_in_expr(&w.condition, name, out);
+            method_refs_in_stmt(w.body, name, out);
+        }
+        StmtKind::DoWhile(d) => {
+            method_refs_in_stmt(d.body, name, out);
+            method_refs_in_expr(&d.condition, name, out);
+        }
+        StmtKind::Foreach(f) => {
+            method_refs_in_expr(&f.expr, name, out);
+            method_refs_in_stmt(f.body, name, out);
+        }
+        StmtKind::For(f) => {
+            for e in f.init.iter() {
+                method_refs_in_expr(e, name, out);
+            }
+            for cond in f.condition.iter() {
+                method_refs_in_expr(cond, name, out);
+            }
+            for e in f.update.iter() {
+                method_refs_in_expr(e, name, out);
+            }
+            method_refs_in_stmt(f.body, name, out);
+        }
+        StmtKind::TryCatch(t) => {
+            method_refs_in_stmts(&t.body, name, out);
+            for catch in t.catches.iter() {
+                method_refs_in_stmts(&catch.body, name, out);
+            }
+            if let Some(finally) = &t.finally {
+                method_refs_in_stmts(finally, name, out);
+            }
+        }
+        StmtKind::Block(stmts) => method_refs_in_stmts(stmts, name, out),
+        _ => {}
+    }
+}
+
+fn method_refs_in_expr(expr: &Expr<'_, '_>, name: &str, out: &mut Vec<Span>) {
+    match &expr.kind {
+        ExprKind::MethodCall(m) => {
+            method_refs_in_expr(m.object, name, out);
+            // Collect the method name span if it matches.
+            if let ExprKind::Identifier(id) = &m.method.kind
+                && id.as_ref() == name
+            {
+                out.push(m.method.span);
+            }
+            for a in m.args.iter() {
+                method_refs_in_expr(&a.value, name, out);
+            }
+        }
+        ExprKind::NullsafeMethodCall(m) => {
+            method_refs_in_expr(m.object, name, out);
+            if let ExprKind::Identifier(id) = &m.method.kind
+                && id.as_ref() == name
+            {
+                out.push(m.method.span);
+            }
+            for a in m.args.iter() {
+                method_refs_in_expr(&a.value, name, out);
+            }
+        }
+        ExprKind::StaticMethodCall(s) => {
+            method_refs_in_expr(s.class, name, out);
+            if s.method.as_ref() == name {
+                // For static calls, the span covers the whole expression; we need the
+                // method-name portion. Use the existing refs_in_expr behaviour which
+                // pushed expr.span for static methods — replicate that here.
+                out.push(expr.span);
+            }
+            for a in s.args.iter() {
+                method_refs_in_expr(&a.value, name, out);
+            }
+        }
+        ExprKind::FunctionCall(f) => {
+            method_refs_in_expr(f.name, name, out);
+            for a in f.args.iter() {
+                method_refs_in_expr(&a.value, name, out);
+            }
+        }
+        ExprKind::New(n) => {
+            for a in n.args.iter() {
+                method_refs_in_expr(&a.value, name, out);
+            }
+        }
+        ExprKind::Assign(a) => {
+            method_refs_in_expr(a.target, name, out);
+            method_refs_in_expr(a.value, name, out);
+        }
+        ExprKind::Binary(b) => {
+            method_refs_in_expr(b.left, name, out);
+            method_refs_in_expr(b.right, name, out);
+        }
+        ExprKind::UnaryPrefix(u) => method_refs_in_expr(u.operand, name, out),
+        ExprKind::UnaryPostfix(u) => method_refs_in_expr(u.operand, name, out),
+        ExprKind::Ternary(t) => {
+            method_refs_in_expr(t.condition, name, out);
+            if let Some(e) = t.then_expr {
+                method_refs_in_expr(e, name, out);
+            }
+            method_refs_in_expr(t.else_expr, name, out);
+        }
+        ExprKind::NullCoalesce(n) => {
+            method_refs_in_expr(n.left, name, out);
+            method_refs_in_expr(n.right, name, out);
+        }
+        ExprKind::Parenthesized(e) => method_refs_in_expr(e, name, out),
+        ExprKind::ErrorSuppress(e) => method_refs_in_expr(e, name, out),
+        ExprKind::Cast(_, e) => method_refs_in_expr(e, name, out),
+        ExprKind::Clone(e) => method_refs_in_expr(e, name, out),
+        ExprKind::ThrowExpr(e) => method_refs_in_expr(e, name, out),
+        ExprKind::Print(e) => method_refs_in_expr(e, name, out),
+        ExprKind::Empty(e) => method_refs_in_expr(e, name, out),
+        ExprKind::Eval(e) => method_refs_in_expr(e, name, out),
+        ExprKind::Yield(y) => {
+            if let Some(k) = y.key {
+                method_refs_in_expr(k, name, out);
+            }
+            if let Some(v) = y.value {
+                method_refs_in_expr(v, name, out);
+            }
+        }
+        ExprKind::ArrayAccess(a) => {
+            method_refs_in_expr(a.array, name, out);
+            if let Some(idx) = a.index {
+                method_refs_in_expr(idx, name, out);
+            }
+        }
+        ExprKind::PropertyAccess(p) => method_refs_in_expr(p.object, name, out),
+        ExprKind::NullsafePropertyAccess(p) => method_refs_in_expr(p.object, name, out),
+        ExprKind::StaticPropertyAccess(s) => method_refs_in_expr(s.class, name, out),
+        ExprKind::Match(m) => {
+            method_refs_in_expr(m.subject, name, out);
+            for arm in m.arms.iter() {
+                if let Some(conds) = &arm.conditions {
+                    for c in conds.iter() {
+                        method_refs_in_expr(c, name, out);
+                    }
+                }
+                method_refs_in_expr(&arm.body, name, out);
+            }
+        }
+        ExprKind::Array(elements) => {
+            for elem in elements.iter() {
+                if let Some(key) = &elem.key {
+                    method_refs_in_expr(key, name, out);
+                }
+                method_refs_in_expr(&elem.value, name, out);
+            }
+        }
+        ExprKind::Isset(exprs) => {
+            for e in exprs.iter() {
+                method_refs_in_expr(e, name, out);
+            }
+        }
+        ExprKind::Include(_, e) => method_refs_in_expr(e, name, out),
+        ExprKind::Exit(Some(e)) => method_refs_in_expr(e, name, out),
+        ExprKind::Closure(c) => method_refs_in_stmts(&c.body, name, out),
+        ExprKind::ArrowFunction(a) => method_refs_in_expr(a.body, name, out),
+        ExprKind::AnonymousClass(c) => {
+            for member in c.members.iter() {
+                if let ClassMemberKind::Method(m) = &member.kind
+                    && let Some(body) = &m.body
+                {
+                    method_refs_in_stmts(body, name, out);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Collect spans where `class_name` is used as a class-type reference:
+/// `new ClassName`, `extends ClassName`, `implements ClassName`, type hints,
+/// and `$x instanceof ClassName`.  Does NOT match free function calls or
+/// method names with the same spelling.
+pub fn class_refs_in_stmts(stmts: &[Stmt<'_, '_>], class_name: &str, out: &mut Vec<Span>) {
+    for stmt in stmts {
+        class_refs_in_stmt(stmt, class_name, out);
+    }
+}
+
+fn class_refs_in_stmt(stmt: &Stmt<'_, '_>, class_name: &str, out: &mut Vec<Span>) {
+    match &stmt.kind {
+        StmtKind::Expression(e) => class_refs_in_expr(e, class_name, out),
+        StmtKind::Return(Some(e)) => class_refs_in_expr(e, class_name, out),
+        StmtKind::Echo(exprs) => {
+            for e in exprs.iter() {
+                class_refs_in_expr(e, class_name, out);
+            }
+        }
+        StmtKind::Function(f) => {
+            // Type hints on params and return type
+            for p in f.params.iter() {
+                if let Some(th) = &p.type_hint {
+                    collect_class_in_type_hint(th, class_name, out);
+                }
+            }
+            if let Some(rt) = &f.return_type {
+                collect_class_in_type_hint(rt, class_name, out);
+            }
+            class_refs_in_stmts(&f.body, class_name, out);
+        }
+        StmtKind::Class(c) => {
+            // `extends ClassName`
+            if let Some(ext) = &c.extends {
+                let last = ext
+                    .to_string_repr()
+                    .rsplit('\\')
+                    .next()
+                    .unwrap_or("")
+                    .to_string();
+                if last == class_name {
+                    let span = ext.span();
+                    let offset = (ext.to_string_repr().len() - last.len()) as u32;
+                    out.push(Span {
+                        start: span.start + offset,
+                        end: span.end,
+                    });
+                }
+            }
+            // `implements ClassName, ...`
+            for iface in c.implements.iter() {
+                let last = iface
+                    .to_string_repr()
+                    .rsplit('\\')
+                    .next()
+                    .unwrap_or("")
+                    .to_string();
+                if last == class_name {
+                    let span = iface.span();
+                    let offset = (iface.to_string_repr().len() - last.len()) as u32;
+                    out.push(Span {
+                        start: span.start + offset,
+                        end: span.end,
+                    });
+                }
+            }
+            for member in c.members.iter() {
+                match &member.kind {
+                    ClassMemberKind::Method(m) => {
+                        for p in m.params.iter() {
+                            if let Some(th) = &p.type_hint {
+                                collect_class_in_type_hint(th, class_name, out);
+                            }
+                        }
+                        if let Some(rt) = &m.return_type {
+                            collect_class_in_type_hint(rt, class_name, out);
+                        }
+                        if let Some(body) = &m.body {
+                            class_refs_in_stmts(body, class_name, out);
+                        }
+                    }
+                    ClassMemberKind::Property(p) => {
+                        if let Some(th) = &p.type_hint {
+                            collect_class_in_type_hint(th, class_name, out);
+                        }
+                        if let Some(default) = &p.default {
+                            class_refs_in_expr(default, class_name, out);
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+        StmtKind::Interface(i) => {
+            for parent in i.extends.iter() {
+                let last = parent
+                    .to_string_repr()
+                    .rsplit('\\')
+                    .next()
+                    .unwrap_or("")
+                    .to_string();
+                if last == class_name {
+                    let span = parent.span();
+                    let offset = (parent.to_string_repr().len() - last.len()) as u32;
+                    out.push(Span {
+                        start: span.start + offset,
+                        end: span.end,
+                    });
+                }
+            }
+        }
+        StmtKind::Trait(t) => {
+            for member in t.members.iter() {
+                if let ClassMemberKind::Method(m) = &member.kind {
+                    for p in m.params.iter() {
+                        if let Some(th) = &p.type_hint {
+                            collect_class_in_type_hint(th, class_name, out);
+                        }
+                    }
+                    if let Some(rt) = &m.return_type {
+                        collect_class_in_type_hint(rt, class_name, out);
+                    }
+                    if let Some(body) = &m.body {
+                        class_refs_in_stmts(body, class_name, out);
+                    }
+                }
+            }
+        }
+        StmtKind::Enum(e) => {
+            for member in e.members.iter() {
+                if let EnumMemberKind::Method(m) = &member.kind {
+                    if let Some(body) = &m.body {
+                        class_refs_in_stmts(body, class_name, out);
+                    }
+                }
+            }
+        }
+        StmtKind::Namespace(ns) => {
+            if let NamespaceBody::Braced(inner) = &ns.body {
+                class_refs_in_stmts(inner, class_name, out);
+            }
+        }
+        StmtKind::If(i) => {
+            class_refs_in_expr(&i.condition, class_name, out);
+            class_refs_in_stmt(i.then_branch, class_name, out);
+            for ei in i.elseif_branches.iter() {
+                class_refs_in_expr(&ei.condition, class_name, out);
+                class_refs_in_stmt(&ei.body, class_name, out);
+            }
+            if let Some(e) = &i.else_branch {
+                class_refs_in_stmt(e, class_name, out);
+            }
+        }
+        StmtKind::While(w) => {
+            class_refs_in_expr(&w.condition, class_name, out);
+            class_refs_in_stmt(w.body, class_name, out);
+        }
+        StmtKind::DoWhile(d) => {
+            class_refs_in_stmt(d.body, class_name, out);
+            class_refs_in_expr(&d.condition, class_name, out);
+        }
+        StmtKind::Foreach(f) => {
+            class_refs_in_expr(&f.expr, class_name, out);
+            class_refs_in_stmt(f.body, class_name, out);
+        }
+        StmtKind::For(f) => {
+            for e in f.init.iter() {
+                class_refs_in_expr(e, class_name, out);
+            }
+            for cond in f.condition.iter() {
+                class_refs_in_expr(cond, class_name, out);
+            }
+            for e in f.update.iter() {
+                class_refs_in_expr(e, class_name, out);
+            }
+            class_refs_in_stmt(f.body, class_name, out);
+        }
+        StmtKind::TryCatch(t) => {
+            class_refs_in_stmts(&t.body, class_name, out);
+            for catch in t.catches.iter() {
+                for ty in catch.types.iter() {
+                    let last = ty
+                        .to_string_repr()
+                        .rsplit('\\')
+                        .next()
+                        .unwrap_or("")
+                        .to_string();
+                    if last == class_name {
+                        let span = ty.span();
+                        let offset = (ty.to_string_repr().len() - last.len()) as u32;
+                        out.push(Span {
+                            start: span.start + offset,
+                            end: span.end,
+                        });
+                    }
+                }
+                class_refs_in_stmts(&catch.body, class_name, out);
+            }
+            if let Some(finally) = &t.finally {
+                class_refs_in_stmts(finally, class_name, out);
+            }
+        }
+        StmtKind::Block(stmts) => class_refs_in_stmts(stmts, class_name, out),
+        _ => {}
+    }
+}
+
+fn class_refs_in_expr(expr: &Expr<'_, '_>, class_name: &str, out: &mut Vec<Span>) {
+    match &expr.kind {
+        // `new ClassName(...)` — the class name is an Identifier child of New.
+        ExprKind::New(n) => {
+            if let ExprKind::Identifier(id) = &n.class.kind
+                && id.as_ref().rsplit('\\').next().unwrap_or(id.as_ref()) == class_name
+            {
+                out.push(n.class.span);
+            } else {
+                // Dynamic `new $var()` etc. — no match but still recurse into args.
+            }
+            for a in n.args.iter() {
+                class_refs_in_expr(&a.value, class_name, out);
+            }
+        }
+        // `$x instanceof ClassName` — right operand is an Identifier.
+        ExprKind::Binary(b) => {
+            class_refs_in_expr(b.left, class_name, out);
+            // For instanceof, the RHS is a class name; for other operators it is not.
+            // We check the RHS regardless — if it is an Identifier and matches, we
+            // include it; class names don't normally appear as operands otherwise.
+            if let ExprKind::Identifier(id) = &b.right.kind
+                && id.as_ref().rsplit('\\').next().unwrap_or(id.as_ref()) == class_name
+            {
+                out.push(b.right.span);
+            } else {
+                class_refs_in_expr(b.right, class_name, out);
+            }
+        }
+        // `ClassName::method()` or `ClassName::$prop` — class side.
+        ExprKind::StaticMethodCall(s) => {
+            if let ExprKind::Identifier(id) = &s.class.kind
+                && id.as_ref().rsplit('\\').next().unwrap_or(id.as_ref()) == class_name
+            {
+                out.push(s.class.span);
+            }
+            for a in s.args.iter() {
+                class_refs_in_expr(&a.value, class_name, out);
+            }
+        }
+        ExprKind::StaticPropertyAccess(s) => {
+            if let ExprKind::Identifier(id) = &s.class.kind
+                && id.as_ref().rsplit('\\').next().unwrap_or(id.as_ref()) == class_name
+            {
+                out.push(s.class.span);
+            }
+        }
+        ExprKind::ClassConstAccess(c) => {
+            if let ExprKind::Identifier(id) = &c.class.kind
+                && id.as_ref().rsplit('\\').next().unwrap_or(id.as_ref()) == class_name
+            {
+                out.push(c.class.span);
+            }
+        }
+        // Recurse into other expression kinds.
+        ExprKind::FunctionCall(f) => {
+            for a in f.args.iter() {
+                class_refs_in_expr(&a.value, class_name, out);
+            }
+        }
+        ExprKind::MethodCall(m) => {
+            class_refs_in_expr(m.object, class_name, out);
+            for a in m.args.iter() {
+                class_refs_in_expr(&a.value, class_name, out);
+            }
+        }
+        ExprKind::NullsafeMethodCall(m) => {
+            class_refs_in_expr(m.object, class_name, out);
+            for a in m.args.iter() {
+                class_refs_in_expr(&a.value, class_name, out);
+            }
+        }
+        ExprKind::Assign(a) => {
+            class_refs_in_expr(a.target, class_name, out);
+            class_refs_in_expr(a.value, class_name, out);
+        }
+        ExprKind::UnaryPrefix(u) => class_refs_in_expr(u.operand, class_name, out),
+        ExprKind::UnaryPostfix(u) => class_refs_in_expr(u.operand, class_name, out),
+        ExprKind::Ternary(t) => {
+            class_refs_in_expr(t.condition, class_name, out);
+            if let Some(e) = t.then_expr {
+                class_refs_in_expr(e, class_name, out);
+            }
+            class_refs_in_expr(t.else_expr, class_name, out);
+        }
+        ExprKind::NullCoalesce(n) => {
+            class_refs_in_expr(n.left, class_name, out);
+            class_refs_in_expr(n.right, class_name, out);
+        }
+        ExprKind::Parenthesized(e) => class_refs_in_expr(e, class_name, out),
+        ExprKind::ErrorSuppress(e) => class_refs_in_expr(e, class_name, out),
+        ExprKind::Cast(_, e) => class_refs_in_expr(e, class_name, out),
+        ExprKind::Clone(e) => class_refs_in_expr(e, class_name, out),
+        ExprKind::ThrowExpr(e) => class_refs_in_expr(e, class_name, out),
+        ExprKind::Print(e) => class_refs_in_expr(e, class_name, out),
+        ExprKind::Empty(e) => class_refs_in_expr(e, class_name, out),
+        ExprKind::Eval(e) => class_refs_in_expr(e, class_name, out),
+        ExprKind::Yield(y) => {
+            if let Some(k) = y.key {
+                class_refs_in_expr(k, class_name, out);
+            }
+            if let Some(v) = y.value {
+                class_refs_in_expr(v, class_name, out);
+            }
+        }
+        ExprKind::ArrayAccess(a) => {
+            class_refs_in_expr(a.array, class_name, out);
+            if let Some(idx) = a.index {
+                class_refs_in_expr(idx, class_name, out);
+            }
+        }
+        ExprKind::PropertyAccess(p) => class_refs_in_expr(p.object, class_name, out),
+        ExprKind::NullsafePropertyAccess(p) => class_refs_in_expr(p.object, class_name, out),
+        ExprKind::Match(m) => {
+            class_refs_in_expr(m.subject, class_name, out);
+            for arm in m.arms.iter() {
+                if let Some(conds) = &arm.conditions {
+                    for c in conds.iter() {
+                        class_refs_in_expr(c, class_name, out);
+                    }
+                }
+                class_refs_in_expr(&arm.body, class_name, out);
+            }
+        }
+        ExprKind::Array(elements) => {
+            for elem in elements.iter() {
+                if let Some(key) = &elem.key {
+                    class_refs_in_expr(key, class_name, out);
+                }
+                class_refs_in_expr(&elem.value, class_name, out);
+            }
+        }
+        ExprKind::Isset(exprs) => {
+            for e in exprs.iter() {
+                class_refs_in_expr(e, class_name, out);
+            }
+        }
+        ExprKind::Include(_, e) => class_refs_in_expr(e, class_name, out),
+        ExprKind::Exit(Some(e)) => class_refs_in_expr(e, class_name, out),
+        ExprKind::Closure(c) => class_refs_in_stmts(&c.body, class_name, out),
+        ExprKind::ArrowFunction(a) => class_refs_in_expr(a.body, class_name, out),
+        ExprKind::AnonymousClass(c) => {
+            for member in c.members.iter() {
+                if let ClassMemberKind::Method(m) = &member.kind
+                    && let Some(body) = &m.body
+                {
+                    class_refs_in_stmts(body, class_name, out);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Walk a type hint and emit a span for any `Named` component that matches `class_name`.
+fn collect_class_in_type_hint(th: &TypeHint<'_, '_>, class_name: &str, out: &mut Vec<Span>) {
+    match &th.kind {
+        TypeHintKind::Named(name) => {
+            let repr = name.to_string_repr();
+            let last = repr.rsplit('\\').next().unwrap_or(repr.as_ref());
+            if last == class_name {
+                let span = name.span();
+                let offset = (repr.len() - last.len()) as u32;
+                out.push(Span {
+                    start: span.start + offset,
+                    end: span.end,
+                });
+            }
+        }
+        TypeHintKind::Nullable(inner) => collect_class_in_type_hint(inner, class_name, out),
+        TypeHintKind::Union(types) | TypeHintKind::Intersection(types) => {
+            for t in types.iter() {
+                collect_class_in_type_hint(t, class_name, out);
+            }
+        }
+        TypeHintKind::Keyword(_, _) => {}
     }
 }


### PR DESCRIPTION
## Summary

- **Problem**: `find_references` matched every occurrence of a word token across all files, including method calls, free function calls, and class names with the same spelling. For common short names (`get`, `set`, `add`) this produced significant false positives.
- **Solution**: Classify the symbol at the cursor into one of three kinds (Function, Method, Class) and dispatch to a dedicated AST walker that only collects the matching context.

## What changed

### `src/walk.rs`
Three new public walkers added at the bottom of the file:

| Walker | Matches |
|---|---|
| `function_refs_in_stmts` | `name(...)` where the callee is a bare `Identifier` — skips `->name()` and `::name()` |
| `method_refs_in_stmts` | `->name()`, `?->name()`, `::name()` — skips free function calls |
| `class_refs_in_stmts` | `new Foo`, `extends`/`implements`, type hints (including nullable/union/intersection), `instanceof`, and static `Foo::` accesses |

### `src/references.rs`
- New `SymbolKind` enum (`Function | Method | Class`).
- `find_references` gains an `Option<SymbolKind>` parameter; `None` falls back to the original general walker.
- `find_references_with_use` (rename path) always uses the general walker so use-import statements are still updated.
- Five new unit tests covering the key false-positive cases.

### `src/backend.rs`
- New `symbol_kind_at()` helper classifies the cursor context from source text:
  - preceded by `->` or `?->` → `Method`
  - preceded by `::` → `Method`
  - first char uppercase → `Class`
  - otherwise → `Function`
- The `references` LSP handler now calls `symbol_kind_at` and passes the result to `find_references`.

### `src/call_hierarchy.rs`, `src/code_lens.rs`
Updated call sites to pass `None` (general walker, preserving existing behaviour).

## Test plan

- [x] `cargo build` — clean compile
- [x] `cargo test` — 531 passed, 0 failed (526 existing + 5 new semantic tests)
- [x] Existing tests unchanged — no regressions
- [x] `function_kind_skips_method_call_with_same_name` — `get()` free call found; `$obj->get()` excluded
- [x] `method_kind_skips_free_function_call_with_same_name` — `$calc->add()` found; `add()` free call excluded
- [x] `class_kind_finds_new_expression` — `new Foo()` found; `Foo()` free call excluded
- [x] `class_kind_finds_extends_and_implements` — `extends Base` and `implements Iface` found
- [x] `class_kind_finds_type_hint` — `Foo $x` parameter type hint found