### PR TITLE
feat(cli): print startup message to stderr on launch

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -60,6 +60,10 @@ async fn main() {
         std::process::exit(0);
     }
 
+    eprintln!(
+        "php-lsp {} — listening on stdin/stdout",
+        env!("CARGO_PKG_VERSION")
+    );
     let stdin = tokio::io::stdin();
     let stdout = tokio::io::stdout();
     let (service, socket) = LspService::new(Backend::new);


### PR DESCRIPTION
## Summary

- Prints `php-lsp <version> — listening on stdin/stdout` to stderr when the server starts
- Uses stderr so it never interferes with the LSP JSON-RPC protocol on stdout
- Helps users confirm the server is running when launched manually

## Test plan

- [ ] Run `php-lsp` directly in a terminal and confirm the message appears
- [ ] Confirm `php-lsp --version` still exits immediately with no extra output
- [ ] Confirm an LSP client (e.g. Neovim, VS Code) connects normally