### PR TITLE
chore: add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,7 @@ jobs:
     needs: test
     runs-on: ${{ matrix.runner }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - target: aarch64-apple-darwin
@@ -92,6 +93,9 @@ jobs:
       - name: Build
         run: cargo build --release --target ${{ matrix.target }}
 
+      - name: Verify binary
+        run: test -s target/${{ matrix.target }}/release/php-lsp
+
       - name: Archive (macOS)
         if: runner.os == 'macOS'
         run: |
@@ -107,6 +111,7 @@ jobs:
       - name: Upload to GitHub Release
         uses: softprops/action-gh-release@v2
         with:
+          generate_release_notes: true
           files: |
             php-lsp-${{ matrix.target }}.tar.gz
             php-lsp-${{ matrix.target }}.tar.gz.sha256
@@ -138,11 +143,10 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
           key: ubuntu-publish-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ubuntu-publish-cargo-
 
       - name: Publish to crates.io
-        run: cargo publish
+        run: cargo publish --package php-lsp
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,147 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    name: Test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check tag is on main
+        run: |
+          git fetch origin main
+          git merge-base --is-ancestor ${{ github.sha }} origin/main || { echo "Tag is not on main branch"; exit 1; }
+        shell: bash
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: "1.94.0"
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+
+      - name: Run tests
+        run: cargo test
+
+  build:
+    name: Build (${{ matrix.target }})
+    needs: test
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        include:
+          - target: aarch64-apple-darwin
+            runner: macos-latest
+          - target: x86_64-apple-darwin
+            runner: macos-latest
+          - target: x86_64-unknown-linux-gnu
+            runner: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check tag is on main
+        run: |
+          git fetch origin main
+          git merge-base --is-ancestor ${{ github.sha }} origin/main || { echo "Tag is not on main branch"; exit 1; }
+        shell: bash
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: "1.94.0"
+          targets: ${{ matrix.target }}
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-${{ matrix.target }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-${{ matrix.target }}-cargo-
+
+      - name: Build
+        run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Archive (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          tar czf php-lsp-${{ matrix.target }}.tar.gz -C target/${{ matrix.target }}/release php-lsp
+          shasum -a 256 php-lsp-${{ matrix.target }}.tar.gz > php-lsp-${{ matrix.target }}.tar.gz.sha256
+
+      - name: Archive (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          tar czf php-lsp-${{ matrix.target }}.tar.gz -C target/${{ matrix.target }}/release php-lsp
+          sha256sum php-lsp-${{ matrix.target }}.tar.gz > php-lsp-${{ matrix.target }}.tar.gz.sha256
+
+      - name: Upload to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            php-lsp-${{ matrix.target }}.tar.gz
+            php-lsp-${{ matrix.target }}.tar.gz.sha256
+
+  publish-crates:
+    name: Publish to crates.io
+    needs: test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check tag is on main
+        run: |
+          git fetch origin main
+          git merge-base --is-ancestor ${{ github.sha }} origin/main || { echo "Tag is not on main branch"; exit 1; }
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: "1.94.0"
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ubuntu-publish-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ubuntu-publish-cargo-
+
+      - name: Publish to crates.io
+        run: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,6 +125,7 @@ jobs:
         run: |
           git fetch origin main
           git merge-base --is-ancestor ${{ github.sha }} origin/main || { echo "Tag is not on main branch"; exit 1; }
+        shell: bash
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@v1


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/release.yml` triggered on `v*` tag pushes on `main`
- Runs full test suite (ubuntu, macos, windows) before building or publishing
- Builds cross-platform binaries (aarch64-apple-darwin, x86_64-apple-darwin, x86_64-unknown-linux-gnu) and uploads `.tar.gz` + `.sha256` to a GitHub Release
- Publishes to crates.io via `cargo publish --package php-lsp`

## Test plan

- [ ] Add `CARGO_REGISTRY_TOKEN` to repo secrets (crates.io token with `publish-update` scope)
- [ ] Bump version in `Cargo.toml`, commit, push a `v*` tag on `main`
- [ ] Verify `test` job passes on all 3 OSes
- [ ] Verify `build` job produces 3 release artifacts with `.sha256` files
- [ ] Verify `publish-crates` job publishes to crates.io