### PR TITLE
perf(semantic_diagnostics): cache stubs and reuse backend codebase

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1470,9 +1470,8 @@ impl LanguageServer for Backend {
                 ));
             }
         };
-        let other_docs = self.docs.other_docs(uri);
         let diag_cfg = self.config.read().unwrap().diagnostics.clone();
-        let sem_diags = semantic_diagnostics(uri, &doc, &other_docs, &diag_cfg);
+        let sem_diags = semantic_diagnostics(uri, &doc, &self.codebase, &diag_cfg);
         let dup_diags = duplicate_declaration_diagnostics(&source, &doc, &diag_cfg);
 
         let mut items = parse_diags;
@@ -1494,7 +1493,6 @@ impl LanguageServer for Backend {
         &self,
         _params: WorkspaceDiagnosticParams,
     ) -> Result<WorkspaceDiagnosticReportResult> {
-        let all_docs = self.docs.all_docs();
         let all_parse_diags = self.docs.all_diagnostics();
         let diag_cfg = self.config.read().unwrap().diagnostics.clone();
 
@@ -1503,15 +1501,8 @@ impl LanguageServer for Backend {
             .filter_map(|(uri, parse_diags, version)| {
                 let doc = self.docs.get_doc(&uri)?;
 
-                // Build other_docs by filtering the current URI out of all_docs.
-                let other_docs: Vec<(Url, Arc<ParsedDoc>)> = all_docs
-                    .iter()
-                    .filter(|(u, _)| u != &uri)
-                    .cloned()
-                    .collect();
-
                 let source = doc.source().to_string();
-                let sem_diags = semantic_diagnostics(&uri, &doc, &other_docs, &diag_cfg);
+                let sem_diags = semantic_diagnostics(&uri, &doc, &self.codebase, &diag_cfg);
                 let dup_diags = duplicate_declaration_diagnostics(&source, &doc, &diag_cfg);
 
                 let mut all_diags = parse_diags;
@@ -1547,7 +1538,7 @@ impl LanguageServer for Backend {
 
         // Semantic diagnostics — collect undefined symbols and offer "Add use import"
         let diag_cfg = self.config.read().unwrap().diagnostics.clone();
-        let sem_diags = semantic_diagnostics(uri, &doc, &other_docs, &diag_cfg);
+        let sem_diags = semantic_diagnostics(uri, &doc, &self.codebase, &diag_cfg);
 
         // Publish semantic diagnostics merged with existing parse diagnostics
         if !sem_diags.is_empty() {

--- a/src/semantic_diagnostics.rs
+++ b/src/semantic_diagnostics.rs
@@ -2,7 +2,7 @@
 ///
 /// Delegates all analysis to the `mir-analyzer` crate and converts its `Issue`
 /// type into the `tower-lsp` `Diagnostic` type expected by the LSP backend.
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use php_ast::{ClassMemberKind, EnumMemberKind, ExprKind, NamespaceBody, Stmt, StmtKind};
 use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, NumberOrString, Position, Range, Url};
@@ -11,34 +11,72 @@ use crate::ast::{ParsedDoc, offset_to_position};
 use crate::backend::DiagnosticsConfig;
 use crate::docblock::{docblock_before, parse_docblock};
 
-/// Run semantic checks on `doc` against `other_docs` and return LSP diagnostics.
-/// Applies `cfg` to suppress individual diagnostic categories.
+/// Cached stubs codebase — loaded once and copied into each analysis codebase.
+static STUBS: OnceLock<mir_codebase::Codebase> = OnceLock::new();
+
+fn stubs_codebase() -> &'static mir_codebase::Codebase {
+    STUBS.get_or_init(|| {
+        let cb = mir_codebase::Codebase::new();
+        mir_analyzer::stubs::load_stubs(&cb);
+        cb
+    })
+}
+
+/// Copy all entries from `src` into `dst`.
+fn copy_codebase(src: &mir_codebase::Codebase, dst: &mir_codebase::Codebase) {
+    for entry in src.functions.iter() {
+        dst.functions
+            .insert(entry.key().clone(), entry.value().clone());
+    }
+    for entry in src.classes.iter() {
+        dst.classes
+            .insert(entry.key().clone(), entry.value().clone());
+    }
+    for entry in src.interfaces.iter() {
+        dst.interfaces
+            .insert(entry.key().clone(), entry.value().clone());
+    }
+    for entry in src.traits.iter() {
+        dst.traits
+            .insert(entry.key().clone(), entry.value().clone());
+    }
+    for entry in src.enums.iter() {
+        dst.enums.insert(entry.key().clone(), entry.value().clone());
+    }
+    for entry in src.constants.iter() {
+        dst.constants
+            .insert(entry.key().clone(), entry.value().clone());
+    }
+    for entry in src.file_imports.iter() {
+        dst.file_imports
+            .insert(entry.key().clone(), entry.value().clone());
+    }
+    for entry in src.file_namespaces.iter() {
+        dst.file_namespaces
+            .insert(entry.key().clone(), entry.value().clone());
+    }
+}
+
+/// Run semantic checks on `doc` using the backend's persistent codebase for
+/// cross-file definitions. Returns LSP diagnostics filtered by `cfg`.
 pub fn semantic_diagnostics(
     uri: &Url,
     doc: &ParsedDoc,
-    other_docs: &[(Url, Arc<ParsedDoc>)],
+    backend_codebase: &mir_codebase::Codebase,
     cfg: &DiagnosticsConfig,
 ) -> Vec<Diagnostic> {
     if !cfg.enabled {
         return vec![];
     }
 
+    // Build a per-call codebase seeded with cached stubs and the backend's
+    // already-collected cross-file definitions, then collect the current doc.
     let codebase = mir_codebase::Codebase::new();
     let file: Arc<str> = Arc::from(uri.as_str());
 
-    // Load PHP built-in stubs so calls to strlen(), array_map(), etc. are recognised.
-    mir_analyzer::stubs::load_stubs(&codebase);
+    copy_codebase(stubs_codebase(), &codebase);
+    copy_codebase(backend_codebase, &codebase);
 
-    // Pass 1: collect definitions from all documents so cross-file type info is available.
-    for (other_uri, other_doc) in other_docs {
-        let other_file: Arc<str> = Arc::from(other_uri.as_str());
-        let collector = mir_analyzer::collector::DefinitionCollector::new(
-            &codebase,
-            other_file,
-            other_doc.source(),
-        );
-        collector.collect(other_doc.program());
-    }
     let collector =
         mir_analyzer::collector::DefinitionCollector::new(&codebase, file.clone(), doc.source());
     let collector_issues = collector.collect(doc.program());


### PR DESCRIPTION
## Summary

Closes #68

- Cache PHP built-in stubs in a `OnceLock` so they are loaded once per process instead of on every diagnostic call
- Copy definitions from the backend's persistent `Codebase` into each per-call analysis codebase, eliminating redundant AST re-collection of all workspace files
- Remove now-unnecessary `other_docs` construction from `diagnostic` and `workspace_diagnostic` handlers

## Test plan

- [x] All 666 existing tests pass
- [x] No clippy warnings
- [ ] Manual testing: open a PHP project, verify diagnostics still appear correctly