### PR TITLE
chore(deps): update all dependencies to latest versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,9 +246,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "foldhash"
@@ -377,9 +377,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
@@ -513,12 +513,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -645,9 +645,9 @@ dependencies = [
 
 [[package]]
 name = "mir-analyzer"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aa207f2f014c76d3d9ebf8636b096495e97ae86e154d42b2530b54c610940ce"
+checksum = "d4a365f21d41ffce944ac21683a79ca3bf91ccbf22ad958c8dd4ec804ea94e48"
 dependencies = [
  "bumpalo",
  "indexmap",
@@ -666,9 +666,9 @@ dependencies = [
 
 [[package]]
 name = "mir-codebase"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74eda3d39b0b3db7107ebfa9f8c96765914b088c648f8f1ea1b184a77db72fb0"
+checksum = "198891f29c5bd9e3b1fe40c7fc837241ee8fb21cd9b03fd1ce5075c4ebef7b59"
 dependencies = [
  "dashmap 6.1.0",
  "indexmap",
@@ -679,9 +679,9 @@ dependencies = [
 
 [[package]]
 name = "mir-issues"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bce51ffe6d55ec77e239e44949e346f8ffaa3fb220169284c0aecbccf0903e"
+checksum = "b5a999021ca6cfae4bd4fffcdbf4e10366ef21b108fd396fb82292cfe0edc98f"
 dependencies = [
  "mir-types",
  "owo-colors",
@@ -691,9 +691,9 @@ dependencies = [
 
 [[package]]
 name = "mir-types"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce00d9c350884464da77fd3a65d1a221e8b30e2dda97c4daf68063a8b11a85ef"
+checksum = "381f74d2137189242b9a0c39a907cbd4fe05012adf6f27141c1e68637bc44099"
 dependencies = [
  "indexmap",
  "serde",
@@ -752,9 +752,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "php-ast"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c2ba12f9fb7454758848aa054fe9d68f427bba8f411520b476995a1e64416bb"
+checksum = "0d5a308bf0bd456c28f8b9cb93bc1f37faf5402c531a1087f46c34a2903f2306"
 dependencies = [
  "bumpalo",
  "serde",
@@ -762,9 +762,9 @@ dependencies = [
 
 [[package]]
 name = "php-lexer"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffda679959e34dc202e5cab735bdace205d2201632b34554a136bc210586811a"
+checksum = "c7b35759abe5da820bac48e5aedea81e018cf32ab20ed5075c62a155c6a76d3e"
 dependencies = [
  "memchr",
  "php-ast",
@@ -791,9 +791,9 @@ dependencies = [
 
 [[package]]
 name = "php-rs-parser"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a7f7db244990e923acce3131537724c15019eafe7dc513ef7e67acc011cd78b"
+checksum = "cad3a83439d31f6285681e274b9f8038ea9129d85ee6da9ab624f941845538ed"
 dependencies = [
  "bumpalo",
  "miette",
@@ -1154,9 +1154,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.51.0"
+version = "1.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd1c4c0fc4a7ab90fc15ef6daaa3ec3b893f004f915f2392557ed23237820cd"
+checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
 dependencies = [
  "bytes",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,12 +8,12 @@ repository = "https://github.com/jorgsowa/php-lsp"
 readme = "README.md"
 
 [dependencies]
-mir-analyzer = "0.2.0"
-mir-issues = "0.2.0"
-mir-codebase = "0.2.0"
-mir-types = "0.2.0"
-php-rs-parser = "0.4.0"
-php-ast = "0.4.0"
+mir-analyzer = "0.3.0"
+mir-issues = "0.3.0"
+mir-codebase = "0.3.0"
+mir-types = "0.3.0"
+php-rs-parser = "0.5.0"
+php-ast = "0.5.0"
 bumpalo = { version = "3", features = ["collections"] }
 tower-lsp = "0.20"
 tokio = { version = "1", features = ["full"] }

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -2001,7 +2001,13 @@ async fn send_refresh_requests(client: &Client) {
 /// Run the definition collector for a single file against the persistent codebase.
 fn collect_into_codebase(codebase: &mir_codebase::Codebase, uri: &Url, doc: &ParsedDoc) {
     let file: Arc<str> = Arc::from(uri.as_str());
-    let collector = mir_analyzer::collector::DefinitionCollector::new(codebase, file, doc.source());
+    let source_map = php_ast::source_map::SourceMap::new(doc.source());
+    let collector = mir_analyzer::collector::DefinitionCollector::new(
+        codebase,
+        file,
+        doc.source(),
+        &source_map,
+    );
     collector.collect(doc.program());
 }
 

--- a/src/semantic_diagnostics.rs
+++ b/src/semantic_diagnostics.rs
@@ -29,14 +29,18 @@ pub fn semantic_diagnostics(
     // Incremental update: evict stale definitions for this file, re-collect,
     // and rebuild inheritance tables.
     codebase.remove_file_definitions(&file);
-    let collector =
-        mir_analyzer::collector::DefinitionCollector::new(codebase, file.clone(), doc.source());
+    let source_map = php_ast::source_map::SourceMap::new(doc.source());
+    let collector = mir_analyzer::collector::DefinitionCollector::new(
+        codebase,
+        file.clone(),
+        doc.source(),
+        &source_map,
+    );
     let collector_issues = collector.collect(doc.program());
     codebase.finalize();
 
     // Pass 2: analyse function/method bodies in the current document.
     let mut issue_buffer = mir_issues::IssueBuffer::new();
-    let source_map = php_ast::source_map::SourceMap::new(doc.source());
     let mut symbols = Vec::new();
     let mut analyzer = mir_analyzer::stmt::StatementsAnalyzer::new(
         codebase,


### PR DESCRIPTION
## Summary

- Bump `mir-analyzer`, `mir-codebase`, `mir-issues`, `mir-types` from 0.2 → 0.3
- Bump `php-ast` and `php-rs-parser` from 0.4 → 0.5 (required by mir 0.3)
- Minor updates: `fastrand`, `hashbrown`, `indexmap`, `tokio`
- Adapt both `DefinitionCollector::new` call sites to the new required `&SourceMap` parameter introduced in mir-analyzer 0.3.0

## Test plan

- [x] `cargo build` passes
- [x] `cargo test` — all 686 tests pass