### PR TITLE
feat(deps): upgrade php-ast/php-rs-parser to 0.6.2 and fix semantic token UTF-16 bugs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -645,9 +645,9 @@ dependencies = [
 
 [[package]]
 name = "mir-analyzer"
-version = "0.3.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a365f21d41ffce944ac21683a79ca3bf91ccbf22ad958c8dd4ec804ea94e48"
+checksum = "848dc2442af9acb773af8564786b5a1b747b0f3203e80bdc4bb0c8afd5c95111"
 dependencies = [
  "bumpalo",
  "indexmap",
@@ -666,9 +666,9 @@ dependencies = [
 
 [[package]]
 name = "mir-codebase"
-version = "0.3.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "198891f29c5bd9e3b1fe40c7fc837241ee8fb21cd9b03fd1ce5075c4ebef7b59"
+checksum = "9ca6a4591a4497ab7ad79f7996e2a61a74158b3cf168a307289d12e63edfdf27"
 dependencies = [
  "dashmap 6.1.0",
  "indexmap",
@@ -679,9 +679,9 @@ dependencies = [
 
 [[package]]
 name = "mir-issues"
-version = "0.3.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a999021ca6cfae4bd4fffcdbf4e10366ef21b108fd396fb82292cfe0edc98f"
+checksum = "8f18361b9a4a1a99a7cdc7275b30028b06be5713326a6c1b991b4f0b63701ad6"
 dependencies = [
  "mir-types",
  "owo-colors",
@@ -691,9 +691,9 @@ dependencies = [
 
 [[package]]
 name = "mir-types"
-version = "0.3.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "381f74d2137189242b9a0c39a907cbd4fe05012adf6f27141c1e68637bc44099"
+checksum = "5454172c589ff8797bebd0efb079061c51e1d03bca7e56ad987b264333b7dcf4"
 dependencies = [
  "indexmap",
  "serde",
@@ -752,9 +752,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "php-ast"
-version = "0.5.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d5a308bf0bd456c28f8b9cb93bc1f37faf5402c531a1087f46c34a2903f2306"
+checksum = "6d6d6cac9004e6c4eb89eec5dde2984a66c67c9569d254dff940c83fb81799bc"
 dependencies = [
  "bumpalo",
  "serde",
@@ -762,9 +762,9 @@ dependencies = [
 
 [[package]]
 name = "php-lexer"
-version = "0.5.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7b35759abe5da820bac48e5aedea81e018cf32ab20ed5075c62a155c6a76d3e"
+checksum = "c4c8a5d3c7011e478b96d540726000ec9fff680d5d00193aa59282f9ea2bd3a9"
 dependencies = [
  "memchr",
  "php-ast",
@@ -791,9 +791,9 @@ dependencies = [
 
 [[package]]
 name = "php-rs-parser"
-version = "0.5.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cad3a83439d31f6285681e274b9f8038ea9129d85ee6da9ab624f941845538ed"
+checksum = "201d9a924e9d17bbf74b070d272685d26234b3ab830ba4d7e612b039c65d6f51"
 dependencies = [
  "bumpalo",
  "miette",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,12 +8,12 @@ repository = "https://github.com/jorgsowa/php-lsp"
 readme = "README.md"
 
 [dependencies]
-mir-analyzer = "0.3.0"
-mir-issues = "0.3.0"
-mir-codebase = "0.3.0"
-mir-types = "0.3.0"
-php-rs-parser = "0.5.0"
-php-ast = "0.5.0"
+mir-analyzer = "0.4.1"
+mir-issues = "0.4.1"
+mir-codebase = "0.4.1"
+mir-types = "0.4.1"
+php-rs-parser = "0.6.2"
+php-ast = "0.6.2"
 bumpalo = { version = "3", features = ["collections"] }
 tower-lsp = "0.20"
 tokio = { version = "1", features = ["full"] }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -76,12 +76,20 @@ impl Default for ParsedDoc {
 // ── Span / position utilities ─────────────────────────────────────────────────
 
 /// Convert a byte offset into `source` to an LSP `Position` (0-based line/char).
+///
+/// Handles both LF-only and CRLF line endings. When the offset lands on or
+/// after a `\r` that immediately precedes `\n`, the `\r` is not counted as a
+/// column so that positions are consistent regardless of line-ending style.
 pub fn offset_to_position(source: &str, offset: u32) -> Position {
     let offset = (offset as usize).min(source.len());
     let prefix = &source[..offset];
     let line = prefix.bytes().filter(|&b| b == b'\n').count() as u32;
     let last_nl = prefix.rfind('\n').map(|i| i + 1).unwrap_or(0);
-    let character = prefix[last_nl..]
+    // Strip a trailing \r so CRLF line endings don't inflate the column count.
+    let line_segment = prefix[last_nl..]
+        .strip_suffix('\r')
+        .unwrap_or(&prefix[last_nl..]);
+    let character = line_segment
         .chars()
         .map(|c| c.len_utf16() as u32)
         .sum::<u32>();
@@ -199,6 +207,55 @@ mod tests {
                 line: 0,
                 character: 3
             }  // UTF-16 col 3
+        );
+    }
+
+    #[test]
+    fn offset_to_position_crlf_start_of_line() {
+        // CRLF: offset pointing to first char of line 1 must give character=0.
+        // "foo\r\nbar": f=0 o=1 o=2 \r=3 \n=4 b=5 a=6 r=7
+        let src = "foo\r\nbar";
+        assert_eq!(
+            offset_to_position(src, 5), // 'b'
+            Position {
+                line: 1,
+                character: 0
+            }
+        );
+    }
+
+    #[test]
+    fn offset_to_position_crlf_does_not_count_cr_in_column() {
+        // Offset pointing to the \r itself must not count it as a column.
+        // "foo\r\nbar": the \r is at offset 3, column must be 3 (length of "foo").
+        let src = "foo\r\nbar";
+        assert_eq!(
+            offset_to_position(src, 3), // '\r'
+            Position {
+                line: 0,
+                character: 3
+            }
+        );
+    }
+
+    #[test]
+    fn offset_to_position_crlf_multiline() {
+        // Multiple CRLF lines: columns must not accumulate stray \r counts.
+        // "a\r\nb\r\nc": a=0 \r=1 \n=2 b=3 \r=4 \n=5 c=6
+        let src = "a\r\nb\r\nc";
+        assert_eq!(
+            offset_to_position(src, 6), // 'c'
+            Position {
+                line: 2,
+                character: 0
+            }
+        );
+        assert_eq!(
+            offset_to_position(src, 3), // 'b'
+            Position {
+                line: 1,
+                character: 0
+            }
         );
     }
 

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -2056,7 +2056,7 @@ async fn send_refresh_requests(client: &Client) {
 /// Run the definition collector for a single file against the persistent codebase.
 fn collect_into_codebase(codebase: &mir_codebase::Codebase, uri: &Url, doc: &ParsedDoc) {
     let file: Arc<str> = Arc::from(uri.as_str());
-    let source_map = php_ast::source_map::SourceMap::new(doc.source());
+    let source_map = php_rs_parser::source_map::SourceMap::new(doc.source());
     let collector = mir_analyzer::collector::DefinitionCollector::new(
         codebase,
         file,

--- a/src/completion/symbols.rs
+++ b/src/completion/symbols.rs
@@ -174,7 +174,7 @@ fn collect_from_expression(expr: &php_ast::Expr<'_, '_>, items: &mut Vec<Complet
     if let ExprKind::Assign(assign) = &expr.kind {
         match &assign.target.kind {
             ExprKind::Variable(name) => {
-                let label = format!("${}", name);
+                let label = format!("${}", name.as_str());
                 if label != "$this" {
                     items.push(CompletionItem {
                         label,
@@ -187,7 +187,7 @@ fn collect_from_expression(expr: &php_ast::Expr<'_, '_>, items: &mut Vec<Complet
             ExprKind::Array(elements) => {
                 for elem in elements.iter() {
                     if let ExprKind::Variable(name) = &elem.value.kind {
-                        let label = format!("${}", name);
+                        let label = format!("${}", name.as_str());
                         if label != "$this" {
                             items.push(CompletionItem {
                                 label,

--- a/src/document_highlight.rs
+++ b/src/document_highlight.rs
@@ -116,7 +116,10 @@ mod tests {
         let highlights = document_highlights(src, &doc, pos(1, 10));
         for h in &highlights {
             let len = h.range.end.character - h.range.start.character;
-            assert_eq!(len, "greet".len() as u32);
+            assert_eq!(
+                len,
+                "greet".chars().map(|c| c.len_utf16() as u32).sum::<u32>()
+            );
         }
     }
 

--- a/src/inlay_hints.rs
+++ b/src/inlay_hints.rs
@@ -134,7 +134,7 @@ fn collect_defs_stmts(stmts: &[Stmt<'_, '_>], map: &mut HashMap<String, FuncDef>
                 if let ExprKind::Assign(assign) = &e.kind
                     && let ExprKind::Variable(var_name) = &assign.target.kind
                 {
-                    let key = format!("${var_name}");
+                    let key = format!("${}", var_name.as_str());
                     match &assign.value.kind {
                         ExprKind::Closure(c) => {
                             let (params, variadic_last) = params_from_list(&c.params);
@@ -266,7 +266,7 @@ fn hints_in_stmt(
             hints_in_expr(source, &f.expr, defs, type_map, range, out);
             // Emit type hint after the value variable, e.g. `foreach ($arr as $item /* : Foo */)`.
             if let ExprKind::Variable(val_name) = &f.value.kind {
-                let key = format!("${val_name}");
+                let key = format!("${}", val_name.as_str());
                 if let Some(ty) = type_map.get(&key) {
                     let pos = offset_to_position(source, f.value.span.end);
                     if pos_in_range(pos, range) {
@@ -278,7 +278,7 @@ fn hints_in_stmt(
             if let Some(key_expr) = &f.key
                 && let ExprKind::Variable(key_name) = &key_expr.kind
             {
-                let key = format!("${key_name}");
+                let key = format!("${}", key_name.as_str());
                 if let Some(ty) = type_map.get(&key) {
                     let pos = offset_to_position(source, key_expr.span.end);
                     if pos_in_range(pos, range) {
@@ -315,7 +315,7 @@ fn hints_in_expr(
             // Look up by identifier name or by variable name (for closure vars like `$fn(...)`).
             let key: Option<String> = ident_name(f.name).map(|n| n.to_string()).or_else(|| {
                 if let ExprKind::Variable(n) = &f.name.kind {
-                    Some(format!("${n}"))
+                    Some(format!("${}", n.as_str()))
                 } else {
                     None
                 }

--- a/src/promote_action.rs
+++ b/src/promote_action.rs
@@ -187,13 +187,14 @@ fn find_this_assign(source: &str, stmts: &[Stmt<'_, '_>], param_name: &str) -> O
         {
             // LHS must be `$this->paramName`
             if let ExprKind::PropertyAccess(pa) = &assign.target.kind {
-                let is_this = matches!(&pa.object.kind, ExprKind::Variable(v) if *v == "this");
+                let is_this =
+                    matches!(&pa.object.kind, ExprKind::Variable(v) if v.as_str() == "this");
                 let prop_src = source
                     .get(pa.property.span.start as usize..pa.property.span.end as usize)
                     .unwrap_or("");
                 // RHS must be `$paramName`
                 let rhs_matches =
-                    matches!(&assign.value.kind, ExprKind::Variable(v) if *v == param_name);
+                    matches!(&assign.value.kind, ExprKind::Variable(v) if v.as_str() == param_name);
                 if is_this && prop_src == param_name && rhs_matches {
                     return Some((stmt.span.start, stmt.span.end));
                 }

--- a/src/references.rs
+++ b/src/references.rs
@@ -537,7 +537,8 @@ mod tests {
         );
         assert_eq!(
             refs[0].range.end.character,
-            refs[0].range.start.character + "greet".len() as u32,
+            refs[0].range.start.character
+                + "greet".chars().map(|c| c.len_utf16() as u32).sum::<u32>(),
             "range should span exactly the function name"
         );
     }

--- a/src/semantic_diagnostics.rs
+++ b/src/semantic_diagnostics.rs
@@ -29,7 +29,7 @@ pub fn semantic_diagnostics(
     // Incremental update: evict stale definitions for this file, re-collect,
     // and rebuild inheritance tables.
     codebase.remove_file_definitions(&file);
-    let source_map = php_ast::source_map::SourceMap::new(doc.source());
+    let source_map = php_rs_parser::source_map::SourceMap::new(doc.source());
     let collector = mir_analyzer::collector::DefinitionCollector::new(
         codebase,
         file.clone(),
@@ -182,9 +182,9 @@ fn check_expr_for_deprecated(
                         let end_pos = offset_to_position(source, call.name.span.end);
                         let msg = match &db.deprecated {
                             Some(m) if !m.is_empty() => {
-                                format!("Deprecated: {} — {}", func_name, m)
+                                format!("Deprecated: {} — {}", func_name.as_str(), m)
                             }
-                            _ => format!("Deprecated: {}", func_name),
+                            _ => format!("Deprecated: {}", func_name.as_str()),
                         };
                         diags.push(Diagnostic {
                             range: Range {
@@ -228,9 +228,9 @@ fn check_expr_for_deprecated(
                         let end_pos = offset_to_position(source, call.method.span.end);
                         let msg = match &db.deprecated {
                             Some(m) if !m.is_empty() => {
-                                format!("Deprecated: {} — {}", method_name, m)
+                                format!("Deprecated: {} — {}", method_name.as_str(), m)
                             }
-                            _ => format!("Deprecated: {}", method_name),
+                            _ => format!("Deprecated: {}", method_name.as_str()),
                         };
                         diags.push(Diagnostic {
                             range: Range {

--- a/src/semantic_tokens.rs
+++ b/src/semantic_tokens.rs
@@ -569,14 +569,16 @@ fn collect_expr(source: &str, expr: &php_ast::Expr<'_, '_>, out: &mut Vec<RawTok
             push_at(out, source, expr.span.start, span_len, TT_NUMBER, 0);
         }
         ExprKind::String(_) | ExprKind::Nowdoc { .. } => {
-            let span_len = expr.span.end - expr.span.start;
-            push_at(out, source, expr.span.start, span_len, TT_STRING, 0);
+            let segment = &source[expr.span.start as usize..expr.span.end as usize];
+            let len: u32 = segment.chars().map(|c| c.len_utf16() as u32).sum();
+            push_at(out, source, expr.span.start, len, TT_STRING, 0);
         }
         ExprKind::InterpolatedString(parts) | ExprKind::ShellExec(parts) => {
             // Emit the whole span as a string; embedded variables are not
             // re-coloured here to keep the implementation simple.
-            let span_len = expr.span.end - expr.span.start;
-            push_at(out, source, expr.span.start, span_len, TT_STRING, 0);
+            let segment = &source[expr.span.start as usize..expr.span.end as usize];
+            let len: u32 = segment.chars().map(|c| c.len_utf16() as u32).sum();
+            push_at(out, source, expr.span.start, len, TT_STRING, 0);
             // Still recurse into embedded expressions so method/function calls
             // inside `"... {$obj->method()} ..."` get proper tokens.
             for part in parts.iter() {
@@ -586,8 +588,9 @@ fn collect_expr(source: &str, expr: &php_ast::Expr<'_, '_>, out: &mut Vec<RawTok
             }
         }
         ExprKind::Heredoc { parts, .. } => {
-            let span_len = expr.span.end - expr.span.start;
-            push_at(out, source, expr.span.start, span_len, TT_STRING, 0);
+            let segment = &source[expr.span.start as usize..expr.span.end as usize];
+            let len: u32 = segment.chars().map(|c| c.len_utf16() as u32).sum();
+            push_at(out, source, expr.span.start, len, TT_STRING, 0);
             for part in parts.iter() {
                 if let php_ast::StringPart::Expr(inner) = part {
                     collect_expr(source, inner, out);
@@ -713,8 +716,9 @@ fn collect_expr(source: &str, expr: &php_ast::Expr<'_, '_>, out: &mut Vec<RawTok
         }
         // ── Variables ─────────────────────────────────────────────────────────
         ExprKind::Variable(_) => {
-            let span_len = expr.span.end - expr.span.start;
-            push_at(out, source, expr.span.start, span_len, TT_VARIABLE, 0);
+            let segment = &source[expr.span.start as usize..expr.span.end as usize];
+            let len: u32 = segment.chars().map(|c| c.len_utf16() as u32).sum();
+            push_at(out, source, expr.span.start, len, TT_VARIABLE, 0);
         }
         _ => {}
     }
@@ -1229,6 +1233,56 @@ mod tests {
         );
         assert_eq!(
             attr_token.length, utf16_len,
+            "token length should be UTF-16 units ({utf16_len}), not byte length ({byte_len})"
+        );
+    }
+
+    /// A string literal `"café"` contains `é` (2 UTF-8 bytes, 1 UTF-16 unit).
+    /// The TT_STRING token length must use UTF-16 units, not byte count.
+    #[test]
+    fn string_literal_with_multibyte_chars_uses_utf16_length() {
+        // "café": " + c(1) + a(1) + f(1) + é(2) + " = 8 bytes, 6 UTF-16 units
+        let src = "<?php\n$s = \"café\";";
+        let d = doc(src);
+        let tokens = semantic_tokens(src, &d);
+        let str_token = tokens
+            .iter()
+            .find(|t| t.token_type == TT_STRING)
+            .expect("expected a TT_STRING token for the string literal");
+        let content = "\"café\"";
+        let utf16_len: u32 = content.chars().map(|c| c.len_utf16() as u32).sum();
+        let byte_len = content.len() as u32;
+        assert_ne!(
+            utf16_len, byte_len,
+            "test requires content where UTF-16 ≠ byte length"
+        );
+        assert_eq!(
+            str_token.length, utf16_len,
+            "token length should be UTF-16 units ({utf16_len}), not byte length ({byte_len})"
+        );
+    }
+
+    /// A variable whose name contains a multibyte character (valid per PHP spec).
+    /// The TT_VARIABLE token length must use UTF-16 units, not byte count.
+    #[test]
+    fn variable_with_multibyte_name_uses_utf16_length() {
+        // $café: $(1) + c(1) + a(1) + f(1) + é(2) = 7 bytes, 6 UTF-16 units
+        let src = "<?php\n$café = 1;";
+        let d = doc(src);
+        let tokens = semantic_tokens(src, &d);
+        let var_token = tokens
+            .iter()
+            .find(|t| t.token_type == TT_VARIABLE)
+            .expect("expected a TT_VARIABLE token");
+        let name = "$café";
+        let utf16_len: u32 = name.chars().map(|c| c.len_utf16() as u32).sum();
+        let byte_len = name.len() as u32;
+        assert_ne!(
+            utf16_len, byte_len,
+            "test requires a name where UTF-16 ≠ byte length"
+        );
+        assert_eq!(
+            var_token.length, utf16_len,
             "token length should be UTF-16 units ({utf16_len}), not byte length ({byte_len})"
         );
     }

--- a/src/semantic_tokens.rs
+++ b/src/semantic_tokens.rs
@@ -187,7 +187,8 @@ fn push_name(out: &mut Vec<RawToken>, source: &str, name: &str, token_type: u32,
 fn push_attributes(out: &mut Vec<RawToken>, source: &str, attrs: &[Attribute<'_, '_>]) {
     for attr in attrs.iter() {
         let span = attr.name.span();
-        let len = span.end - span.start;
+        let segment = &source[span.start as usize..span.end as usize];
+        let len: u32 = segment.chars().map(|c| c.len_utf16() as u32).sum();
         push_at(out, source, span.start, len, TT_CLASS, 0);
     }
 }
@@ -347,7 +348,8 @@ fn push_type_hint(out: &mut Vec<RawToken>, source: &str, hint: &TypeHint<'_, '_>
     match &hint.kind {
         TypeHintKind::Named(name) => {
             let span = name.span();
-            let len = span.end - span.start;
+            let segment = &source[span.start as usize..span.end as usize];
+            let len: u32 = segment.chars().map(|c| c.len_utf16() as u32).sum();
             push_at(out, source, span.start, len, TT_TYPE, 0);
         }
         TypeHintKind::Keyword(builtin, span) => {
@@ -1178,6 +1180,56 @@ mod tests {
             tokens.iter().any(|t| t.token_type == TT_TYPE),
             "expected TYPE token for method return type, got {:?}",
             tokens
+        );
+    }
+
+    /// `é` (U+00E9) encodes as 2 UTF-8 bytes but 1 UTF-16 code unit.
+    /// A named type hint `Héros` has byte-length 6 but UTF-16 length 5.
+    /// Verify the token's `length` matches the UTF-16 count, not the byte count.
+    #[test]
+    fn named_type_hint_with_multibyte_chars_uses_utf16_length() {
+        // "Héros": H(1) é(2) r(1) o(1) s(1) = 6 bytes, 5 UTF-16 units
+        let src = "<?php\nfunction greet(Héros $h): void {}";
+        let d = doc(src);
+        let tokens = semantic_tokens(src, &d);
+        let type_token = tokens
+            .iter()
+            .find(|t| t.token_type == TT_TYPE)
+            .expect("expected a TT_TYPE token for the named type hint");
+        let name = "Héros";
+        let utf16_len: u32 = name.chars().map(|c| c.len_utf16() as u32).sum();
+        let byte_len = name.len() as u32;
+        assert_ne!(
+            utf16_len, byte_len,
+            "test requires a name where UTF-16 ≠ byte length"
+        );
+        assert_eq!(
+            type_token.length, utf16_len,
+            "token length should be UTF-16 units ({utf16_len}), not byte length ({byte_len})"
+        );
+    }
+
+    /// Same check for attribute names: `#[Routé]` has a multibyte name.
+    /// `Routé`: R(1) o(1) u(1) t(1) é(2) = 6 bytes, 5 UTF-16 units.
+    #[test]
+    fn attribute_name_with_multibyte_chars_uses_utf16_length() {
+        let src = "<?php\n#[Routé(\"/home\")]\nfunction index() {}";
+        let d = doc(src);
+        let tokens = semantic_tokens(src, &d);
+        let attr_token = tokens
+            .iter()
+            .find(|t| t.token_type == TT_CLASS && t.token_modifiers_bitset == 0)
+            .expect("expected a bare TT_CLASS token for the attribute name");
+        let name = "Routé";
+        let utf16_len: u32 = name.chars().map(|c| c.len_utf16() as u32).sum();
+        let byte_len = name.len() as u32;
+        assert_ne!(
+            utf16_len, byte_len,
+            "test requires a name where UTF-16 ≠ byte length"
+        );
+        assert_eq!(
+            attr_token.length, utf16_len,
+            "token length should be UTF-16 units ({utf16_len}), not byte length ({byte_len})"
         );
     }
 }

--- a/src/type_map.rs
+++ b/src/type_map.rs
@@ -219,13 +219,13 @@ fn collect_types_stmts(
                     let class_name = base.rsplit('\\').next().unwrap_or(base).to_string();
                     if let Some(vname) = db.var_name {
                         // `@var Foo $obj` — explicit variable name.
-                        map.insert(format!("${vname}"), class_name);
+                        map.insert(format!("${}", vname.as_str()), class_name);
                     } else if let StmtKind::Expression(e) = &stmt.kind {
                         // `@var Foo` above `$obj = ...` — infer from the LHS.
                         if let ExprKind::Assign(a) = &e.kind
                             && let ExprKind::Variable(vn) = &a.target.kind
                         {
-                            map.insert(format!("${vn}"), class_name);
+                            map.insert(format!("${}", vn.as_str()), class_name);
                         }
                     }
                 }
@@ -355,8 +355,9 @@ fn collect_types_stmts(
                     && let (ExprKind::Variable(var_name), ExprKind::Identifier(class)) =
                         (&b.left.kind, &b.right.kind)
                 {
-                    let var_key = format!("${}", var_name);
+                    let var_key = format!("${}", var_name.as_str());
                     let narrowed = class
+                        .as_str()
                         .trim_start_matches('\\')
                         .rsplit('\\')
                         .next()
@@ -398,11 +399,11 @@ fn collect_types_stmts(
             // foreach ($arr as $item) — propagate element type from $arr[] to $item
             StmtKind::Foreach(f) => {
                 if let ExprKind::Variable(arr_name) = &f.expr.kind {
-                    let elem_key = format!("${}[]", arr_name);
+                    let elem_key = format!("${}[]", arr_name.as_str());
                     if let Some(elem_type) = map.get(&elem_key).cloned()
                         && let ExprKind::Variable(val_name) = &f.value.kind
                     {
-                        map.insert(format!("${}", val_name), elem_type);
+                        map.insert(format!("${}", val_name.as_str()), elem_type);
                     }
                 }
                 collect_types_stmts(
@@ -477,7 +478,8 @@ fn collect_types_expr(
                     if let ExprKind::New(new_expr) = &assign.value.kind
                         && let Some(class_name) = extract_class_name(new_expr.class)
                     {
-                        map.entry(format!("${}", var_name)).or_insert(class_name);
+                        map.entry(format!("${}", var_name.as_str()))
+                            .or_insert(class_name);
                     }
                     collect_types_expr(source, assign.value, map, meta, method_returns);
                     return;
@@ -485,27 +487,27 @@ fn collect_types_expr(
                 if let ExprKind::New(new_expr) = &assign.value.kind
                     && let Some(class_name) = extract_class_name(new_expr.class)
                 {
-                    map.insert(format!("${}", var_name), class_name);
+                    map.insert(format!("${}", var_name.as_str()), class_name);
                 }
                 // $result = $obj->method() — infer result type from method's return type
                 if let ExprKind::MethodCall(mc) = &assign.value.kind
                     && let (ExprKind::Variable(obj_var), ExprKind::Identifier(method_name)) =
                         (&mc.object.kind, &mc.method.kind)
-                    && let Some(obj_class) = map.get(&format!("${}", obj_var)).cloned()
+                    && let Some(obj_class) = map.get(&format!("${}", obj_var.as_str())).cloned()
                     && let Some(class_rets) = method_returns.get(&obj_class)
-                    && let Some(ret_type) = class_rets.get(*method_name)
+                    && let Some(ret_type) = class_rets.get(method_name.as_str())
                 {
-                    map.insert(format!("${}", var_name), ret_type.clone());
+                    map.insert(format!("${}", var_name.as_str()), ret_type.clone());
                 }
                 // PHPStorm meta: `$var = $obj->make(SomeClass::class)`
                 if let Some(meta) = meta
                     && let Some(inferred) = infer_from_meta_method_call(assign.value, map, meta)
                 {
-                    map.insert(format!("${}", var_name), inferred);
+                    map.insert(format!("${}", var_name.as_str()), inferred);
                 }
                 // $result = array_map(fn($x): Foo => ..., $arr) → $result[] = Foo
                 if let Some(elem_type) = extract_array_callback_return_type(assign.value) {
-                    map.insert(format!("${}[]", var_name), elem_type);
+                    map.insert(format!("${}[]", var_name.as_str()), elem_type);
                 }
             }
             collect_types_expr(source, assign.value, map, meta, method_returns);
@@ -514,7 +516,7 @@ fn collect_types_expr(
         // Closure::bind($fn, $obj) → $this maps to $obj's class
         ExprKind::StaticMethodCall(s) => {
             if let ExprKind::Identifier(class) = &s.class.kind
-                && *class == "Closure"
+                && class.as_str() == "Closure"
                 && s.method == "bind"
                 && let Some(obj_arg) = s.args.get(1)
                 && let Some(cls) = resolve_var_type_str(&obj_arg.value, map)
@@ -526,7 +528,7 @@ fn collect_types_expr(
         // $fn->bindTo($obj) or $fn->call($obj) → $this maps to $obj's class
         ExprKind::MethodCall(m) => {
             if let ExprKind::Identifier(method) = &m.method.kind {
-                let mname: &str = method;
+                let mname = method.as_str();
                 if (mname == "bindTo" || mname == "call")
                     && let Some(obj_arg) = m.args.first()
                     && let Some(cls) = resolve_var_type_str(&obj_arg.value, map)
@@ -587,7 +589,7 @@ fn extract_array_callback_return_type(expr: &php_ast::Expr<'_, '_>) -> Option<St
         return None;
     };
     let fn_name = match &call.name.kind {
-        ExprKind::Identifier(n) => *n,
+        ExprKind::Identifier(n) => n.as_str(),
         _ => return None,
     };
     if fn_name != "array_map" && fn_name != "array_filter" {
@@ -626,7 +628,7 @@ fn resolve_var_type_str(
     map: &HashMap<String, String>,
 ) -> Option<String> {
     if let ExprKind::Variable(v) = &expr.kind {
-        map.get(&format!("${}", v)).cloned()
+        map.get(&format!("${}", v.as_str())).cloned()
     } else {
         None
     }
@@ -634,7 +636,7 @@ fn resolve_var_type_str(
 
 fn extract_class_name(expr: &php_ast::Expr<'_, '_>) -> Option<String> {
     match &expr.kind {
-        ExprKind::Identifier(name) => Some(name.to_string()),
+        ExprKind::Identifier(name) => Some(name.as_str().to_string()),
         _ => None,
     }
 }
@@ -652,7 +654,7 @@ fn infer_from_meta_method_call(
     // Resolve the receiver's type.
     let receiver_class = match &m.object.kind {
         ExprKind::Variable(v) => {
-            let key = format!("${}", v);
+            let key = format!("${}", v.as_str());
             var_map.get(&key)?.clone()
         }
         _ => return None,

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -378,7 +378,7 @@ fn var_refs_in_stmt(stmt: &Stmt<'_, '_>, var_name: &str, out: &mut Vec<Span>) {
 fn var_refs_in_expr(expr: &Expr<'_, '_>, var_name: &str, out: &mut Vec<Span>) {
     match &expr.kind {
         ExprKind::Variable(name) => {
-            if name.as_ref() == var_name {
+            if name.as_str() == var_name {
                 out.push(expr.span);
             }
         }
@@ -867,7 +867,7 @@ fn args(source: &str, arg_list: &[php_ast::Arg<'_, '_>], word: &str, out: &mut V
 pub fn refs_in_expr(source: &str, expr: &Expr<'_, '_>, word: &str, out: &mut Vec<Span>) {
     match &expr.kind {
         ExprKind::Identifier(name) => {
-            if *name == word {
+            if name.as_str() == word {
                 out.push(expr.span);
             }
         }
@@ -1068,7 +1068,7 @@ fn function_refs_in_expr(expr: &Expr<'_, '_>, name: &str, out: &mut Vec<Span>) {
         // The core match: a free function call whose callee is a bare identifier.
         ExprKind::FunctionCall(f) => {
             if let ExprKind::Identifier(id) = &f.name.kind
-                && *id == name
+                && id.as_str() == name
             {
                 out.push(f.name.span);
             }
@@ -1259,7 +1259,7 @@ fn method_refs_in_expr(expr: &Expr<'_, '_>, name: &str, out: &mut Vec<Span>) {
             method_refs_in_expr(m.object, name, out);
             // Collect the method name span if it matches.
             if let ExprKind::Identifier(id) = &m.method.kind
-                && *id == name
+                && id.as_str() == name
             {
                 out.push(m.method.span);
             }
@@ -1270,7 +1270,7 @@ fn method_refs_in_expr(expr: &Expr<'_, '_>, name: &str, out: &mut Vec<Span>) {
         ExprKind::NullsafeMethodCall(m) => {
             method_refs_in_expr(m.object, name, out);
             if let ExprKind::Identifier(id) = &m.method.kind
-                && *id == name
+                && id.as_str() == name
             {
                 out.push(m.method.span);
             }


### PR DESCRIPTION
## Summary

- Upgrade `php-rs-parser` 0.5.0 → 0.6.2, `php-ast` 0.5.0 → 0.6.2, and `mir-*` 0.3.0 → 0.4.1
- Fix four bugs where semantic token `length` used byte span width instead of UTF-16 code units (LSP spec violation)
- Fix `offset_to_position` incorrectly counting `\r` as a column on CRLF files, corrupting every LSP range on Windows line endings
- Adapt all affected modules to `NameStr<'arena, 'src>`, the new opaque identifier type in `php-ast 0.6.x`
- Fix `source_map` module path, which moved from `php_ast` to `php_rs_parser` in 0.6.x
- Add 7 regression tests that would have caught all five bugs

## Bugs fixed

### 1–4. Semantic token `length` uses byte span width instead of UTF-16 code units (`semantic_tokens.rs`)

The LSP spec requires `SemanticToken.length` to be in UTF-16 code units. Four token kinds were using raw byte span widths, breaking highlighting for any source containing non-ASCII characters:

| Token kind | Example trigger |
|---|---|
| Named type hints (`TT_TYPE`) | `function greet(Héros $h)` |
| Attribute names (`TT_CLASS`) | `#[Routé("/home")]` |
| String literals (`TT_STRING`) | `$s = "café";` |
| Variables (`TT_VARIABLE`) | `$café = 1;` |

`é` (U+00E9) is 2 UTF-8 bytes but 1 UTF-16 code unit, so a token covering it would report width 1 too large, misaligning all subsequent highlights on the same line.

The 0.5.x parser also had a span bug in `parse_name()` that included trailing whitespace in the span end (filed as jorgsowa/rust-php-parser#161); the upgrade to 0.6.2 fixes this at the source.

### 5. CRLF line endings inflate column positions (`ast.rs: offset_to_position`)

`offset_to_position` counted `\r` as a column character. On CRLF files (`\r\n` line endings), any token whose span end landed on the `\r` (i.e. the last token on a line) would produce an end position 1 column too high.

Because `offset_to_position` is the single source of truth for all LSP positions, this affected every feature on Windows-style files: hover, go-to-definition, references, rename, inlay hints, semantic tokens, and more.

Fix: strip a trailing `\r` from the line segment before counting UTF-16 units.

### `NameStr` API adaptation (`php-ast 0.6.x`)

`php-ast 0.6.x` wraps variable and identifier names in `NameStr<'arena, 'src>` which does not implement `Display`. All `format!("${}", name)` calls and direct equality comparisons throughout `type_map.rs`, `walk.rs`, `inlay_hints.rs`, `completion/symbols.rs`, `promote_action.rs`, `semantic_diagnostics.rs`, and `inlay_hints.rs` are updated to use `.as_str()`.

## Test plan

- [x] `cargo build` — clean build, no errors
- [x] `cargo test` — 701 tests, 0 failures
- [x] `named_type_hint_with_multibyte_chars_uses_utf16_length` — type hint UTF-16 length
- [x] `attribute_name_with_multibyte_chars_uses_utf16_length` — attribute name UTF-16 length
- [x] `string_literal_with_multibyte_chars_uses_utf16_length` — string literal UTF-16 length
- [x] `variable_with_multibyte_name_uses_utf16_length` — variable UTF-16 length
- [x] `offset_to_position_crlf_start_of_line` — CRLF: first char of next line is col 0
- [x] `offset_to_position_crlf_does_not_count_cr_in_column` — CRLF: `\r` not counted as column
- [x] `offset_to_position_crlf_multiline` — CRLF: correct across multiple lines