### PR TITLE
feat(organize_imports): handle use function and use const statements

### DIFF
--- a/src/organize_imports.rs
+++ b/src/organize_imports.rs
@@ -17,16 +17,24 @@ pub fn organize_imports_action(source: &str, uri: &Url) -> Option<CodeActionOrCo
     let body_start_byte = block.body_start_byte;
     let body = &source[body_start_byte..];
 
-    let mut kept: Vec<UseStatement> = block
-        .statements
-        .into_iter()
-        .filter(|u| is_used(u, body))
-        .collect();
+    // Split into three groups by kind, filtering unused imports.
+    let mut class_uses: Vec<UseStatement> = Vec::new();
+    let mut fn_uses: Vec<UseStatement> = Vec::new();
+    let mut const_uses: Vec<UseStatement> = Vec::new();
 
-    if kept.is_empty() {
-        // Remove the entire use block (replace with empty string).
-        // Guard: don't produce an action that deletes everything.
-        // Only act if there really were use-statements.
+    for u in block.statements {
+        if !is_used(&u, body) {
+            continue;
+        }
+        match u.kind {
+            UseKind::Class => class_uses.push(u),
+            UseKind::Function => fn_uses.push(u),
+            UseKind::Const => const_uses.push(u),
+        }
+    }
+
+    // If everything was removed, emit an empty replacement.
+    if class_uses.is_empty() && fn_uses.is_empty() && const_uses.is_empty() {
         let edit = TextEdit {
             range: block.range,
             new_text: String::new(),
@@ -34,30 +42,27 @@ pub fn organize_imports_action(source: &str, uri: &Url) -> Option<CodeActionOrCo
         return Some(make_action(uri, edit));
     }
 
-    // Sort: group by leading namespace segment, then alphabetically within group.
-    kept.sort_by(|a, b| a.fqn.to_lowercase().cmp(&b.fqn.to_lowercase()));
+    // Sort and deduplicate each group alphabetically (case-insensitive).
+    sort_and_dedup(&mut class_uses);
+    sort_and_dedup(&mut fn_uses);
+    sort_and_dedup(&mut const_uses);
 
-    let sorted_text: String = kept
-        .iter()
-        .map(|u| {
-            if let Some(alias) = &u.alias {
-                format!("use {} as {};\n", u.fqn, alias)
-            } else {
-                format!("use {};\n", u.fqn)
-            }
-        })
-        .collect();
-
-    // Preserve leading indentation from the first use statement.
+    // Build the output: class uses → (blank line) → function uses → (blank line) → const uses.
     let indent = block.indent.clone();
-    let indented: String = if indent.is_empty() {
-        sorted_text
-    } else {
-        sorted_text
-            .lines()
-            .map(|l| format!("{indent}{l}\n"))
-            .collect()
-    };
+    let mut parts: Vec<String> = Vec::new();
+
+    if !class_uses.is_empty() {
+        parts.push(render_group(&class_uses, &indent, None));
+    }
+    if !fn_uses.is_empty() {
+        parts.push(render_group(&fn_uses, &indent, Some("function")));
+    }
+    if !const_uses.is_empty() {
+        parts.push(render_group(&const_uses, &indent, Some("const")));
+    }
+
+    // Join groups with a blank line between them.
+    let indented = parts.join("\n");
 
     // Only emit an action if something actually changed.
     let current_text = &source[byte_range_of(source, block.range)];
@@ -70,6 +75,35 @@ pub fn organize_imports_action(source: &str, uri: &Url) -> Option<CodeActionOrCo
         new_text: indented,
     };
     Some(make_action(uri, edit))
+}
+
+/// Render a group of use statements as a string block ending with a trailing newline.
+fn render_group(stmts: &[UseStatement], indent: &str, keyword: Option<&str>) -> String {
+    stmts
+        .iter()
+        .map(|u| {
+            let kw = match keyword {
+                Some(k) => format!("{k} "),
+                None => String::new(),
+            };
+            let stmt = if let Some(alias) = &u.alias {
+                format!("use {}{} as {};\n", kw, u.fqn, alias)
+            } else {
+                format!("use {}{};\n", kw, u.fqn)
+            };
+            if indent.is_empty() {
+                stmt
+            } else {
+                format!("{indent}{stmt}")
+            }
+        })
+        .collect()
+}
+
+/// Sort a group alphabetically (case-insensitive) and deduplicate by FQN.
+fn sort_and_dedup(group: &mut Vec<UseStatement>) {
+    group.sort_by(|a, b| a.fqn.to_lowercase().cmp(&b.fqn.to_lowercase()));
+    group.dedup_by(|a, b| a.fqn.to_lowercase() == b.fqn.to_lowercase());
 }
 
 fn make_action(uri: &Url, edit: TextEdit) -> CodeActionOrCommand {
@@ -86,6 +120,14 @@ fn make_action(uri: &Url, edit: TextEdit) -> CodeActionOrCommand {
     })
 }
 
