### PR TITLE
chore: migrate from mir-php to mir-analyzer for semantic diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,6 +82,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -100,10 +109,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
 
 [[package]]
 name = "dashmap"
@@ -133,6 +180,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -148,6 +205,12 @@ name = "dissimilar"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aeda16ab4059c5fd2a83f2b9c9e9c981327b18aa8e3b313f7e6563799d4f093e"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "equivalent"
@@ -273,6 +336,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -326,12 +399,13 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -339,9 +413,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -352,9 +426,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -366,15 +440,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -386,15 +460,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -434,9 +508,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
@@ -452,9 +526,9 @@ checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "lazy_static"
@@ -470,9 +544,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "linux-raw-sys"
@@ -482,9 +556,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -561,9 +635,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
@@ -571,16 +645,60 @@ dependencies = [
 ]
 
 [[package]]
-name = "mir-php"
+name = "mir-analyzer"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dbf5f2caaf1e0fa0a6598db3aa61ca255f0a5fe18ea1a1c5f5075ccf6c5ebff"
+checksum = "c7eb0b262979613f1487e7331384b8fafb2ef94fa76b92d5f1d3853765fd4a6a"
 dependencies = [
  "bumpalo",
+ "indexmap",
+ "mir-codebase",
+ "mir-issues",
+ "mir-types",
  "php-ast",
  "php-rs-parser",
+ "quick-xml",
+ "rayon",
  "serde",
  "serde_json",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
+name = "mir-codebase"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81d3db4cb9e8ef44e5a13397ca24f49ee58fafd79cfd9108d3c6c0f22803889b"
+dependencies = [
+ "dashmap 6.1.0",
+ "indexmap",
+ "mir-types",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "mir-issues"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "499a530e37ab4685f95fa272b4ed93be3b61efaf2104089b8adeed9999ad24a9"
+dependencies = [
+ "mir-types",
+ "owo-colors",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "mir-types"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76e81c8e9806ecf1d9c3c25184bd97e370a5c112e5a68f8800d53a89d6a8d31c"
+dependencies = [
+ "indexmap",
+ "serde",
+ "smallvec",
 ]
 
 [[package]]
@@ -635,9 +753,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "php-ast"
-version = "0.2.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d29a3f129e19c4e0d915827070ff5179615f8285153e453f9f252f19f597c82"
+checksum = "3ef35f57f31b36618952c2ae004ff4eb03b4bfdbb77de1a40c9f96d3b2376200"
 dependencies = [
  "bumpalo",
  "serde",
@@ -645,9 +763,9 @@ dependencies = [
 
 [[package]]
 name = "php-lexer"
-version = "0.2.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6497df6fc700ab7ca6892ec32ce1dbd1224389d2299a79241a3f69b6b556affd"
+checksum = "6ecc8b49c656484509ff0eb1dbbd21156aaca81d03e4e47f39e7fed8860a73ad"
 dependencies = [
  "memchr",
  "php-ast",
@@ -655,12 +773,14 @@ dependencies = [
 
 [[package]]
 name = "php-lsp"
-version = "0.1.47"
+version = "0.1.48"
 dependencies = [
  "bumpalo",
  "dashmap 6.1.0",
  "expect-test",
- "mir-php",
+ "mir-analyzer",
+ "mir-codebase",
+ "mir-issues",
  "php-ast",
  "php-rs-parser",
  "serde_json",
@@ -671,9 +791,9 @@ dependencies = [
 
 [[package]]
 name = "php-rs-parser"
-version = "0.2.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4203d0a12f4b8532d664b82be7bcac4578401ffb5c25aa2ba29b3cdc7068c560"
+checksum = "e47d33893b05565b4640fb9fd52ec882ef9b0b4a1f791d120823cf5a32a25701"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -711,9 +831,9 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -738,6 +858,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.36.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -751,6 +880,26 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -788,9 +937,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -847,6 +996,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -867,6 +1027,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -982,9 +1145,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -992,9 +1155,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "2bd1c4c0fc4a7ab90fc15ef6daaa3ec3b893f004f915f2392557ed23237820cd"
 dependencies = [
  "bytes",
  "libc",
@@ -1009,9 +1172,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1123,6 +1286,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1170,6 +1339,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"
@@ -1334,15 +1509,15 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -1351,9 +1526,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1363,18 +1538,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1384,9 +1559,9 @@ dependencies = [
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -1395,9 +1570,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -1406,9 +1581,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "php-lsp"
-version = "0.1.47"
+version = "0.1.48"
 edition = "2024"
 description = "A PHP Language Server Protocol implementation"
 license = "MIT"
@@ -8,9 +8,11 @@ repository = "https://github.com/jorgsowa/php-lsp"
 readme = "README.md"
 
 [dependencies]
-mir-php = "0.1.0"
-php-rs-parser = "0.2.1"
-php-ast = "0.2.1"
+mir-analyzer = "0.1.0"
+mir-issues = "0.1.0"
+mir-codebase = "0.1.0"
+php-rs-parser = "0.3.2"
+php-ast = "0.3.2"
 bumpalo = { version = "3", features = ["collections"] }
 tower-lsp = "0.20"
 tokio = { version = "1", features = ["full"] }

--- a/src/semantic_diagnostics.rs
+++ b/src/semantic_diagnostics.rs
@@ -1,13 +1,11 @@
 /// Semantic diagnostics bridge.
 ///
-/// Delegates all analysis to the `mir-php` crate and converts its `Diagnostic`
+/// Delegates all analysis to the `mir-analyzer` crate and converts its `Issue`
 /// type into the `tower-lsp` `Diagnostic` type expected by the LSP backend.
 use std::sync::Arc;
 
 use php_ast::{ClassMemberKind, EnumMemberKind, ExprKind, NamespaceBody, Stmt, StmtKind};
-use tower_lsp::lsp_types::{
-    Diagnostic, DiagnosticRelatedInformation, DiagnosticSeverity, Location, Position, Range, Url,
-};
+use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, Position, Range, Url};
 
 use crate::ast::{ParsedDoc, offset_to_position};
 use crate::backend::DiagnosticsConfig;
@@ -25,48 +23,72 @@ pub fn semantic_diagnostics(
         return vec![];
     }
 
-    let source = doc.source();
-    let stmts: &[php_ast::Stmt<'_, '_>] = doc.program().stmts.as_ref();
+    let codebase = mir_codebase::Codebase::new();
+    let file: Arc<str> = Arc::from(uri.as_str());
 
-    // Build the workspace context: (source, stmts) for each document.
-    let mut all: Vec<(&str, &[php_ast::Stmt<'_, '_>])> = Vec::with_capacity(1 + other_docs.len());
-    all.push((source, stmts));
-    for (_, d) in other_docs {
-        all.push((d.source(), d.program().stmts.as_ref()));
+    // Load PHP built-in stubs so calls to strlen(), array_map(), etc. are recognised.
+    mir_analyzer::stubs::load_stubs(&codebase);
+
+    // Pass 1: collect definitions from all documents so cross-file type info is available.
+    for (other_uri, other_doc) in other_docs {
+        let other_file: Arc<str> = Arc::from(other_uri.as_str());
+        let collector = mir_analyzer::collector::DefinitionCollector::new(
+            &codebase,
+            other_file,
+            other_doc.source(),
+        );
+        collector.collect(other_doc.program());
     }
+    let collector =
+        mir_analyzer::collector::DefinitionCollector::new(&codebase, file.clone(), doc.source());
+    let collector_issues = collector.collect(doc.program());
 
-    mir_php::analyze(source, stmts, &all)
+    // Resolve inheritance, build dispatch tables, etc.
+    codebase.finalize();
+
+    // Pass 2: analyse function/method bodies in the current document.
+    let mut issue_buffer = mir_issues::IssueBuffer::new();
+    let mut analyzer = mir_analyzer::stmt::StatementsAnalyzer::new(
+        &codebase,
+        file.clone(),
+        doc.source(),
+        &mut issue_buffer,
+    );
+    let mut ctx = mir_analyzer::context::Context::new();
+    analyzer.analyze_stmts(&doc.program().stmts, &mut ctx);
+
+    collector_issues
         .into_iter()
-        .filter(|d| diagnostic_passes_filter(d, cfg))
-        .map(|d| to_lsp_diagnostic(d, uri))
+        .chain(issue_buffer.into_issues())
+        .filter(|i| !i.suppressed)
+        .filter(|i| issue_passes_filter(i, cfg))
+        .map(|i| to_lsp_diagnostic(i, uri))
         .collect()
 }
 
-/// Returns `true` if the mir-php diagnostic is allowed through by the config.
-fn diagnostic_passes_filter(d: &mir_php::Diagnostic, cfg: &DiagnosticsConfig) -> bool {
-    let msg = &d.message;
-    if msg.starts_with("Undefined variable:") {
-        return cfg.undefined_variables;
-    }
-    if let Some(name) = msg.strip_prefix("Undefined: ") {
-        // Heuristic: PHP classes start with an uppercase letter, functions with lowercase.
-        let first = name.chars().next().unwrap_or('_');
-        return if first.is_uppercase() {
-            cfg.undefined_classes
-        } else {
+/// Returns `true` if the mir-analyzer issue is allowed through by the config.
+fn issue_passes_filter(issue: &mir_issues::Issue, cfg: &DiagnosticsConfig) -> bool {
+    use mir_issues::IssueKind;
+    match &issue.kind {
+        IssueKind::UndefinedVariable { .. } | IssueKind::PossiblyUndefinedVariable { .. } => {
+            cfg.undefined_variables
+        }
+        IssueKind::UndefinedFunction { .. } | IssueKind::UndefinedMethod { .. } => {
             cfg.undefined_functions
-        };
+        }
+        IssueKind::UndefinedClass { .. } => cfg.undefined_classes,
+        IssueKind::InvalidReturnType { .. }
+        | IssueKind::InvalidArgument { .. }
+        | IssueKind::NullMethodCall { .. }
+        | IssueKind::NullPropertyFetch { .. }
+        | IssueKind::NullableReturnStatement { .. }
+        | IssueKind::InvalidPropertyAssignment { .. }
+        | IssueKind::InvalidOperand { .. } => cfg.type_errors,
+        IssueKind::DeprecatedMethod { .. } | IssueKind::DeprecatedClass { .. } => {
+            cfg.deprecated_calls
+        }
+        _ => true,
     }
-    if msg.starts_with("Too few arguments") || msg.starts_with("Too many arguments") {
-        return cfg.arity_errors;
-    }
-    if msg.starts_with("Cannot return null")
-        || msg.starts_with("Calling a method on null")
-        || msg.contains("type mismatch")
-    {
-        return cfg.type_errors;
-    }
-    true
 }
 
 /// Check for deprecated function/method calls and emit Warning diagnostics.
@@ -398,52 +420,29 @@ fn collect_duplicate_decls(
     }
 }
 
-fn to_lsp_diagnostic(d: mir_php::Diagnostic, uri: &Url) -> Diagnostic {
-    let related_information = if d.related.is_empty() {
-        None
-    } else {
-        Some(
-            d.related
-                .into_iter()
-                .map(|(sl, sc, el, ec, msg)| DiagnosticRelatedInformation {
-                    location: Location {
-                        uri: uri.clone(),
-                        range: Range {
-                            start: Position {
-                                line: sl,
-                                character: sc,
-                            },
-                            end: Position {
-                                line: el,
-                                character: ec,
-                            },
-                        },
-                    },
-                    message: msg,
-                })
-                .collect(),
-        )
-    };
+fn to_lsp_diagnostic(issue: mir_issues::Issue, _uri: &Url) -> Diagnostic {
+    // mir-analyzer uses 1-based line numbers; LSP uses 0-based.
+    let line = issue.location.line.saturating_sub(1);
+    let col_start = issue.location.col_start as u32;
+    let col_end = issue.location.col_end as u32;
     Diagnostic {
         range: Range {
             start: Position {
-                line: d.start_line,
-                character: d.start_char,
+                line,
+                character: col_start,
             },
             end: Position {
-                line: d.end_line,
-                character: d.end_char,
+                line,
+                character: col_end.max(col_start + 1),
             },
         },
-        severity: Some(match d.severity {
-            mir_php::Severity::Error => DiagnosticSeverity::ERROR,
-            mir_php::Severity::Warning => DiagnosticSeverity::WARNING,
-            mir_php::Severity::Information => DiagnosticSeverity::INFORMATION,
-            mir_php::Severity::Hint => DiagnosticSeverity::HINT,
+        severity: Some(match issue.severity {
+            mir_issues::Severity::Error => DiagnosticSeverity::ERROR,
+            mir_issues::Severity::Warning => DiagnosticSeverity::WARNING,
+            mir_issues::Severity::Info => DiagnosticSeverity::INFORMATION,
         }),
         source: Some("php-lsp".to_string()),
-        message: d.message,
-        related_information,
+        message: issue.kind.message(),
         ..Default::default()
     }
 }


### PR DESCRIPTION
## Summary

- `mir-php 0.1.1` dropped its library target (now CLI-only); the analysis engine was extracted into separate crates
- Replace `mir-php` with `mir-analyzer = "0.1.0"` + `mir-issues = "0.1.0"` + `mir-codebase = "0.1.0"`
- Upgrade `php-ast` and `php-rs-parser` from `0.2.1` → `0.3.2` to match what mir-analyzer requires
- Bump version to `0.1.48`

## What changed in `semantic_diagnostics.rs`

The old single `mir_php::analyze(source, stmts, all)` call is replaced with the explicit two-pass pipeline:

1. **Pass 1 — `DefinitionCollector`**: collects class/function/trait/interface definitions from all open documents into a shared `Codebase`
2. **`codebase.finalize()`**: resolves inheritance and builds dispatch tables
3. **Pass 2 — `StatementsAnalyzer`**: walks function/method bodies in the current document to produce issues

Additional changes:
- Load PHP built-in stubs via `mir_analyzer::stubs::load_stubs()` so standard functions are not flagged as undefined
- Replace string-matching diagnostic filter with `IssueKind` variant matching
- Severity mapping updated: `Information/Hint` → `Info` (new enum has `Error | Warning | Info`)
- `relatedInformation` dropped (not present in the new `Issue` type)

## Test plan

- [x] `cargo build` — clean compile
- [x] `cargo test` — 578 passed, 0 failed