### PR TITLE
test: add snapshot tests with expect-test for hover and completion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,6 +144,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dissimilar"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aeda16ab4059c5fd2a83f2b9c9e9c981327b18aa8e3b313f7e6563799d4f093e"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -157,6 +163,16 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys",
+]
+
+[[package]]
+name = "expect-test"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63af43ff4431e848fb47472a920f14fa71c24de13255a5692e93d4e90302acb0"
+dependencies = [
+ "dissimilar",
+ "once_cell",
 ]
 
 [[package]]
@@ -643,6 +659,7 @@ version = "0.1.47"
 dependencies = [
  "bumpalo",
  "dashmap 6.1.0",
+ "expect-test",
  "mir-php",
  "php-ast",
  "php-rs-parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,4 @@ dashmap = "6"
 
 [dev-dependencies]
 tempfile = "3"
+expect-test = "1"

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -2415,4 +2415,78 @@ mod tests {
             ls
         );
     }
+
+    // ── Snapshot tests ───────────────────────────────────────────────────────
+
+    use expect_test::{Expect, expect};
+
+    /// Collect completion labels from a source string (no trigger, no cross-file docs),
+    /// sort them, and compare against the snapshot.
+    #[allow(dead_code)]
+    fn check_completion_labels(src: &str, expect: Expect) {
+        let d = doc(src);
+        let items = filtered_completions_at(&d, &[], None, None, None, None, None);
+        let mut ls: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
+        ls.sort_unstable();
+        expect.assert_eq(&ls.join("\n"));
+    }
+
+    #[test]
+    fn snapshot_keyword_completions_present() {
+        // Verify a handful of core PHP keywords appear in the default completion list.
+        let items = keyword_completions();
+        let mut ls: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
+        ls.sort_unstable();
+        // Snapshot just the first 10 sorted keywords so the test is stable even
+        // if new keywords are added later.
+        let first_ten = ls[..10.min(ls.len())].join("\n");
+        expect![[r#"
+            abstract
+            and
+            array
+            as
+            break
+            callable
+            case
+            catch
+            class
+            clone"#]].assert_eq(&first_ten);
+    }
+
+    #[test]
+    fn snapshot_symbol_completions_for_simple_class() {
+        let d = doc("<?php\nclass Counter { public function increment(): void {} public function reset(): void {} }");
+        let items = symbol_completions(&d);
+        let mut ls: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
+        ls.sort_unstable();
+        expect![[r#"
+            Counter
+            increment
+            reset"#]].assert_eq(&ls.join("\n"));
+    }
+
+    #[test]
+    fn snapshot_symbol_completions_for_function_with_params() {
+        let d = doc("<?php\nfunction connect(string $host, int $port): void {}");
+        let items = symbol_completions(&d);
+        let mut ls: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
+        ls.sort_unstable();
+        expect![[r#"
+            $host
+            $port
+            connect"#]].assert_eq(&ls.join("\n"));
+    }
+
+    #[test]
+    fn snapshot_arrow_completions_for_typed_var() {
+        let src = "<?php\nclass Greeter { public function sayHello(): void {} public function sayBye(): void {} }\n$g = new Greeter();\n$g->";
+        let d = doc(src);
+        let pos = Position { line: 3, character: 4 };
+        let items = filtered_completions_at(&d, &[], Some(">"), Some(src), Some(pos), None, None);
+        let mut ls: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
+        ls.sort_unstable();
+        expect![[r#"
+            sayBye
+            sayHello"#]].assert_eq(&ls.join("\n"));
+    }
 }

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -2450,19 +2450,23 @@ mod tests {
             case
             catch
             class
-            clone"#]].assert_eq(&first_ten);
+            clone"#]]
+        .assert_eq(&first_ten);
     }
 
     #[test]
     fn snapshot_symbol_completions_for_simple_class() {
-        let d = doc("<?php\nclass Counter { public function increment(): void {} public function reset(): void {} }");
+        let d = doc(
+            "<?php\nclass Counter { public function increment(): void {} public function reset(): void {} }",
+        );
         let items = symbol_completions(&d);
         let mut ls: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
         ls.sort_unstable();
         expect![[r#"
             Counter
             increment
-            reset"#]].assert_eq(&ls.join("\n"));
+            reset"#]]
+        .assert_eq(&ls.join("\n"));
     }
 
     #[test]
@@ -2474,19 +2478,24 @@ mod tests {
         expect![[r#"
             $host
             $port
-            connect"#]].assert_eq(&ls.join("\n"));
+            connect"#]]
+        .assert_eq(&ls.join("\n"));
     }
 
     #[test]
     fn snapshot_arrow_completions_for_typed_var() {
         let src = "<?php\nclass Greeter { public function sayHello(): void {} public function sayBye(): void {} }\n$g = new Greeter();\n$g->";
         let d = doc(src);
-        let pos = Position { line: 3, character: 4 };
+        let pos = Position {
+            line: 3,
+            character: 4,
+        };
         let items = filtered_completions_at(&d, &[], Some(">"), Some(src), Some(pos), None, None);
         let mut ls: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
         ls.sort_unstable();
         expect![[r#"
             sayBye
-            sayHello"#]].assert_eq(&ls.join("\n"));
+            sayHello"#]]
+        .assert_eq(&ls.join("\n"));
     }
 }

--- a/src/hover.rs
+++ b/src/hover.rs
@@ -943,4 +943,106 @@ mod tests {
             "hover content should contain 'strlen', got: {text}"
         );
     }
+
+    // ── Snapshot tests ───────────────────────────────────────────────────────
+
+    use expect_test::{Expect, expect};
+
+    fn check_hover(src: &str, position: Position, expect: Expect) {
+        let doc = ParsedDoc::parse(src.to_string());
+        let result = hover_info(src, &doc, position, &[]);
+        let actual = match result {
+            Some(Hover {
+                contents: HoverContents::Markup(mc),
+                ..
+            }) => mc.value,
+            Some(_) => "(non-markup hover)".to_string(),
+            None => "(no hover)".to_string(),
+        };
+        expect.assert_eq(&actual);
+    }
+
+    #[test]
+    fn snapshot_hover_simple_function() {
+        check_hover(
+            "<?php\nfunction init() {}",
+            pos(1, 10),
+            expect![[r#"
+                ```php
+                function init()
+                ```"#]],
+        );
+    }
+
+    #[test]
+    fn snapshot_hover_function_with_return_type() {
+        check_hover(
+            "<?php\nfunction greet(string $name): string {}",
+            pos(1, 10),
+            expect![[r#"
+                ```php
+                function greet(string $name): string
+                ```"#]],
+        );
+    }
+
+    #[test]
+    fn snapshot_hover_class() {
+        check_hover(
+            "<?php\nclass MyService {}",
+            pos(1, 8),
+            expect![[r#"
+                ```php
+                class MyService
+                ```"#]],
+        );
+    }
+
+    #[test]
+    fn snapshot_hover_class_with_extends() {
+        check_hover(
+            "<?php\nclass Dog extends Animal {}",
+            pos(1, 8),
+            expect![[r#"
+                ```php
+                class Dog extends Animal
+                ```"#]],
+        );
+    }
+
+    #[test]
+    fn snapshot_hover_method() {
+        check_hover(
+            "<?php\nclass Calc { public function add(int $a, int $b): int {} }",
+            pos(1, 32),
+            expect![[r#"
+                ```php
+                function add(int $a, int $b): int
+                ```"#]],
+        );
+    }
+
+    #[test]
+    fn snapshot_hover_trait() {
+        check_hover(
+            "<?php\ntrait Loggable {}",
+            pos(1, 8),
+            expect![[r#"
+                ```php
+                trait Loggable
+                ```"#]],
+        );
+    }
+
+    #[test]
+    fn snapshot_hover_interface() {
+        check_hover(
+            "<?php\ninterface Serializable {}",
+            pos(1, 12),
+            expect![[r#"
+                ```php
+                interface Serializable
+                ```"#]],
+        );
+    }
 }

--- a/src/organize_imports.rs
+++ b/src/organize_imports.rs
@@ -221,9 +221,10 @@ fn is_used(u: &UseStatement, body: &str) -> bool {
     while let Some(pos) = body[start..].find(short.as_str()) {
         let abs = start + pos;
         let before_ok = abs == 0
-            || !body.as_bytes().get(abs - 1).is_some_and(|b| {
-                b.is_ascii_alphanumeric() || *b == b'_' || *b == b'\\'
-            });
+            || !body
+                .as_bytes()
+                .get(abs - 1)
+                .is_some_and(|b| b.is_ascii_alphanumeric() || *b == b'_' || *b == b'\\');
         let after_ok = body
             .as_bytes()
             .get(abs + short.len())


### PR DESCRIPTION
## Summary

- Adds `expect-test = "1"` dev dependency to `Cargo.toml`
- Adds `check_hover` snapshot helper + 7 new snapshot tests in `hover::tests` covering simple functions, functions with return types, classes, classes with extends, methods, traits, and interfaces
- Adds `check_completion_labels` snapshot helper + 4 new snapshot tests in `completion::tests` covering keyword completions, symbol completions for a class, symbol completions for a function with params, and arrow member completions for a typed variable

Unlike the existing `assert!(mc.value.contains("..."))` assertions, snapshot tests capture the **full** markdown output and label lists, surfacing regressions as readable diffs on failure.

## Updating snapshots

Because this project uses git worktrees, set `CARGO_WORKSPACE_DIR` to point at the worktree root when auto-updating:

```bash
CARGO_WORKSPACE_DIR=$(pwd) UPDATE_EXPECT=1 cargo test snapshot
```

## Test plan
- [ ] `cargo test hover::tests::snapshot` passes (7 tests)
- [ ] `cargo test completion::tests::snapshot` passes (4 tests)
- [ ] `CARGO_WORKSPACE_DIR=$(pwd) UPDATE_EXPECT=1 cargo test snapshot` produces no diff (all snapshots already match)