### PR TITLE
test: add cursor() position marker helper for test fixtures

### DIFF
--- a/src/definition.rs
+++ b/src/definition.rs
@@ -139,6 +139,7 @@ fn _name_range_from_offset(source: &str, name: &str) -> Range {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_utils::cursor;
 
     fn uri() -> Url {
         Url::parse("file:///test.php").unwrap()
@@ -150,9 +151,9 @@ mod tests {
 
     #[test]
     fn jumps_to_function_definition() {
-        let src = "<?php\nfunction greet() {}";
-        let doc = ParsedDoc::parse(src.to_string());
-        let result = goto_definition(&uri(), src, &doc, &[], pos(1, 10));
+        let (src, p) = cursor("<?php\nfunction g$0reet() {}");
+        let doc = ParsedDoc::parse(src.clone());
+        let result = goto_definition(&uri(), &src, &doc, &[], p);
         assert!(result.is_some(), "expected a location");
         let loc = result.unwrap();
         assert_eq!(loc.range.start.line, 1);
@@ -161,9 +162,9 @@ mod tests {
 
     #[test]
     fn jumps_to_class_definition() {
-        let src = "<?php\nclass MyService {}";
-        let doc = ParsedDoc::parse(src.to_string());
-        let result = goto_definition(&uri(), src, &doc, &[], pos(1, 8));
+        let (src, p) = cursor("<?php\nclass My$0Service {}");
+        let doc = ParsedDoc::parse(src.clone());
+        let result = goto_definition(&uri(), &src, &doc, &[], p);
         assert!(result.is_some());
         let loc = result.unwrap();
         assert_eq!(loc.range.start.line, 1);
@@ -171,9 +172,9 @@ mod tests {
 
     #[test]
     fn jumps_to_interface_definition() {
-        let src = "<?php\ninterface Countable {}";
-        let doc = ParsedDoc::parse(src.to_string());
-        let result = goto_definition(&uri(), src, &doc, &[], pos(1, 12));
+        let (src, p) = cursor("<?php\ninterface Co$0untable {}");
+        let doc = ParsedDoc::parse(src.clone());
+        let result = goto_definition(&uri(), &src, &doc, &[], p);
         assert!(result.is_some());
         assert_eq!(result.unwrap().range.start.line, 1);
     }

--- a/src/hover.rs
+++ b/src/hover.rs
@@ -532,6 +532,7 @@ fn find_property_type_in_stmts<'a>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_utils::cursor;
 
     fn pos(line: u32, character: u32) -> Position {
         Position { line, character }
@@ -539,9 +540,9 @@ mod tests {
 
     #[test]
     fn hover_on_function_name_returns_signature() {
-        let src = "<?php\nfunction greet(string $name): string {}";
-        let doc = ParsedDoc::parse(src.to_string());
-        let result = hover_info(src, &doc, pos(1, 10), &[]);
+        let (src, p) = cursor("<?php\nfunction g$0reet(string $name): string {}");
+        let doc = ParsedDoc::parse(src.clone());
+        let result = hover_info(&src, &doc, p, &[]);
         assert!(result.is_some(), "expected hover result");
         if let Some(Hover {
             contents: HoverContents::Markup(mc),
@@ -558,9 +559,9 @@ mod tests {
 
     #[test]
     fn hover_on_class_name_returns_class_sig() {
-        let src = "<?php\nclass MyService {}";
-        let doc = ParsedDoc::parse(src.to_string());
-        let result = hover_info(src, &doc, pos(1, 8), &[]);
+        let (src, p) = cursor("<?php\nclass My$0Service {}");
+        let doc = ParsedDoc::parse(src.clone());
+        let result = hover_info(&src, &doc, p, &[]);
         assert!(result.is_some(), "expected hover result");
         if let Some(Hover {
             contents: HoverContents::Markup(mc),
@@ -593,8 +594,8 @@ mod tests {
 
     #[test]
     fn word_at_extracts_from_middle_of_identifier() {
-        let src = "<?php\nfunction greetUser() {}";
-        let word = word_at(src, pos(1, 13));
+        let (src, p) = cursor("<?php\nfunction greet$0User() {}");
+        let word = word_at(&src, p);
         assert_eq!(word.as_deref(), Some("greetUser"));
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,8 @@ mod type_map;
 mod use_resolver;
 mod util;
 mod walk;
+#[cfg(test)]
+mod test_utils;
 
 use backend::Backend;
 use tower_lsp::{LspService, Server};

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,0 +1,25 @@
+use tower_lsp::lsp_types::Position;
+
+/// Strip the `$0` cursor marker from a PHP source string and return
+/// the cleaned source together with the `Position` of that marker.
+///
+/// Useful in tests to avoid computing line/character offsets by hand:
+///
+/// ```rust
+/// let (src, pos) = cursor("<?php\nfunction foo$0() {}");
+/// // src == "<?php\nfunction foo() {}"
+/// // pos == Position { line: 1, character: 12 }
+/// ```
+///
+/// Panics if there is no `$0` in `src`.
+pub fn cursor(src: &str) -> (String, Position) {
+    const MARKER: &str = "$0";
+    let marker_byte = src.find(MARKER).expect("no `$0` cursor marker in source");
+    let before = &src[..marker_byte];
+    let line = before.chars().filter(|&c| c == '\n').count() as u32;
+    let last_nl_end = before.rfind('\n').map(|i| i + 1).unwrap_or(0);
+    // LSP positions are UTF-16 code units
+    let character = before[last_nl_end..].encode_utf16().count() as u32;
+    let cleaned = format!("{}{}", before, &src[marker_byte + MARKER.len()..]);
+    (cleaned, Position { line, character })
+}


### PR DESCRIPTION
## Summary

- Adds `src/test_utils.rs` with a `cursor()` function that strips a `$0` marker from PHP source strings and returns the cleaned source + `Position` (UTF-16 aware)
- Registers the module in `src/main.rs` as `#[cfg(test)] mod test_utils`
- Updates 3 tests in `src/hover.rs` and 3 tests in `src/definition.rs` to use `cursor()` instead of hardcoded `pos(line, col)` calls

## Test plan

- [ ] `cargo test` passes (526 tests, 0 failures)
- [ ] `hover_on_function_name_returns_signature` uses `cursor("<?php\nfunction g$0reet(...)")`
- [ ] `hover_on_class_name_returns_class_sig` uses `cursor("<?php\nclass My$0Service {}")`
- [ ] `word_at_extracts_from_middle_of_identifier` uses `cursor("<?php\nfunction greet$0User() {}")`
- [ ] `jumps_to_function_definition` uses `cursor("<?php\nfunction g$0reet() {}")`
- [ ] `jumps_to_class_definition` uses `cursor("<?php\nclass My$0Service {}")`
- [ ] `jumps_to_interface_definition` uses `cursor("<?php\ninterface Co$0untable {}")`