### PR TITLE
fix(safety): replace unwrap() in production code paths

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -341,15 +341,9 @@ impl LanguageServer for Backend {
             Registration {
                 id: "php-lsp-file-watcher".to_string(),
                 method: "workspace/didChangeWatchedFiles".to_string(),
-                register_options: Some(
-                    serde_json::to_value(DidChangeWatchedFilesRegistrationOptions {
-                        watchers: vec![FileSystemWatcher {
-                            glob_pattern: GlobPattern::String("**/*.php".to_string()),
-                            kind: None,
-                        }],
-                    })
-                    .unwrap(),
-                ),
+                register_options: Some(serde_json::json!({
+                    "watchers": [{"globPattern": "**/*.php"}]
+                })),
             },
             // Type hierarchy has no static ServerCapabilities field in lsp-types 0.94,
             // so register it dynamically here.

--- a/src/declaration.rs
+++ b/src/declaration.rs
@@ -102,7 +102,10 @@ fn find_any_declaration(
                 return Some(name_range(source, f.name));
             }
             StmtKind::Class(c) if c.name == Some(word) => {
-                return Some(name_range(source, c.name.unwrap()));
+                return Some(name_range(
+                    source,
+                    c.name.expect("match guard ensures Some"),
+                ));
             }
             StmtKind::Class(c) => {
                 for member in c.members.iter() {

--- a/src/definition.rs
+++ b/src/definition.rs
@@ -70,7 +70,7 @@ fn scan_statements(source: &str, stmts: &[Stmt<'_, '_>], word: &str) -> Option<R
                 return Some(name_range(source, f.name));
             }
             StmtKind::Class(c) if c.name == Some(word) => {
-                let name = c.name.unwrap();
+                let name = c.name.expect("match guard ensures Some");
                 return Some(name_range(source, name));
             }
             StmtKind::Class(c) => {

--- a/src/references.rs
+++ b/src/references.rs
@@ -113,9 +113,9 @@ fn is_declaration_span(source: &str, stmts: &[Stmt<'_, '_>], word: &str, span: &
                     }
                 }
                 StmtKind::Class(c) if c.name == Some(word) => {
-                    // c.name is Some(word) per the guard; unwrap to get the
+                    // c.name is Some(word) per the guard; extract to get the
                     // arena-allocated slice so str_offset uses pointer arithmetic.
-                    let name = c.name.unwrap();
+                    let name = c.name.expect("match guard ensures Some");
                     if spans_equal(&name_span(source, name), span) {
                         return true;
                     }

--- a/src/type_definition.rs
+++ b/src/type_definition.rs
@@ -73,7 +73,10 @@ fn find_class_range(source: &str, stmts: &[Stmt<'_, '_>], name: &str) -> Option<
     for stmt in stmts {
         match &stmt.kind {
             StmtKind::Class(c) if c.name == Some(name) => {
-                return Some(name_range(source, c.name.unwrap()));
+                return Some(name_range(
+                    source,
+                    c.name.expect("match guard ensures Some"),
+                ));
             }
             StmtKind::Interface(i) if i.name == name => {
                 return Some(name_range(source, i.name));

--- a/src/type_hierarchy.rs
+++ b/src/type_hierarchy.rs
@@ -33,7 +33,7 @@ fn find_type_item(
     for stmt in stmts {
         match &stmt.kind {
             StmtKind::Class(c) if c.name == Some(word) => {
-                let name = c.name.unwrap();
+                let name = c.name.expect("match guard ensures Some");
                 return Some(make_item(source, name, SymbolKind::CLASS, uri));
             }
             StmtKind::Interface(i) if i.name == word => {


### PR DESCRIPTION
## Summary

- Replace `c.name.unwrap()` with `c.name.expect("match guard ensures Some")` in 5 modules (`declaration`, `definition`, `references`, `type_definition`, `type_hierarchy`) — the calls were logically safe due to `c.name == Some(word)` match guards, but `unwrap()` gave no diagnostic context on panic
- Replace `serde_json::to_value(...).unwrap()` in `Backend::initialized()` with an infallible `serde_json::json!()` macro call

Note: all `panic!()` calls listed in the issue are inside `#[cfg(test)] mod tests` blocks and are not production code paths.

Closes #95