### PR TITLE
hover: show enum case backing value and class constant type

### DIFF
--- a/src/hover.rs
+++ b/src/hover.rs
@@ -273,6 +273,25 @@ fn scan_statements(stmts: &[Stmt<'_, '_>], word: &str) -> Option<String> {
             StmtKind::Interface(i) if i.name == word => {
                 return Some(format!("interface {}", word));
             }
+            StmtKind::Interface(i) => {
+                for member in i.members.iter() {
+                    match &member.kind {
+                        ClassMemberKind::Method(m) if m.name == word => {
+                            let params = format_params(&m.params);
+                            let ret = m
+                                .return_type
+                                .as_ref()
+                                .map(|r| format!(": {}", format_type_hint(r)))
+                                .unwrap_or_default();
+                            return Some(format!("function {}({}){}", word, params, ret));
+                        }
+                        ClassMemberKind::ClassConst(k) if k.name == word => {
+                            return Some(format_class_const(k));
+                        }
+                        _ => {}
+                    }
+                }
+            }
             StmtKind::Trait(t) if t.name == word => {
                 return Some(format!("trait {}", word));
             }
@@ -334,16 +353,20 @@ fn scan_statements(stmts: &[Stmt<'_, '_>], word: &str) -> Option<String> {
             }
             StmtKind::Trait(t) => {
                 for member in t.members.iter() {
-                    if let ClassMemberKind::Method(m) = &member.kind
-                        && m.name == word
-                    {
-                        let params = format_params(&m.params);
-                        let ret = m
-                            .return_type
-                            .as_ref()
-                            .map(|r| format!(": {}", format_type_hint(r)))
-                            .unwrap_or_default();
-                        return Some(format!("function {}({}){}", word, params, ret));
+                    match &member.kind {
+                        ClassMemberKind::Method(m) if m.name == word => {
+                            let params = format_params(&m.params);
+                            let ret = m
+                                .return_type
+                                .as_ref()
+                                .map(|r| format!(": {}", format_type_hint(r)))
+                                .unwrap_or_default();
+                            return Some(format!("function {}({}){}", word, params, ret));
+                        }
+                        ClassMemberKind::ClassConst(k) if k.name == word => {
+                            return Some(format_class_const(k));
+                        }
+                        _ => {}
                     }
                 }
             }
@@ -1247,6 +1270,45 @@ mod tests {
             expect![[r#"
                 ```php
                 const float PI = 3.14
+                ```"#]],
+        );
+    }
+
+    #[test]
+    fn snapshot_hover_class_const_infers_type_from_value() {
+        let (src, p) = cursor("<?php\nclass Config { const VERSION$0 = '1.0.0'; }");
+        check_hover(
+            &src,
+            p,
+            expect![[r#"
+                ```php
+                const string VERSION = '1.0.0'
+                ```"#]],
+        );
+    }
+
+    #[test]
+    fn snapshot_hover_interface_const_shows_type_and_value() {
+        let (src, p) = cursor("<?php\ninterface Limits { const int MA$0X = 100; }");
+        check_hover(
+            &src,
+            p,
+            expect![[r#"
+                ```php
+                const int MAX = 100
+                ```"#]],
+        );
+    }
+
+    #[test]
+    fn snapshot_hover_trait_const_shows_type_and_value() {
+        let (src, p) = cursor("<?php\ntrait HasVersion { const string TAG$0 = 'v1'; }");
+        check_hover(
+            &src,
+            p,
+            expect![[r#"
+                ```php
+                const string TAG = 'v1'
                 ```"#]],
         );
     }

--- a/src/hover.rs
+++ b/src/hover.rs
@@ -315,16 +315,20 @@ fn scan_statements(stmts: &[Stmt<'_, '_>], word: &str) -> Option<String> {
             }
             StmtKind::Class(c) => {
                 for member in c.members.iter() {
-                    if let ClassMemberKind::Method(m) = &member.kind
-                        && m.name == word
-                    {
-                        let params = format_params(&m.params);
-                        let ret = m
-                            .return_type
-                            .as_ref()
-                            .map(|r| format!(": {}", format_type_hint(r)))
-                            .unwrap_or_default();
-                        return Some(format!("function {}({}){}", word, params, ret));
+                    match &member.kind {
+                        ClassMemberKind::Method(m) if m.name == word => {
+                            let params = format_params(&m.params);
+                            let ret = m
+                                .return_type
+                                .as_ref()
+                                .map(|r| format!(": {}", format_type_hint(r)))
+                                .unwrap_or_default();
+                            return Some(format!("function {}({}){}", word, params, ret));
+                        }
+                        ClassMemberKind::ClassConst(k) if k.name == word => {
+                            return Some(format_class_const(k));
+                        }
+                        _ => {}
                     }
                 }
             }
@@ -363,6 +367,28 @@ fn format_expr_literal(expr: &php_ast::Expr<'_, '_>) -> Option<String> {
         ExprKind::String(s) => Some(format!("\"{}\"", s)),
         _ => None,
     }
+}
+
+/// Format a class/interface/enum constant declaration for hover display.
+fn format_class_const(c: &php_ast::ClassConstDecl<'_, '_>) -> String {
+    let type_str = c
+        .type_hint
+        .as_ref()
+        .map(|t| format!("{} ", format_type_hint(t)))
+        .or_else(|| {
+            // Infer type from literal value when no annotation present.
+            // format_expr_literal wraps strings in double quotes and ints as plain digits.
+            match format_expr_literal(&c.value) {
+                Some(ref v) if v.starts_with('"') => Some("string ".to_string()),
+                Some(ref v) if v.parse::<i64>().is_ok() => Some("int ".to_string()),
+                _ => None,
+            }
+        })
+        .unwrap_or_default();
+    let value_str = format_expr_literal(&c.value)
+        .map(|v| format!(" = {v}"))
+        .unwrap_or_default();
+    format!("const {}{}{}", type_str, c.name, value_str)
 }
 
 /// Look up markdown documentation for a symbol by name across all indexed documents.
@@ -1212,5 +1238,30 @@ mod tests {
                 interface Serializable
                 ```"#]],
         );
+    }
+
+    #[test]
+    fn hover_on_class_const_with_type_hint() {
+        let src = "<?php\nclass Config { const string VERSION = '1.0.0'; }";
+        let doc = ParsedDoc::parse(src.to_string());
+        // "VERSION" starts at col 34: "class Config { const string VERSION"
+        let result = hover_info(src, &doc, pos(1, 34), &[]);
+        assert!(result.is_some(), "expected hover on class constant");
+        if let Some(Hover {
+            contents: HoverContents::Markup(mc),
+            ..
+        }) = result
+        {
+            assert!(
+                mc.value.contains("string VERSION"),
+                "expected type and name, got: {}",
+                mc.value
+            );
+            assert!(
+                mc.value.contains("'1.0.0'") || mc.value.contains("\"1.0.0\""),
+                "expected value, got: {}",
+                mc.value
+            );
+        }
     }
 }

--- a/src/hover.rs
+++ b/src/hover.rs
@@ -360,10 +360,12 @@ fn scan_statements(stmts: &[Stmt<'_, '_>], word: &str) -> Option<String> {
     None
 }
 
-/// Format a literal expression value for hover display (int or string literals only).
+/// Format a literal expression value for hover display (int, float, bool, or string literals).
 fn format_expr_literal(expr: &php_ast::Expr<'_, '_>) -> Option<String> {
     match &expr.kind {
         ExprKind::Int(n) => Some(n.to_string()),
+        ExprKind::Float(f) => Some(f.to_string()),
+        ExprKind::Bool(b) => Some(if *b { "true" } else { "false" }.to_string()),
         ExprKind::String(s) => Some(format!("'{}'", s)),
         _ => None,
     }
@@ -842,28 +844,15 @@ mod tests {
     }
 
     #[test]
-    fn hover_on_backed_enum_case_shows_value() {
-        let src = "<?php\nenum Color: string { case Red = 'red'; }";
-        let doc = ParsedDoc::parse(src.to_string());
-        // "Red" starts at col 26: "enum Color: string { case Red"
-        let result = hover_info(src, &doc, pos(1, 27), &[]);
-        assert!(result.is_some(), "expected hover on backed enum case");
-        if let Some(Hover {
-            contents: HoverContents::Markup(mc),
-            ..
-        }) = result
-        {
-            assert!(
-                mc.value.contains("Color::Red"),
-                "expected 'Color::Red', got: {}",
-                mc.value
-            );
-            assert!(
-                mc.value.contains("'red'"),
-                "expected case value, got: {}",
-                mc.value
-            );
-        }
+    fn snapshot_hover_backed_enum_case_shows_value() {
+        check_hover(
+            "<?php\nenum Color: string { case Red = 'red'; }",
+            pos(1, 27),
+            expect![[r#"
+                ```php
+                case Color::Red = 'red'
+                ```"#]],
+        );
     }
 
     #[test]
@@ -1246,6 +1235,18 @@ mod tests {
             expect![[r#"
                 ```php
                 const string VERSION = '1.0.0'
+                ```"#]],
+        );
+    }
+
+    #[test]
+    fn snapshot_hover_class_const_float_value() {
+        check_hover(
+            "<?php\nclass Math { const float PI = 3.14; }",
+            pos(1, 27),
+            expect![[r#"
+                ```php
+                const float PI = 3.14
                 ```"#]],
         );
     }

--- a/src/hover.rs
+++ b/src/hover.rs
@@ -328,6 +328,9 @@ fn scan_statements(stmts: &[Stmt<'_, '_>], word: &str) -> Option<String> {
                                 .unwrap_or_default();
                             return Some(format!("case {}::{}{}", e.name, c.name, value_str));
                         }
+                        EnumMemberKind::ClassConst(k) if k.name == word => {
+                            return Some(format_class_const(k));
+                        }
                         _ => {}
                     }
                 }
@@ -874,6 +877,18 @@ mod tests {
             expect![[r#"
                 ```php
                 case Color::Red = 'red'
+                ```"#]],
+        );
+    }
+
+    #[test]
+    fn snapshot_hover_enum_class_const() {
+        check_hover(
+            "<?php\nenum Suit { const int MAX = 4; }",
+            pos(1, 22),
+            expect![[r#"
+                ```php
+                const int MAX = 4
                 ```"#]],
         );
     }

--- a/src/hover.rs
+++ b/src/hover.rs
@@ -364,7 +364,7 @@ fn scan_statements(stmts: &[Stmt<'_, '_>], word: &str) -> Option<String> {
 fn format_expr_literal(expr: &php_ast::Expr<'_, '_>) -> Option<String> {
     match &expr.kind {
         ExprKind::Int(n) => Some(n.to_string()),
-        ExprKind::String(s) => Some(format!("\"{}\"", s)),
+        ExprKind::String(s) => Some(format!("'{}'", s)),
         _ => None,
     }
 }
@@ -375,14 +375,12 @@ fn format_class_const(c: &php_ast::ClassConstDecl<'_, '_>) -> String {
         .type_hint
         .as_ref()
         .map(|t| format!("{} ", format_type_hint(t)))
-        .or_else(|| {
-            // Infer type from literal value when no annotation present.
-            // format_expr_literal wraps strings in double quotes and ints as plain digits.
-            match format_expr_literal(&c.value) {
-                Some(ref v) if v.starts_with('"') => Some("string ".to_string()),
-                Some(ref v) if v.parse::<i64>().is_ok() => Some("int ".to_string()),
-                _ => None,
-            }
+        .or_else(|| match &c.value.kind {
+            ExprKind::Int(_) => Some("int ".to_string()),
+            ExprKind::String(_) => Some("string ".to_string()),
+            ExprKind::Float(_) => Some("float ".to_string()),
+            ExprKind::Bool(_) => Some("bool ".to_string()),
+            _ => None,
         })
         .unwrap_or_default();
     let value_str = format_expr_literal(&c.value)
@@ -861,7 +859,7 @@ mod tests {
                 mc.value
             );
             assert!(
-                mc.value.contains("\"red\""),
+                mc.value.contains("'red'"),
                 "expected case value, got: {}",
                 mc.value
             );
@@ -1241,27 +1239,14 @@ mod tests {
     }
 
     #[test]
-    fn hover_on_class_const_with_type_hint() {
-        let src = "<?php\nclass Config { const string VERSION = '1.0.0'; }";
-        let doc = ParsedDoc::parse(src.to_string());
-        // "VERSION" starts at col 34: "class Config { const string VERSION"
-        let result = hover_info(src, &doc, pos(1, 34), &[]);
-        assert!(result.is_some(), "expected hover on class constant");
-        if let Some(Hover {
-            contents: HoverContents::Markup(mc),
-            ..
-        }) = result
-        {
-            assert!(
-                mc.value.contains("string VERSION"),
-                "expected type and name, got: {}",
-                mc.value
-            );
-            assert!(
-                mc.value.contains("'1.0.0'") || mc.value.contains("\"1.0.0\""),
-                "expected value, got: {}",
-                mc.value
-            );
-        }
+    fn snapshot_hover_class_const_with_type_hint() {
+        check_hover(
+            "<?php\nclass Config { const string VERSION = '1.0.0'; }",
+            pos(1, 28),
+            expect![[r#"
+                ```php
+                const string VERSION = '1.0.0'
+                ```"#]],
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Add `format_class_const` helper that formats a `ClassConstDecl` into a hover signature with type (explicit annotation or inferred from literal) and value
- Extend `scan_statements` to handle `ClassMemberKind::ClassConst` in Class, Interface, and Trait branches, and `EnumMemberKind::ClassConst` in the Enum branch
- Extend `format_expr_literal` to cover Float and Bool literals; switch strings to single-quote convention

## Test Plan
- [ ] 615 tests pass with no regressions (`cargo test`)
- [ ] Hover on `const string VERSION = '1.0.0'` shows `const string VERSION = '1.0.0'`
- [ ] Hover on unannotated `const VERSION = '1.0.0'` infers and shows `const string VERSION = '1.0.0'`
- [ ] Hover on interface/trait constants works the same as class constants
- [ ] Hover on enum class constant (e.g. `const int MAX = 4`) shows `const int MAX = 4`

Closes #38