### PR TITLE
cleanup: remove dead code and unused parameters

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1573,8 +1573,8 @@ impl LanguageServer for Backend {
             }
 
             // Find a class with this short name in other indexed documents
-            for (other_uri, other_doc) in &other_docs {
-                if let Some(fqn) = find_fqn_for_class(other_doc, class_name, other_uri) {
+            for (_other_uri, other_doc) in &other_docs {
+                if let Some(fqn) = find_fqn_for_class(other_doc, class_name) {
                     let edit = build_use_import_edit(&source, uri, &fqn);
                     let action = CodeAction {
                         title: format!("Add use {fqn}"),
@@ -1753,7 +1753,7 @@ fn defer_actions(
 
 /// Find the fully-qualified name for a class with the given short `name` by
 /// walking the ParsedDoc AST. Returns `Namespace\ClassName` when inside a namespace.
-fn find_fqn_for_class(doc: &ParsedDoc, name: &str, _uri: &Url) -> Option<String> {
+fn find_fqn_for_class(doc: &ParsedDoc, name: &str) -> Option<String> {
     use php_ast::{NamespaceBody, StmtKind};
     for stmt in doc.program().stmts.iter() {
         match &stmt.kind {

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -2837,18 +2837,7 @@ mod tests {
 
     // ── Snapshot tests ───────────────────────────────────────────────────────
 
-    use expect_test::{Expect, expect};
-
-    /// Collect completion labels from a source string (no trigger, no cross-file docs),
-    /// sort them, and compare against the snapshot.
-    #[allow(dead_code)]
-    fn check_completion_labels(src: &str, expect: Expect) {
-        let d = doc(src);
-        let items = filtered_completions_at(&d, &[], None, &CompletionCtx::default());
-        let mut ls: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
-        ls.sort_unstable();
-        expect.assert_eq(&ls.join("\n"));
-    }
+    use expect_test::expect;
 
     #[test]
     fn snapshot_keyword_completions_present() {

--- a/src/hover.rs
+++ b/src/hover.rs
@@ -14,17 +14,15 @@ pub fn hover_info(
     position: Position,
     other_docs: &[(tower_lsp::lsp_types::Url, Arc<ParsedDoc>)],
 ) -> Option<Hover> {
-    hover_at(source, doc, other_docs, position, None)
+    hover_at(source, doc, other_docs, position)
 }
 
-/// Full hover implementation with optional other-docs slice.
-/// The `other_docs_arc` parameter is used internally for TypeMap construction.
+/// Full hover implementation.
 pub fn hover_at(
     source: &str,
     doc: &ParsedDoc,
     other_docs: &[(tower_lsp::lsp_types::Url, Arc<ParsedDoc>)],
     position: Position,
-    _other_docs_arc: Option<&[Arc<ParsedDoc>]>,
 ) -> Option<Hover> {
     // Feature 6: hover on use statement shows full FQN
     // Check this before word_at since cursor may be past the last word boundary
@@ -942,7 +940,7 @@ mod tests {
     fn hover_on_variable_shows_type() {
         let src = "<?php\n$obj = new Mailer();\n$obj";
         let doc = ParsedDoc::parse(src.to_string());
-        let h = hover_at(src, &doc, &[], pos(2, 2), None);
+        let h = hover_at(src, &doc, &[], pos(2, 2));
         assert!(h.is_some());
         let text = match h.unwrap().contents {
             HoverContents::Markup(m) => m.value,
@@ -955,7 +953,7 @@ mod tests {
     fn hover_on_builtin_class_shows_stub_info() {
         let src = "<?php\n$pdo = new PDO('sqlite::memory:');\n$pdo->query('SELECT 1');";
         let doc = ParsedDoc::parse(src.to_string());
-        let h = hover_at(src, &doc, &[], pos(1, 12), None);
+        let h = hover_at(src, &doc, &[], pos(1, 12));
         assert!(h.is_some(), "should hover on PDO");
         let text = match h.unwrap().contents {
             HoverContents::Markup(m) => m.value,
@@ -969,7 +967,7 @@ mod tests {
         let src = "<?php\nclass User { public string $name; public int $age; }\n$u = new User();\n$u->name";
         let doc = ParsedDoc::parse(src.to_string());
         // "name" in "$u->name" — col 4 in "$u->name"
-        let h = hover_at(src, &doc, &[], pos(3, 5), None);
+        let h = hover_at(src, &doc, &[], pos(3, 5));
         assert!(h.is_some(), "expected hover on property");
         let text = match h.unwrap().contents {
             HoverContents::Markup(m) => m.value,
@@ -985,7 +983,7 @@ mod tests {
         let src = "<?php\nclass Point {\n    public function __construct(\n        public float $x,\n        public float $y,\n    ) {}\n}\n$p = new Point(1.0, 2.0);\n$p->x";
         let doc = ParsedDoc::parse(src.to_string());
         // "x" at the end of "$p->x"
-        let h = hover_at(src, &doc, &[], pos(8, 4), None);
+        let h = hover_at(src, &doc, &[], pos(8, 4));
         assert!(h.is_some(), "expected hover on promoted property");
         let text = match h.unwrap().contents {
             HoverContents::Markup(m) => m.value,
@@ -1007,7 +1005,7 @@ mod tests {
         let src = "<?php\nclass User {\n    /**\n     * Create a user.\n     * @param string $name The user's display name\n     * @param int $age The user's age\n     * @return void\n     * @throws \\InvalidArgumentException\n     */\n    public function __construct(\n        public string $name,\n        public int $age,\n    ) {}\n}\n$u = new User('Alice', 30);\n$u->name";
         let doc = ParsedDoc::parse(src.to_string());
         // hover on "$u->name" — cursor on 'name' (line 15, char 4 after "$u->")
-        let h = hover_at(src, &doc, &[], pos(15, 4), None);
+        let h = hover_at(src, &doc, &[], pos(15, 4));
         assert!(h.is_some(), "expected hover on promoted property");
         let text = match h.unwrap().contents {
             HoverContents::Markup(m) => m.value,
@@ -1041,7 +1039,7 @@ mod tests {
         // hover should still work (showing type) without appending any docblock section.
         let src = "<?php\nclass User {\n    /**\n     * Create a user.\n     * @return void\n     */\n    public function __construct(\n        public string $name,\n    ) {}\n}\n$u = new User('Alice');\n$u->name";
         let doc = ParsedDoc::parse(src.to_string());
-        let h = hover_at(src, &doc, &[], pos(11, 4), None);
+        let h = hover_at(src, &doc, &[], pos(11, 4));
         assert!(h.is_some(), "expected hover on promoted property");
         let text = match h.unwrap().contents {
             HoverContents::Markup(m) => m.value,
@@ -1066,7 +1064,6 @@ mod tests {
                 line: 1,
                 character: 20,
             },
-            None,
         );
         assert!(h.is_some());
         let text = match h.unwrap().contents {
@@ -1115,7 +1112,7 @@ mod tests {
         let src = "<?php\nclass User {\n    /** The user's display name. */\n    public string $name;\n}\n$u = new User();\n$u->name";
         let doc = ParsedDoc::parse(src.to_string());
         // "name" in "$u->name" at the last line
-        let h = hover_at(src, &doc, &[], pos(6, 5), None);
+        let h = hover_at(src, &doc, &[], pos(6, 5));
         assert!(h.is_some(), "expected hover on property with docblock");
         let text = match h.unwrap().contents {
             HoverContents::Markup(m) => m.value,
@@ -1136,7 +1133,7 @@ mod tests {
         let src = "<?php\nclass Counter {\n    public int $count = 0;\n    public function increment(): void {\n        $this->count;\n    }\n}";
         let doc = ParsedDoc::parse(src.to_string());
         // "$this->count" — "count" starts at col 15 in "        $this->count;"
-        let h = hover_at(src, &doc, &[], pos(4, 16), None);
+        let h = hover_at(src, &doc, &[], pos(4, 16));
         assert!(h.is_some(), "expected hover on $this->property");
         let text = match h.unwrap().contents {
             HoverContents::Markup(m) => m.value,
@@ -1152,7 +1149,7 @@ mod tests {
         let src = "<?php\nclass Profile { public string $bio; }\n$p = new Profile();\n$p?->bio";
         let doc = ParsedDoc::parse(src.to_string());
         // "bio" in "$p?->bio" at line 3, col 5
-        let h = hover_at(src, &doc, &[], pos(3, 5), None);
+        let h = hover_at(src, &doc, &[], pos(3, 5));
         assert!(h.is_some(), "expected hover on nullsafe property access");
         let text = match h.unwrap().contents {
             HoverContents::Markup(m) => m.value,

--- a/src/semantic_tokens.rs
+++ b/src/semantic_tokens.rs
@@ -13,17 +13,14 @@ use crate::ast::{ParsedDoc, offset_to_position, str_offset};
 use crate::docblock::{docblock_before, parse_docblock};
 
 // Token type indices — order must match `legend()` vec order
-#[allow(dead_code)]
-const TT_NAMESPACE: u32 = 0;
+const _TT_NAMESPACE: u32 = 0;
 const TT_CLASS: u32 = 1;
 const TT_INTERFACE: u32 = 2;
 const TT_FUNCTION: u32 = 3;
 const TT_METHOD: u32 = 4;
 const TT_PROPERTY: u32 = 5;
-#[allow(dead_code)]
 const TT_VARIABLE: u32 = 6;
 const TT_PARAMETER: u32 = 7;
-#[allow(dead_code)]
 const TT_TYPE: u32 = 8;
 const TT_STRING: u32 = 9;
 const TT_NUMBER: u32 = 10;
@@ -34,8 +31,7 @@ const TT_KEYWORD: u32 = 12;
 const MOD_DECLARATION: u32 = 1 << 0;
 const MOD_STATIC: u32 = 1 << 1;
 const MOD_ABSTRACT: u32 = 1 << 2;
-#[allow(dead_code)]
-const MOD_READONLY: u32 = 1 << 3;
+const _MOD_READONLY: u32 = 1 << 3;
 const MOD_DEPRECATED: u32 = 1 << 4;
 
 /// Raw token: (line_0based, col_0based, length, token_type, modifiers_bitmask)


### PR DESCRIPTION
## Summary
- Remove unused `_other_docs_arc` parameter from `hover_at` and all call sites
- Remove unused `_uri` parameter from `find_fqn_for_class` and its call site
- Delete unused `check_completion_labels` test helper and its `Expect` import
- Clean up `#[allow(dead_code)]` annotations in `semantic_tokens.rs`

Closes #69