### PR TITLE
feat(hover): infer types for catch-block and static variables

### DIFF
--- a/src/hover.rs
+++ b/src/hover.rs
@@ -1327,4 +1327,67 @@ mod tests {
                 ```"#]],
         );
     }
+
+    #[test]
+    fn hover_on_catch_variable_shows_exception_class() {
+        let (src, p) = cursor("<?php\ntry { } catch (RuntimeException $e$0) { }");
+        let doc = ParsedDoc::parse(src.clone());
+        let result = hover_info(&src, &doc, p, &[]);
+        assert!(result.is_some(), "expected hover result for catch variable");
+        if let Some(Hover {
+            contents: HoverContents::Markup(mc),
+            ..
+        }) = result
+        {
+            assert!(
+                mc.value.contains("RuntimeException"),
+                "expected RuntimeException in hover, got: {}",
+                mc.value
+            );
+        }
+    }
+
+    #[test]
+    fn hover_on_static_var_with_array_default_shows_array() {
+        let (src, p) = cursor("<?php\nfunction counter() { static $cach$0e = []; }");
+        let doc = ParsedDoc::parse(src.clone());
+        let result = hover_info(&src, &doc, p, &[]);
+        assert!(
+            result.is_some(),
+            "expected hover result for static variable"
+        );
+        if let Some(Hover {
+            contents: HoverContents::Markup(mc),
+            ..
+        }) = result
+        {
+            assert!(
+                mc.value.contains("array"),
+                "expected array type in hover, got: {}",
+                mc.value
+            );
+        }
+    }
+
+    #[test]
+    fn hover_on_static_var_with_new_shows_class() {
+        let (src, p) = cursor("<?php\nfunction make() { static $inst$0ance = new MyService(); }");
+        let doc = ParsedDoc::parse(src.clone());
+        let result = hover_info(&src, &doc, p, &[]);
+        assert!(
+            result.is_some(),
+            "expected hover result for static variable"
+        );
+        if let Some(Hover {
+            contents: HoverContents::Markup(mc),
+            ..
+        }) = result
+        {
+            assert!(
+                mc.value.contains("MyService"),
+                "expected MyService in hover, got: {}",
+                mc.value
+            );
+        }
+    }
 }

--- a/src/type_map.rs
+++ b/src/type_map.rs
@@ -449,6 +449,49 @@ fn collect_types_stmts(
                     method_returns,
                 );
             }
+            // try { ... } catch (FooException $e) { ... }
+            // Map the catch variable to the first caught exception class.
+            StmtKind::TryCatch(t) => {
+                collect_types_stmts(source, &t.body, map, meta, method_returns);
+                for catch in t.catches.iter() {
+                    if let Some(var_name) = &catch.var
+                        && let Some(first_type) = catch.types.first()
+                    {
+                        let class_name = first_type
+                            .to_string_repr()
+                            .trim_start_matches('\\')
+                            .rsplit('\\')
+                            .next()
+                            .unwrap_or("")
+                            .to_string();
+                        if !class_name.is_empty() {
+                            map.insert(format!("${}", var_name), class_name);
+                        }
+                    }
+                    collect_types_stmts(source, &catch.body, map, meta, method_returns);
+                }
+                if let Some(finally) = &t.finally {
+                    collect_types_stmts(source, finally, map, meta, method_returns);
+                }
+            }
+
+            // static $var = expr — infer type from the default value expression.
+            StmtKind::StaticVar(vars) => {
+                for var in vars.iter() {
+                    let var_key = format!("${}", var.name);
+                    if let Some(default) = &var.default {
+                        if let ExprKind::New(new_expr) = &default.kind
+                            && let Some(class_name) = extract_class_name(new_expr.class)
+                        {
+                            map.insert(var_key.clone(), class_name);
+                        }
+                        if let ExprKind::Array(_) = &default.kind {
+                            map.insert(var_key, "array".to_string());
+                        }
+                    }
+                }
+            }
+
             _ => {}
         }
     }


### PR DESCRIPTION
## Summary

- `catch (FooException $e)` — `$e` now hovers as `FooException`
- `static $cache = []` — `$cache` now hovers as `array`; `static $obj = new Foo()` hovers as `Foo`
- Both handled by extending `collect_types_stmts` in `type_map.rs` with `StmtKind::TryCatch` and `StmtKind::StaticVar` arms