### PR TITLE
docs(editors): mention native PhpStorm plugin under marketplace review

### DIFF
--- a/docs/editors.md
+++ b/docs/editors.md
@@ -182,6 +182,8 @@ vim.api.nvim_create_autocmd('FileType', {
 
 ### PHPStorm
 
+> **Native plugin:** A dedicated php-lsp plugin for PhpStorm is currently [under review on the JetBrains Marketplace](https://plugins.jetbrains.com/plugin/31223-php-lsp). Once approved, it will offer a simpler setup than the LSP4IJ approach below.
+
 1. Install the [LSP4IJ](https://plugins.jetbrains.com/plugin/23257-lsp4ij) plugin (**Settings → Plugins → Marketplace → "LSP4IJ"**).
 2. Go to **Settings → Languages & Frameworks → LSP → Language Servers → +**, choose **Custom server**, and fill in the **Server** tab:
 


### PR DESCRIPTION
## Summary

- Adds a callout in the PHPStorm section of `docs/editors.md` pointing to the native php-lsp plugin currently under review on the JetBrains Marketplace
- Links to https://plugins.jetbrains.com/plugin/31223-php-lsp
- Notes that once approved it will offer a simpler setup than the LSP4IJ approach

## Test plan

- [ ] Verify the link renders correctly in the docs