### PR TITLE
docs(editors): replace llllvvuu-lsp-client with dedicated VS Code extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ For full installation options see **[docs/getting-started.md](docs/getting-start
 
 | Editor | Setup |
 |---|---|
-| VS Code | [llllvvuu-lsp-client](https://marketplace.visualstudio.com/items?itemName=llllvvuu.llllvvuu-lsp-client) extension |
+| VS Code | [php-lsp](https://marketplace.visualstudio.com/items?itemName=jorgsowa.php-lsp) extension |
 | Neovim 0.11+ | Native `vim.lsp.enable` |
 | Neovim 0.10 | `vim.lsp.start` in a `FileType` autocmd |
 | Zed | `lsp` block in `~/.config/zed/settings.json` |

--- a/docs/editors.md
+++ b/docs/editors.md
@@ -111,23 +111,24 @@ Add to `~/.config/zed/settings.json`:
 
 ### VS Code
 
-1. Install an extension that supports custom LSP servers, such as [llllvvuu-lsp-client](https://marketplace.visualstudio.com/items?itemName=llllvvuu.llllvvuu-lsp-client).
-2. Add to your `.vscode/settings.json` (project) or `~/.config/Code/User/settings.json` (global):
+Install the [php-lsp](https://marketplace.visualstudio.com/items?itemName=jorgsowa.php-lsp) extension. It ships a pre-built binary — no separate install required.
 
-```json
-{
-  "llllvvuu-lsp-client.servers": {
-    "php-lsp": {
-      "command": "/usr/local/bin/php-lsp",
-      "filetypes": ["php"],
-      "initializationOptions": {
-        "phpVersion": "8.3",
-        "excludePaths": []
-      }
-    }
-  }
-}
+Via the Quick Open palette (`Ctrl+P` / `Cmd+P`):
+
 ```
+ext install jorgsowa.php-lsp
+```
+
+Available settings (VS Code `settings.json`):
+
+| Setting | Default | Description |
+|---|---|---|
+| `php-lsp.serverPath` | *(auto)* | Path to the `php-lsp` binary; leave empty for auto-detection |
+| `php-lsp.phpVersion` | `8.3` | PHP version (`7.4` – `8.3`) |
+| `php-lsp.excludePaths` | `[]` | Glob patterns to exclude from the workspace |
+| `php-lsp.diagnostics.*` | `true` | Per-diagnostic toggles (undefined variables/functions/classes, arity errors, type mismatches, deprecated calls, duplicate declarations) |
+
+> **Note:** If Intelephense (or another PHP extension) is installed, it will conflict with php-lsp. Disable it via **Extensions → Intelephense → Disable** before using this extension.
 
 ---
 


### PR DESCRIPTION
## Summary

- Replaces the generic `llllvvuu-lsp-client` setup in `docs/editors.md` with the dedicated [`jorgsowa.php-lsp`](https://marketplace.visualstudio.com/items?itemName=jorgsowa.php-lsp) extension
- Updates the VS Code row in the `README.md` editor table to link to the dedicated extension
- Adds a note about disabling Intelephense to avoid conflicts