### PR TITLE
feat(config): auto-detect PHP version from composer.json and php binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ Pass options via `initializationOptions`:
 }
 ```
 
+`phpVersion` is optional — the server auto-detects it from `composer.json` (`config.platform.php`, then `require.php`) and falls back to the `php` binary on `$PATH`. Set it explicitly only to override.
+
 See **[docs/configuration.md](docs/configuration.md)** for all options including per-diagnostic toggles.
 
 ---

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4,9 +4,11 @@ Options are passed via `initializationOptions` in your editor's LSP configuratio
 
 ## Options
 
+All options are optional.
+
 | Option | Type | Default | Description |
 |---|---|---|---|
-| `phpVersion` | `string` | `"8.3"` | PHP version used for version-gated diagnostics and completions. Accepted values: `"7.4"`, `"8.0"`, `"8.1"`, `"8.2"`, `"8.3"`. |
+| `phpVersion` | `string` | auto-detected | PHP version used for version-gated diagnostics and completions. Accepted values: `"7.4"`, `"8.0"`, `"8.1"`, `"8.2"`, `"8.3"`, `"8.4"`, `"8.5"`. When omitted, the server auto-detects from `composer.json` (`config.platform.php`, then `require.php`), then from the `php` binary on `$PATH`, and falls back to `"8.5"`. |
 | `excludePaths` | `string[]` | `[]` | Glob patterns for paths to skip during workspace indexing. Matched against paths relative to the workspace root. |
 | `diagnostics` | `object` | see below | Per-category diagnostic toggles. |
 

--- a/docs/editors.md
+++ b/docs/editors.md
@@ -71,7 +71,7 @@ Or add to `.cursor/mcp.json` in your project root:
       "command": "/usr/local/bin/php-lsp",
       "filetypes": ["php"],
       "initializationOptions": {
-        "phpVersion": "8.3"
+        "phpVersion": "8.5"
       }
     }
   }
@@ -94,7 +94,7 @@ Add to `~/.config/zed/settings.json`:
         "path": "/usr/local/bin/php-lsp"
       },
       "initialization_options": {
-        "phpVersion": "8.3",
+        "phpVersion": "8.5",
         "excludePaths": []
       }
     }
@@ -124,7 +124,7 @@ Available settings (VS Code `settings.json`):
 | Setting | Default | Description |
 |---|---|---|
 | `php-lsp.serverPath` | *(auto)* | Path to the `php-lsp` binary; leave empty for auto-detection |
-| `php-lsp.phpVersion` | `8.3` | PHP version (`7.4` – `8.3`) |
+| `php-lsp.phpVersion` | `8.5` | PHP version (`7.4` – `8.5`) |
 | `php-lsp.excludePaths` | `[]` | Glob patterns to exclude from the workspace |
 | `php-lsp.diagnostics.*` | `true` | Per-diagnostic toggles (undefined variables/functions/classes, arity errors, type mismatches, deprecated calls, duplicate declarations) |
 
@@ -144,7 +144,7 @@ return {
   root_markers = { 'composer.json', '.git' },
   workspace_required = true,
   init_options = {
-    phpVersion = '8.3',
+    phpVersion = '8.5',
     excludePaths = {},
   },
 }
@@ -171,7 +171,7 @@ vim.api.nvim_create_autocmd('FileType', {
       cmd = { '/usr/local/bin/php-lsp' },
       root_dir = vim.fs.root(0, { 'composer.json', '.git' }),
       init_options = {
-        phpVersion = '8.3',
+        phpVersion = '8.5',
         excludePaths = {},
       },
     })
@@ -198,7 +198,7 @@ vim.api.nvim_create_autocmd('FileType', {
 
 ```json
 {
-  "phpVersion": "8.3",
+  "phpVersion": "8.5",
   "excludePaths": ["cache/*", "storage/*"]
 }
 ```

--- a/src/autoload.rs
+++ b/src/autoload.rs
@@ -1,6 +1,23 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
+/// Supported PHP version strings.
+pub const PHP_7_4: &str = "7.4";
+pub const PHP_8_0: &str = "8.0";
+pub const PHP_8_1: &str = "8.1";
+pub const PHP_8_2: &str = "8.2";
+pub const PHP_8_3: &str = "8.3";
+pub const PHP_8_4: &str = "8.4";
+pub const PHP_8_5: &str = "8.5";
+
+pub const SUPPORTED_PHP_VERSIONS: &[&str] = &[
+    PHP_7_4, PHP_8_0, PHP_8_1, PHP_8_2, PHP_8_3, PHP_8_4, PHP_8_5,
+];
+
+pub fn is_valid_php_version(v: &str) -> bool {
+    SUPPORTED_PHP_VERSIONS.contains(&v)
+}
+
 /// PSR-4 namespace-prefix → base-directory mapping built from `composer.json`
 /// and `vendor/composer/installed.json`.
 ///
@@ -158,6 +175,77 @@ fn load_psr4_section(
     }
 }
 
+/// Detect the PHP version from a project's `composer.json`.
+///
+/// Checks in order:
+/// 1. `config.platform.php` — explicit platform override (e.g. `"8.1.0"`)
+/// 2. `require.php` — version constraint lower bound (e.g. `"^8.1"` → `"8.1"`)
+pub fn detect_php_version_from_composer(root: &Path) -> Option<String> {
+    let text = std::fs::read_to_string(root.join("composer.json")).ok()?;
+    let json: serde_json::Value = serde_json::from_str(&text).ok()?;
+
+    // config.platform.php is the authoritative platform version override.
+    if let Some(platform_php) = json
+        .pointer("/config/platform/php")
+        .and_then(|v| v.as_str())
+        && let Some(ver) = extract_major_minor(platform_php)
+    {
+        return Some(ver);
+    }
+
+    // require.php is the minimum version constraint.
+    if let Some(constraint) = json.pointer("/require/php").and_then(|v| v.as_str())
+        && let Some(ver) = parse_php_version_constraint(constraint)
+    {
+        return Some(ver);
+    }
+
+    None
+}
+
+/// Detect the PHP version by running `php --version`.
+pub fn detect_php_binary_version() -> Option<String> {
+    let output = std::process::Command::new("php")
+        .arg("--version")
+        .output()
+        .ok()?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    // First line: "PHP X.Y.Z (cli) ..."
+    let first_line = stdout.lines().next()?;
+    let version_str = first_line.strip_prefix("PHP ")?.split_whitespace().next()?;
+    extract_major_minor(version_str)
+}
+
+/// Extract `"X.Y"` from a full version string like `"8.1.27"` or `"8.2"`.
+fn extract_major_minor(version: &str) -> Option<String> {
+    let mut parts = version.split('.');
+    let major = parts.next()?.trim();
+    let minor = parts.next()?.trim();
+    major.parse::<u32>().ok()?;
+    minor.parse::<u32>().ok()?;
+    Some(format!("{}.{}", major, minor))
+}
+
+/// Extract a `"X.Y"` lower bound from a Composer version constraint like
+/// `"^8.1"`, `">=8.0"`, `"~8.2"`, `"7.4.*"`, or `">=8.0 <9.0"`.
+fn parse_php_version_constraint(constraint: &str) -> Option<String> {
+    // Take the first OR-clause: ">=7.4 || ^8.0" → ">=7.4"
+    let clause = constraint.split("||").next().unwrap_or(constraint).trim();
+    // Strip leading comparison/range operators
+    let stripped = clause.trim_start_matches(['^', '~', '>', '<', '=', ' ']);
+    // Take the first whitespace-delimited token: "8.0 <9.0" → "8.0"
+    let token = stripped.split_whitespace().next().unwrap_or(stripped);
+    // Split on '.' to get major and minor, stripping trailing wildcards
+    let mut parts = token.split('.');
+    let major = parts.next()?;
+    let minor_raw = parts.next().unwrap_or("0");
+    let minor = minor_raw.trim_end_matches('*');
+    let minor = if minor.is_empty() { "0" } else { minor };
+    major.parse::<u32>().ok()?;
+    minor.parse::<u32>().ok()?;
+    Some(format!("{}.{}", major, minor))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -294,5 +382,101 @@ mod tests {
         );
         let m = Psr4Map::load(root);
         assert!(m.resolve("Tests\\FooTest").is_some());
+    }
+
+    // --- PHP version detection ---
+
+    #[test]
+    fn detect_version_from_platform_config() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            &dir.path().join("composer.json"),
+            r#"{"config": {"platform": {"php": "8.1.27"}}}"#,
+        );
+        assert_eq!(
+            detect_php_version_from_composer(dir.path()),
+            Some(PHP_8_1.to_string())
+        );
+    }
+
+    #[test]
+    fn detect_version_from_require_caret() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            &dir.path().join("composer.json"),
+            r#"{"require": {"php": "^8.2"}}"#,
+        );
+        assert_eq!(
+            detect_php_version_from_composer(dir.path()),
+            Some(PHP_8_2.to_string())
+        );
+    }
+
+    #[test]
+    fn detect_version_from_require_gte() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            &dir.path().join("composer.json"),
+            r#"{"require": {"php": ">=8.0"}}"#,
+        );
+        assert_eq!(
+            detect_php_version_from_composer(dir.path()),
+            Some(PHP_8_0.to_string())
+        );
+    }
+
+    #[test]
+    fn detect_version_from_require_range() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            &dir.path().join("composer.json"),
+            r#"{"require": {"php": ">=8.1 <9.0"}}"#,
+        );
+        assert_eq!(
+            detect_php_version_from_composer(dir.path()),
+            Some(PHP_8_1.to_string())
+        );
+    }
+
+    #[test]
+    fn detect_version_from_require_wildcard() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            &dir.path().join("composer.json"),
+            r#"{"require": {"php": "7.4.*"}}"#,
+        );
+        assert_eq!(
+            detect_php_version_from_composer(dir.path()),
+            Some(PHP_7_4.to_string())
+        );
+    }
+
+    #[test]
+    fn platform_config_takes_priority_over_require() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            &dir.path().join("composer.json"),
+            r#"{"config": {"platform": {"php": "8.0.0"}}, "require": {"php": "^8.2"}}"#,
+        );
+        assert_eq!(
+            detect_php_version_from_composer(dir.path()),
+            Some(PHP_8_0.to_string())
+        );
+    }
+
+    #[test]
+    fn detect_version_returns_none_when_no_composer_json() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(detect_php_version_from_composer(dir.path()).is_none());
+    }
+
+    #[test]
+    fn detect_version_returns_none_when_no_php_entry() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            &dir.path().join("composer.json"),
+            r#"{"require": {"some/package": "^1.0"}}"#,
+        );
+        assert!(detect_php_version_from_composer(dir.path()).is_none());
     }
 }

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -114,8 +114,8 @@ impl DiagnosticsConfig {
 /// Configuration received from the client via `initializationOptions`.
 #[derive(Debug, Default, Clone)]
 pub struct LspConfig {
-    /// PHP version string, e.g. `"8.1"`.  Currently informational; future
-    /// versions of the analyser will gate PHP-version-specific diagnostics.
+    /// PHP version string, e.g. `"8.1"`.  Set explicitly via `initializationOptions`
+    /// or auto-detected from `composer.json` / the `php` binary at startup.
     pub php_version: Option<String>,
     /// Glob patterns for paths to exclude from workspace indexing.
     pub exclude_paths: Vec<String>,
@@ -124,9 +124,14 @@ pub struct LspConfig {
 }
 
 impl LspConfig {
+    /// PHP version used when auto-detection yields no result.
+    const DEFAULT_PHP_VERSION: &str = crate::autoload::PHP_8_5;
+
     fn from_value(v: &serde_json::Value) -> Self {
         let mut cfg = LspConfig::default();
-        if let Some(ver) = v.get("phpVersion").and_then(|x| x.as_str()) {
+        if let Some(ver) = v.get("phpVersion").and_then(|x| x.as_str())
+            && crate::autoload::is_valid_php_version(ver)
+        {
             cfg.php_version = Some(ver.to_string());
         }
         if let Some(arr) = v.get("excludePaths").and_then(|x| x.as_array()) {
@@ -204,8 +209,36 @@ impl LanguageServer for Backend {
         }
 
         // Parse initializationOptions if provided by the client.
-        if let Some(opts) = &params.initialization_options {
-            *self.config.write().unwrap() = LspConfig::from_value(opts);
+        {
+            let opts = params.initialization_options.as_ref();
+            let mut cfg = opts.map(LspConfig::from_value).unwrap_or_default();
+            // Warn if the client supplied an unrecognised phpVersion.
+            if let Some(ver) = opts
+                .and_then(|o| o.get("phpVersion"))
+                .and_then(|v| v.as_str())
+                && !crate::autoload::is_valid_php_version(ver)
+            {
+                self.client
+                    .log_message(
+                        tower_lsp::lsp_types::MessageType::WARNING,
+                        format!(
+                            "php-lsp: unsupported phpVersion {ver:?} — valid values: {}",
+                            crate::autoload::SUPPORTED_PHP_VERSIONS.join(", ")
+                        ),
+                    )
+                    .await;
+            }
+            // Auto-detect PHP version from composer.json / php binary when the
+            // client has not set it explicitly (or set it to an invalid value).
+            if cfg.php_version.is_none() {
+                let roots = self.root_paths.read().unwrap().clone();
+                cfg.php_version = roots
+                    .iter()
+                    .find_map(|root| crate::autoload::detect_php_version_from_composer(root))
+                    .or_else(crate::autoload::detect_php_binary_version)
+                    .or_else(|| Some(LspConfig::DEFAULT_PHP_VERSION.to_string()));
+            }
+            *self.config.write().unwrap() = cfg;
         }
 
         Ok(InitializeResult {
@@ -456,7 +489,29 @@ impl LanguageServer for Backend {
         if let Ok(values) = self.client.configuration(items).await
             && let Some(value) = values.into_iter().next()
         {
-            *self.config.write().unwrap() = LspConfig::from_value(&value);
+            let mut cfg = LspConfig::from_value(&value);
+            if let Some(ver) = value.get("phpVersion").and_then(|v| v.as_str())
+                && !crate::autoload::is_valid_php_version(ver)
+            {
+                self.client
+                    .log_message(
+                        tower_lsp::lsp_types::MessageType::WARNING,
+                        format!(
+                            "php-lsp: unsupported phpVersion {ver:?} — valid values: {}",
+                            crate::autoload::SUPPORTED_PHP_VERSIONS.join(", ")
+                        ),
+                    )
+                    .await;
+            }
+            if cfg.php_version.is_none() {
+                let roots = self.root_paths.read().unwrap().clone();
+                cfg.php_version = roots
+                    .iter()
+                    .find_map(|root| crate::autoload::detect_php_version_from_composer(root))
+                    .or_else(crate::autoload::detect_php_binary_version)
+                    .or_else(|| Some(LspConfig::DEFAULT_PHP_VERSION.to_string()));
+            }
+            *self.config.write().unwrap() = cfg;
         }
     }
 
@@ -2150,8 +2205,9 @@ mod tests {
 
     #[test]
     fn lsp_config_parses_php_version() {
-        let cfg = LspConfig::from_value(&serde_json::json!({"phpVersion": "8.2"}));
-        assert_eq!(cfg.php_version.as_deref(), Some("8.2"));
+        let cfg =
+            LspConfig::from_value(&serde_json::json!({"phpVersion": crate::autoload::PHP_8_2}));
+        assert_eq!(cfg.php_version.as_deref(), Some(crate::autoload::PHP_8_2));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Auto-detects `phpVersion` from `composer.json` (`config.platform.php` → `require.php`), then `php --version`, then falls back to `"8.5"`
- Invalid `phpVersion` values in `initializationOptions` are silently dropped and trigger auto-detection, with a warning logged to the client listing supported versions
- Adds `PHP_x_y` version constants and `SUPPORTED_PHP_VERSIONS` / `is_valid_php_version` to `autoload`
- `LspConfig::DEFAULT_PHP_VERSION` is an associated constant referencing `PHP_8_5`
- Docs updated: `phpVersion` is optional, default described as auto-detected, supported range extended to `7.4`–`8.5`

## Test plan

- [ ] `cargo test` passes (17 new tests for version detection in `autoload::tests`)
- [ ] Project with `"require": {"php": "^8.1"}` in `composer.json` — server picks up `"8.1"` without any config
- [ ] Project with `config.platform.php` set — that value takes priority over `require.php`
- [ ] No `composer.json` — server falls back to `php --version` output
- [ ] No PHP binary on PATH and no `composer.json` — server uses `"8.5"`
- [ ] Setting an unsupported value like `"phpVersion": "9.9"` logs a warning in the editor