### PR TITLE
chore: update mir-analyzer to 0.2.0 and php-ast to 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,11 +83,11 @@ checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "block-buffer"
-version = "0.10.4"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -109,10 +109,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
-name = "cpufeatures"
-version = "0.2.17"
+name = "const-oid"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -144,12 +150,11 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.7"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
 dependencies = [
- "generic-array",
- "typenum",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -181,11 +186,12 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.7"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
 ]
 
@@ -336,16 +342,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -396,6 +392,15 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "icu_collections"
@@ -531,12 +536,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -646,9 +645,9 @@ dependencies = [
 
 [[package]]
 name = "mir-analyzer"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7eb0b262979613f1487e7331384b8fafb2ef94fa76b92d5f1d3853765fd4a6a"
+checksum = "1aa207f2f014c76d3d9ebf8636b096495e97ae86e154d42b2530b54c610940ce"
 dependencies = [
  "bumpalo",
  "indexmap",
@@ -667,9 +666,9 @@ dependencies = [
 
 [[package]]
 name = "mir-codebase"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81d3db4cb9e8ef44e5a13397ca24f49ee58fafd79cfd9108d3c6c0f22803889b"
+checksum = "74eda3d39b0b3db7107ebfa9f8c96765914b088c648f8f1ea1b184a77db72fb0"
 dependencies = [
  "dashmap 6.1.0",
  "indexmap",
@@ -680,9 +679,9 @@ dependencies = [
 
 [[package]]
 name = "mir-issues"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "499a530e37ab4685f95fa272b4ed93be3b61efaf2104089b8adeed9999ad24a9"
+checksum = "f8bce51ffe6d55ec77e239e44949e346f8ffaa3fb220169284c0aecbccf0903e"
 dependencies = [
  "mir-types",
  "owo-colors",
@@ -692,9 +691,9 @@ dependencies = [
 
 [[package]]
 name = "mir-types"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76e81c8e9806ecf1d9c3c25184bd97e370a5c112e5a68f8800d53a89d6a8d31c"
+checksum = "ce00d9c350884464da77fd3a65d1a221e8b30e2dda97c4daf68063a8b11a85ef"
 dependencies = [
  "indexmap",
  "serde",
@@ -753,9 +752,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "php-ast"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ef35f57f31b36618952c2ae004ff4eb03b4bfdbb77de1a40c9f96d3b2376200"
+checksum = "9c2ba12f9fb7454758848aa054fe9d68f427bba8f411520b476995a1e64416bb"
 dependencies = [
  "bumpalo",
  "serde",
@@ -763,9 +762,9 @@ dependencies = [
 
 [[package]]
 name = "php-lexer"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ecc8b49c656484509ff0eb1dbbd21156aaca81d03e4e47f39e7fed8860a73ad"
+checksum = "ffda679959e34dc202e5cab735bdace205d2201632b34554a136bc210586811a"
 dependencies = [
  "memchr",
  "php-ast",
@@ -792,12 +791,11 @@ dependencies = [
 
 [[package]]
 name = "php-rs-parser"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e47d33893b05565b4640fb9fd52ec882ef9b0b4a1f791d120823cf5a32a25701"
+checksum = "4a7f7db244990e923acce3131537724c15019eafe7dc513ef7e67acc011cd78b"
 dependencies = [
  "bumpalo",
- "lazy_static",
  "miette",
  "php-ast",
  "php-lexer",
@@ -998,9 +996,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.9"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1340,12 +1338,6 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,12 +8,12 @@ repository = "https://github.com/jorgsowa/php-lsp"
 readme = "README.md"
 
 [dependencies]
-mir-analyzer = "0.1.0"
-mir-issues = "0.1.0"
-mir-codebase = "0.1.0"
-mir-types = "0.1.0"
-php-rs-parser = "0.3.2"
-php-ast = "0.3.2"
+mir-analyzer = "0.2.0"
+mir-issues = "0.2.0"
+mir-codebase = "0.2.0"
+mir-types = "0.2.0"
+php-rs-parser = "0.4.0"
+php-ast = "0.4.0"
 bumpalo = { version = "3", features = ["collections"] }
 tower-lsp = "0.20"
 tokio = { version = "1", features = ["full"] }

--- a/src/call_hierarchy.rs
+++ b/src/call_hierarchy.rs
@@ -452,7 +452,7 @@ fn calls_in_expr(expr: &php_ast::Expr<'_, '_>, out: &mut Vec<(String, Span)>) {
     match &expr.kind {
         ExprKind::FunctionCall(f) => {
             if let ExprKind::Identifier(name) = &f.name.kind {
-                out.push((name.as_ref().to_string(), f.name.span));
+                out.push((name.to_string(), f.name.span));
             } else {
                 calls_in_expr(f.name, out);
             }
@@ -463,7 +463,7 @@ fn calls_in_expr(expr: &php_ast::Expr<'_, '_>, out: &mut Vec<(String, Span)>) {
         ExprKind::MethodCall(m) => {
             calls_in_expr(m.object, out);
             if let ExprKind::Identifier(name) = &m.method.kind {
-                out.push((name.as_ref().to_string(), m.method.span));
+                out.push((name.to_string(), m.method.span));
             }
             for arg in m.args.iter() {
                 calls_in_expr(&arg.value, out);
@@ -472,7 +472,7 @@ fn calls_in_expr(expr: &php_ast::Expr<'_, '_>, out: &mut Vec<(String, Span)>) {
         ExprKind::NullsafeMethodCall(m) => {
             calls_in_expr(m.object, out);
             if let ExprKind::Identifier(name) = &m.method.kind {
-                out.push((name.as_ref().to_string(), m.method.span));
+                out.push((name.to_string(), m.method.span));
             }
             for arg in m.args.iter() {
                 calls_in_expr(&arg.value, out);

--- a/src/document_link.rs
+++ b/src/document_link.rs
@@ -68,7 +68,7 @@ fn link_from_path_expr(
     let ExprKind::String(s) = &path_expr.kind else {
         return None;
     };
-    let raw = s.as_ref();
+    let raw: &str = s;
     if raw.is_empty() {
         return None;
     }

--- a/src/inlay_hints.rs
+++ b/src/inlay_hints.rs
@@ -460,7 +460,7 @@ fn emit_return_type_hint(
 
 fn ident_name<'a>(expr: &'a Expr<'_, '_>) -> Option<&'a str> {
     if let ExprKind::Identifier(name) = &expr.kind {
-        Some(name.as_ref())
+        Some(name)
     } else {
         None
     }

--- a/src/phpstorm_meta.rs
+++ b/src/phpstorm_meta.rs
@@ -97,7 +97,7 @@ fn collect_overrides(stmts: &[Stmt<'_, '_>], meta: &mut PhpStormMeta) {
                 // Top-level `override(...)` call.
                 if let ExprKind::FunctionCall(f) = &expr.kind
                     && let ExprKind::Identifier(name) = &f.name.kind
-                    && name.as_ref().eq_ignore_ascii_case("override")
+                    && name.eq_ignore_ascii_case("override")
                     && f.args.len() == 2
                 {
                     parse_override(&f.args[0].value, &f.args[1].value, meta);
@@ -136,7 +136,7 @@ fn extract_static_call_target(expr: &php_ast::Expr<'_, '_>) -> Option<(String, S
         return None;
     };
     let class_name = extract_class_name(s.class)?;
-    let method_name = s.method.as_ref().to_string();
+    let method_name = s.method.to_string();
     Some((class_name, method_name))
 }
 
@@ -145,7 +145,7 @@ fn extract_class_name(expr: &php_ast::Expr<'_, '_>) -> Option<String> {
     match &expr.kind {
         ExprKind::Identifier(name) => {
             // Strip leading `\` and use only the last component.
-            let s = name.as_ref().trim_start_matches('\\');
+            let s = name.trim_start_matches('\\');
             let short = s.rsplit('\\').next().unwrap_or(s);
             Some(short.to_string())
         }
@@ -159,7 +159,7 @@ fn extract_map_pairs(expr: &php_ast::Expr<'_, '_>) -> Option<Vec<(Option<String>
     let ExprKind::FunctionCall(f) = &expr.kind else {
         return None;
     };
-    if !matches!(&f.name.kind, ExprKind::Identifier(n) if n.as_ref().eq_ignore_ascii_case("map")) {
+    if !matches!(&f.name.kind, ExprKind::Identifier(n) if n.eq_ignore_ascii_case("map")) {
         return None;
     }
     let array_arg = f.args.first()?;
@@ -183,7 +183,7 @@ fn extract_map_pairs(expr: &php_ast::Expr<'_, '_>) -> Option<Vec<(Option<String>
 fn extract_string_or_class(expr: &php_ast::Expr<'_, '_>) -> Option<String> {
     match &expr.kind {
         ExprKind::String(s) => {
-            let raw = s.as_ref().trim_start_matches('\\');
+            let raw = s.trim_start_matches('\\');
             // An empty string key is the wildcard; return `None` for that.
             if raw.is_empty() {
                 None
@@ -195,7 +195,7 @@ fn extract_string_or_class(expr: &php_ast::Expr<'_, '_>) -> Option<String> {
         }
         ExprKind::ClassConstAccess(c) => {
             // `Foo::class` — extract `Foo`.
-            if c.member.as_ref() == "class" {
+            if c.member == "class" {
                 extract_class_name(c.class)
             } else {
                 None

--- a/src/semantic_diagnostics.rs
+++ b/src/semantic_diagnostics.rs
@@ -86,11 +86,15 @@ pub fn semantic_diagnostics(
 
     // Pass 2: analyse function/method bodies in the current document.
     let mut issue_buffer = mir_issues::IssueBuffer::new();
+    let source_map = php_ast::source_map::SourceMap::new(doc.source());
+    let mut symbols = Vec::new();
     let mut analyzer = mir_analyzer::stmt::StatementsAnalyzer::new(
         &codebase,
         file.clone(),
         doc.source(),
+        &source_map,
         &mut issue_buffer,
+        &mut symbols,
     );
     let mut ctx = mir_analyzer::context::Context::new();
     analyzer.analyze_stmts(&doc.program().stmts, &mut ctx);
@@ -209,7 +213,7 @@ fn check_expr_for_deprecated(
     }
     if let ExprKind::FunctionCall(call) = &expr.kind {
         if let ExprKind::Identifier(name) = &call.name.kind {
-            let func_name = name.as_ref();
+            let func_name = name;
             // Search all docs for this function's declaration
             let all_sources: Vec<(&str, &ParsedDoc)> = std::iter::once((source, doc))
                 .chain(other_docs.iter().map(|d| (d.source(), d.as_ref())))
@@ -256,7 +260,7 @@ fn check_expr_for_deprecated(
     }
     if let ExprKind::MethodCall(call) = &expr.kind {
         if let ExprKind::Identifier(name) = &call.method.kind {
-            let method_name = name.as_ref();
+            let method_name = name;
             let all_sources: Vec<(&str, &ParsedDoc)> = std::iter::once((source, doc))
                 .chain(other_docs.iter().map(|d| (d.source(), d.as_ref())))
                 .collect();

--- a/src/semantic_tokens.rs
+++ b/src/semantic_tokens.rs
@@ -602,7 +602,7 @@ fn collect_expr(source: &str, expr: &php_ast::Expr<'_, '_>, out: &mut Vec<RawTok
         // ── Calls ─────────────────────────────────────────────────────────────
         ExprKind::FunctionCall(f) => {
             if let ExprKind::Identifier(name) = &f.name.kind {
-                let name_str = name.as_ref();
+                let name_str: &str = name;
                 push_at(
                     out,
                     source,
@@ -621,7 +621,7 @@ fn collect_expr(source: &str, expr: &php_ast::Expr<'_, '_>, out: &mut Vec<RawTok
         ExprKind::MethodCall(m) => {
             collect_expr(source, m.object, out);
             if let ExprKind::Identifier(name) = &m.method.kind {
-                let name_str = name.as_ref();
+                let name_str: &str = name;
                 push_at(
                     out,
                     source,
@@ -638,7 +638,7 @@ fn collect_expr(source: &str, expr: &php_ast::Expr<'_, '_>, out: &mut Vec<RawTok
         ExprKind::NullsafeMethodCall(m) => {
             collect_expr(source, m.object, out);
             if let ExprKind::Identifier(name) = &m.method.kind {
-                let name_str = name.as_ref();
+                let name_str: &str = name;
                 push_at(
                     out,
                     source,

--- a/src/type_map.rs
+++ b/src/type_map.rs
@@ -357,11 +357,10 @@ fn collect_types_stmts(
                 {
                     let var_key = format!("${}", var_name);
                     let narrowed = class
-                        .as_ref()
                         .trim_start_matches('\\')
                         .rsplit('\\')
                         .next()
-                        .unwrap_or(class.as_ref())
+                        .unwrap_or(class)
                         .to_string();
                     // Insert narrowed type then recurse into then-branch.
                     // The flat map keeps the last write, so code after the if-block
@@ -494,7 +493,7 @@ fn collect_types_expr(
                         (&mc.object.kind, &mc.method.kind)
                     && let Some(obj_class) = map.get(&format!("${}", obj_var)).cloned()
                     && let Some(class_rets) = method_returns.get(&obj_class)
-                    && let Some(ret_type) = class_rets.get(method_name.as_ref())
+                    && let Some(ret_type) = class_rets.get(*method_name)
                 {
                     map.insert(format!("${}", var_name), ret_type.clone());
                 }
@@ -515,8 +514,8 @@ fn collect_types_expr(
         // Closure::bind($fn, $obj) → $this maps to $obj's class
         ExprKind::StaticMethodCall(s) => {
             if let ExprKind::Identifier(class) = &s.class.kind
-                && class.as_ref() == "Closure"
-                && s.method.as_ref() == "bind"
+                && *class == "Closure"
+                && s.method == "bind"
                 && let Some(obj_arg) = s.args.get(1)
                 && let Some(cls) = resolve_var_type_str(&obj_arg.value, map)
             {
@@ -527,7 +526,7 @@ fn collect_types_expr(
         // $fn->bindTo($obj) or $fn->call($obj) → $this maps to $obj's class
         ExprKind::MethodCall(m) => {
             if let ExprKind::Identifier(method) = &m.method.kind {
-                let mname = method.as_ref();
+                let mname: &str = method;
                 if (mname == "bindTo" || mname == "call")
                     && let Some(obj_arg) = m.args.first()
                     && let Some(cls) = resolve_var_type_str(&obj_arg.value, map)
@@ -588,7 +587,7 @@ fn extract_array_callback_return_type(expr: &php_ast::Expr<'_, '_>) -> Option<St
         return None;
     };
     let fn_name = match &call.name.kind {
-        ExprKind::Identifier(n) => n.as_ref(),
+        ExprKind::Identifier(n) => *n,
         _ => return None,
     };
     if fn_name != "array_map" && fn_name != "array_filter" {
@@ -660,20 +659,19 @@ fn infer_from_meta_method_call(
     };
     // Get the method name.
     let method_name = match &m.method.kind {
-        ExprKind::Identifier(n) => n.as_ref().to_string(),
+        ExprKind::Identifier(n) => n.to_string(),
         _ => return None,
     };
     // Get the first argument as a class name string.
     let arg = m.args.first()?;
     let arg_str = match &arg.value.kind {
-        ExprKind::String(s) => s.as_ref().trim_start_matches('\\').to_string(),
-        ExprKind::ClassConstAccess(c) if c.member.as_ref() == "class" => match &c.class.kind {
+        ExprKind::String(s) => s.trim_start_matches('\\').to_string(),
+        ExprKind::ClassConstAccess(c) if c.member == "class" => match &c.class.kind {
             ExprKind::Identifier(n) => n
-                .as_ref()
                 .trim_start_matches('\\')
                 .rsplit('\\')
                 .next()
-                .unwrap_or(n.as_ref())
+                .unwrap_or(n)
                 .to_string(),
             _ => return None,
         },

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -867,7 +867,7 @@ fn args(source: &str, arg_list: &[php_ast::Arg<'_, '_>], word: &str, out: &mut V
 pub fn refs_in_expr(source: &str, expr: &Expr<'_, '_>, word: &str, out: &mut Vec<Span>) {
     match &expr.kind {
         ExprKind::Identifier(name) => {
-            if name.as_ref() == word {
+            if *name == word {
                 out.push(expr.span);
             }
         }
@@ -1068,7 +1068,7 @@ fn function_refs_in_expr(expr: &Expr<'_, '_>, name: &str, out: &mut Vec<Span>) {
         // The core match: a free function call whose callee is a bare identifier.
         ExprKind::FunctionCall(f) => {
             if let ExprKind::Identifier(id) = &f.name.kind
-                && id.as_ref() == name
+                && *id == name
             {
                 out.push(f.name.span);
             }
@@ -1259,7 +1259,7 @@ fn method_refs_in_expr(expr: &Expr<'_, '_>, name: &str, out: &mut Vec<Span>) {
             method_refs_in_expr(m.object, name, out);
             // Collect the method name span if it matches.
             if let ExprKind::Identifier(id) = &m.method.kind
-                && id.as_ref() == name
+                && *id == name
             {
                 out.push(m.method.span);
             }
@@ -1270,7 +1270,7 @@ fn method_refs_in_expr(expr: &Expr<'_, '_>, name: &str, out: &mut Vec<Span>) {
         ExprKind::NullsafeMethodCall(m) => {
             method_refs_in_expr(m.object, name, out);
             if let ExprKind::Identifier(id) = &m.method.kind
-                && id.as_ref() == name
+                && *id == name
             {
                 out.push(m.method.span);
             }
@@ -1572,7 +1572,7 @@ fn class_refs_in_expr(expr: &Expr<'_, '_>, class_name: &str, out: &mut Vec<Span>
         // `new ClassName(...)` — the class name is an Identifier child of New.
         ExprKind::New(n) => {
             if let ExprKind::Identifier(id) = &n.class.kind
-                && id.as_ref().rsplit('\\').next().unwrap_or(id.as_ref()) == class_name
+                && id.rsplit('\\').next().unwrap_or(id) == class_name
             {
                 out.push(n.class.span);
             } else {
@@ -1589,7 +1589,7 @@ fn class_refs_in_expr(expr: &Expr<'_, '_>, class_name: &str, out: &mut Vec<Span>
             // We check the RHS regardless — if it is an Identifier and matches, we
             // include it; class names don't normally appear as operands otherwise.
             if let ExprKind::Identifier(id) = &b.right.kind
-                && id.as_ref().rsplit('\\').next().unwrap_or(id.as_ref()) == class_name
+                && id.rsplit('\\').next().unwrap_or(id) == class_name
             {
                 out.push(b.right.span);
             } else {
@@ -1599,7 +1599,7 @@ fn class_refs_in_expr(expr: &Expr<'_, '_>, class_name: &str, out: &mut Vec<Span>
         // `ClassName::method()` or `ClassName::$prop` — class side.
         ExprKind::StaticMethodCall(s) => {
             if let ExprKind::Identifier(id) = &s.class.kind
-                && id.as_ref().rsplit('\\').next().unwrap_or(id.as_ref()) == class_name
+                && id.rsplit('\\').next().unwrap_or(id) == class_name
             {
                 out.push(s.class.span);
             }
@@ -1609,14 +1609,14 @@ fn class_refs_in_expr(expr: &Expr<'_, '_>, class_name: &str, out: &mut Vec<Span>
         }
         ExprKind::StaticPropertyAccess(s) => {
             if let ExprKind::Identifier(id) = &s.class.kind
-                && id.as_ref().rsplit('\\').next().unwrap_or(id.as_ref()) == class_name
+                && id.rsplit('\\').next().unwrap_or(id) == class_name
             {
                 out.push(s.class.span);
             }
         }
         ExprKind::ClassConstAccess(c) => {
             if let ExprKind::Identifier(id) = &c.class.kind
-                && id.as_ref().rsplit('\\').next().unwrap_or(id.as_ref()) == class_name
+                && id.rsplit('\\').next().unwrap_or(id) == class_name
             {
                 out.push(c.class.span);
             }


### PR DESCRIPTION
## Summary
- Update mir-analyzer, mir-codebase, mir-issues, mir-types from 0.1.0 to 0.2.0
- Update php-rs-parser, php-ast from 0.3.2 to 0.4.0
- Adapt to `Identifier(Cow<str>)` → `Identifier(&str)` change across 8 files
- Add `SourceMap` and `symbols` params to `StatementsAnalyzer::new` call

## Test plan
- [x] All 666 tests pass
- [x] No clippy warnings