+/// The kind of a `use` statement.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum UseKind {
+    Class,
+    Function,
+    Const,
+}
+
 /// A single parsed `use` statement.
 #[derive(Debug, Clone)]
 struct UseStatement {
@@ -95,6 +137,8 @@ struct UseStatement {
     alias: Option<String>,
     /// The short (unaliased) name used in the code body, e.g. `Mailer` or `Bar`.
     short: String,
+    /// Whether this is a class, function, or const import.
+    kind: UseKind,
 }
 
 struct UseBlock {
@@ -137,13 +181,17 @@ fn find_use_block(source: &str) -> Option<UseBlock> {
                 }
                 continue;
             }
-            // Reject `use function` / `use const` for now (keep simple).
-            if rest.starts_with("function ") || rest.starts_with("const ") {
-                continue;
-            }
 
-            let stmt_text = rest.trim_end_matches(';').trim();
-            if let Some(us) = parse_use_statement(stmt_text) {
+            // Detect `use function` / `use const`.
+            let (kind, stmt_text) = if let Some(fn_rest) = rest.strip_prefix("function ") {
+                (UseKind::Function, fn_rest.trim_end_matches(';').trim())
+            } else if let Some(const_rest) = rest.strip_prefix("const ") {
+                (UseKind::Const, const_rest.trim_end_matches(';').trim())
+            } else {
+                (UseKind::Class, rest.trim_end_matches(';').trim())
+            };
+
+            if let Some(us) = parse_use_statement(stmt_text, kind) {
                 if first_line.is_none() {
                     first_line = Some(line_no);
                     indent = line
@@ -189,7 +237,7 @@ fn find_use_block(source: &str) -> Option<UseBlock> {
     })
 }
 
-fn parse_use_statement(text: &str) -> Option<UseStatement> {
+fn parse_use_statement(text: &str, kind: UseKind) -> Option<UseStatement> {
     // Handle `Foo\Bar as Baz` and plain `Foo\Bar`.
     let (fqn_part, alias) = if let Some((fqn, al)) = text.split_once(" as ") {
         (fqn.trim(), Some(al.trim().to_string()))
@@ -210,6 +258,7 @@ fn parse_use_statement(text: &str) -> Option<UseStatement> {
         fqn: fqn_part.to_string(),
         alias,
         short,
+        kind,
     })
 }
 
@@ -294,6 +343,23 @@ mod tests {
         Url::parse("file:///test.php").unwrap()
     }
 
+    fn extract_new_text(action: CodeActionOrCommand) -> String {
+        let CodeActionOrCommand::CodeAction(ca) = action else {
+            panic!("expected CodeAction");
+        };
+        ca.edit
+            .unwrap()
+            .changes
+            .unwrap()
+            .into_values()
+            .next()
+            .unwrap()
+            .into_iter()
+            .next()
+            .unwrap()
+            .new_text
+    }
+
     #[test]
     fn no_use_statements_returns_none() {
         let src = "<?php\n\nclass Foo {}\n";
@@ -313,18 +379,7 @@ mod tests {
             "<?php\nuse App\\Zebra;\nuse App\\Alpha;\n\n$a = new Alpha();\n$z = new Zebra();\n";
         let action = organize_imports_action(src, &uri());
         assert!(action.is_some(), "should produce an action");
-        let CodeActionOrCommand::CodeAction(ca) = action.unwrap() else {
-            panic!("expected CodeAction");
-        };
-        let edits = ca
-            .edit
-            .unwrap()
-            .changes
-            .unwrap()
-            .into_values()
-            .next()
-            .unwrap();
-        let new_text = &edits[0].new_text;
+        let new_text = extract_new_text(action.unwrap());
         let alpha_pos = new_text.find("Alpha").unwrap();
         let zebra_pos = new_text.find("Zebra").unwrap();
         assert!(alpha_pos < zebra_pos, "Alpha should come before Zebra");
@@ -339,18 +394,7 @@ mod tests {
             action.is_some(),
             "should produce an action to remove Logger"
         );
-        let CodeActionOrCommand::CodeAction(ca) = action.unwrap() else {
-            panic!("expected CodeAction");
-        };
-        let edits = ca
-            .edit
-            .unwrap()
-            .changes
-            .unwrap()
-            .into_values()
-            .next()
-            .unwrap();
-        let new_text = &edits[0].new_text;
+        let new_text = extract_new_text(action.unwrap());
         assert!(!new_text.contains("Logger"), "Logger should be removed");
         assert!(new_text.contains("Mailer"), "Mailer should be kept");
     }
@@ -371,18 +415,7 @@ mod tests {
             "<?php\nuse App\\Zebra as Z;\nuse App\\Alpha;\n\n$a = new Alpha();\n$z = new Z();\n";
         let action = organize_imports_action(src, &uri());
         assert!(action.is_some());
-        let CodeActionOrCommand::CodeAction(ca) = action.unwrap() else {
-            panic!("expected CodeAction");
-        };
-        let edits = ca
-            .edit
-            .unwrap()
-            .changes
-            .unwrap()
-            .into_values()
-            .next()
-            .unwrap();
-        let new_text = &edits[0].new_text;
+        let new_text = extract_new_text(action.unwrap());
         assert!(
             new_text.contains("as Z"),
             "aliased import should keep alias syntax"
@@ -398,5 +431,113 @@ mod tests {
             panic!("expected CodeAction");
         };
         assert_eq!(ca.kind, Some(CodeActionKind::SOURCE_ORGANIZE_IMPORTS));
+    }
+
+    #[test]
+    fn use_function_and_const_sorted_and_grouped() {
+        // Mixed class, function, and const imports in unsorted order.
+        // PSR-12: class uses first, then function uses, then const uses.
+        let src = concat!(
+            "<?php\n",
+            "use function Zlib\\deflate;\n",
+            "use const Math\\PI;\n",
+            "use App\\Zebra;\n",
+            "use function App\\helpers\\format;\n",
+            "use const Config\\MAX_SIZE;\n",
+            "use App\\Alpha;\n",
+            "\n",
+            "$a = new Alpha();\n",
+            "$z = new Zebra();\n",
+            "deflate($a);\n",
+            "format($z);\n",
+            "echo PI;\n",
+            "echo MAX_SIZE;\n",
+        );
+        let action = organize_imports_action(src, &uri());
+        assert!(action.is_some(), "should produce an action");
+        let new_text = extract_new_text(action.unwrap());
+
+        // Class uses come before function uses.
+        let alpha_pos = new_text.find("App\\Alpha").unwrap();
+        let format_fn_pos = new_text.find("use function").unwrap();
+        assert!(
+            alpha_pos < format_fn_pos,
+            "class uses should precede function uses"
+        );
+
+        // Function uses come before const uses.
+        let fn_pos = new_text.find("use function").unwrap();
+        let const_pos = new_text.find("use const").unwrap();
+        assert!(
+            fn_pos < const_pos,
+            "function uses should precede const uses"
+        );
+
+        // Within function group: format before deflate (alphabetical by FQN).
+        let format_pos = new_text.find("format").unwrap();
+        let deflate_pos = new_text.find("deflate").unwrap();
+        assert!(
+            format_pos < deflate_pos,
+            "format should come before deflate alphabetically"
+        );
+
+        // Within const group: MAX_SIZE before PI (alphabetical).
+        let max_pos = new_text.find("MAX_SIZE").unwrap();
+        let pi_pos = new_text.find("PI").unwrap();
+        assert!(max_pos < pi_pos, "MAX_SIZE should come before PI");
+
+        // Groups separated by blank line.
+        assert!(
+            new_text.contains(";\n\nuse function"),
+            "blank line between class and function groups"
+        );
+        assert!(
+            new_text.contains(";\n\nuse const"),
+            "blank line between function and const groups"
+        );
+    }
+
+    #[test]
+    fn use_function_only_no_class_imports() {
+        let src = concat!(
+            "<?php\n",
+            "use function Zlib\\deflate;\n",
+            "use function App\\format;\n",
+            "\n",
+            "deflate(format('x'));\n",
+        );
+        let action = organize_imports_action(src, &uri());
+        assert!(action.is_some(), "should sort function-only imports");
+        let new_text = extract_new_text(action.unwrap());
+        let app_pos = new_text.find("App").unwrap();
+        let zlib_pos = new_text.find("Zlib").unwrap();
+        assert!(
+            app_pos < zlib_pos,
+            "App\\format should come before Zlib\\deflate"
+        );
+        // No blank lines since there's only one group.
+        assert!(
+            !new_text.contains("\n\n"),
+            "single group should have no blank line separator"
+        );
+    }
+
+    #[test]
+    fn duplicate_use_statements_are_deduplicated() {
+        let src = concat!(
+            "<?php\n",
+            "use App\\Mailer;\n",
+            "use App\\Mailer;\n",
+            "\n",
+            "$m = new Mailer();\n",
+        );
+        let action = organize_imports_action(src, &uri());
+        assert!(action.is_some(), "should produce an action to deduplicate");
+        let new_text = extract_new_text(action.unwrap());
+        assert_eq!(
+            new_text.matches("App\\Mailer").count(),
+            1,
+            "duplicate should be removed"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Extended `organize_imports` to sort, deduplicate, and group all three import kinds
- Groups emitted in PSR-12 order: class imports → `use function` → `use const` (blank line between non-empty groups)
- Added `UseKind` enum to distinguish import types
- 3 new tests covering mixed sorting, function-only imports, and deduplication

Closes #35