### PR TITLE
fix(php-version): improve detection accuracy and wire version through diagnostics

### DIFF
--- a/src/autoload.rs
+++ b/src/autoload.rs
@@ -273,7 +273,11 @@ fn parse_php_version_constraint(constraint: &str) -> Option<String> {
             let stripped = clause
                 .trim()
                 .trim_start_matches(['^', '~', '>', '<', '=', ' ']);
-            // Take the first whitespace-delimited token: "8.0 <9.0" → "8.0"
+            // Take the first whitespace-delimited token: "8.0 <9.0" → "8.0".
+            // TODO: for single-range constraints like ">=7.4 <9.0" this returns the
+            // lower bound (7.4) rather than the actual runtime version. There is no
+            // reliable way to infer the runtime from a range alone; the php binary
+            // (detect_php_binary_version) is a better signal for that case.
             let token = stripped.split_whitespace().next().unwrap_or(stripped);
             // Split on '.' to get major and minor, stripping trailing wildcards.
             let mut parts = token.split('.');

--- a/src/autoload.rs
+++ b/src/autoload.rs
@@ -175,32 +175,64 @@ fn load_psr4_section(
     }
 }
 
-/// Detect the PHP version from a project's `composer.json`.
+/// Detect PHP version from `config.platform.php` in `composer.json`.
 ///
-/// Checks in order:
-/// 1. `config.platform.php` — explicit platform override (e.g. `"8.1.0"`)
-/// 2. `require.php` — version constraint lower bound (e.g. `"^8.1"` → `"8.1"`)
-pub fn detect_php_version_from_composer(root: &Path) -> Option<String> {
+/// This is an explicit developer override that tells Composer to treat a
+/// specific PHP version as the runtime (commonly used to lock CI). It is
+/// the most authoritative composer-based source.
+pub fn detect_php_platform_version_from_composer(root: &Path) -> Option<String> {
     let text = std::fs::read_to_string(root.join("composer.json")).ok()?;
     let json: serde_json::Value = serde_json::from_str(&text).ok()?;
+    let platform_php = json.pointer("/config/platform/php")?.as_str()?;
+    extract_major_minor(platform_php)
+}
 
-    // config.platform.php is the authoritative platform version override.
-    if let Some(platform_php) = json
-        .pointer("/config/platform/php")
-        .and_then(|v| v.as_str())
-        && let Some(ver) = extract_major_minor(platform_php)
-    {
-        return Some(ver);
+/// Detect PHP version from `require.php` in `composer.json`.
+///
+/// This is a compatibility range, not the exact runtime version. Use as a
+/// last resort after `detect_php_platform_version_from_composer` and
+/// `detect_php_binary_version`.
+pub fn detect_php_require_version_from_composer(root: &Path) -> Option<String> {
+    let text = std::fs::read_to_string(root.join("composer.json")).ok()?;
+    let json: serde_json::Value = serde_json::from_str(&text).ok()?;
+    let constraint = json.pointer("/require/php")?.as_str()?;
+    parse_php_version_constraint(constraint)
+}
+
+/// Resolve the PHP version to use, in priority order:
+///
+/// 1. `explicit` — set by the client via `initializationOptions` or
+///    `workspace/configuration` (highest priority).
+/// 2. `config.platform.php` in `composer.json` — explicit project-level override.
+/// 3. `php --version` — actual runtime on the machine (or inside the container
+///    when the LSP server runs there).
+/// 4. `require.php` in `composer.json` — compatibility range, last resort.
+/// 5. `PHP_8_5` — server default.
+///
+/// Returns `(version, source)` so the caller can log where the version came from.
+pub fn resolve_php_version_from_roots(
+    roots: &[PathBuf],
+    explicit: Option<&str>,
+) -> (String, &'static str) {
+    if let Some(ver) = explicit {
+        return (ver.to_string(), "set by editor");
     }
-
-    // require.php is the minimum version constraint.
-    if let Some(constraint) = json.pointer("/require/php").and_then(|v| v.as_str())
-        && let Some(ver) = parse_php_version_constraint(constraint)
+    if let Some(ver) = roots
+        .iter()
+        .find_map(|r| detect_php_platform_version_from_composer(r))
     {
-        return Some(ver);
+        return (ver, "composer.json config.platform.php");
     }
-
-    None
+    if let Some(ver) = detect_php_binary_version() {
+        return (ver, "php binary");
+    }
+    if let Some(ver) = roots
+        .iter()
+        .find_map(|r| detect_php_require_version_from_composer(r))
+    {
+        return (ver, "composer.json require");
+    }
+    (PHP_8_5.to_string(), "default")
 }
 
 /// Detect the PHP version by running `php --version`.
@@ -226,24 +258,35 @@ fn extract_major_minor(version: &str) -> Option<String> {
     Some(format!("{}.{}", major, minor))
 }
 
-/// Extract a `"X.Y"` lower bound from a Composer version constraint like
-/// `"^8.1"`, `">=8.0"`, `"~8.2"`, `"7.4.*"`, or `">=8.0 <9.0"`.
+/// Extract the highest `"X.Y"` lower bound from a Composer version constraint
+/// like `"^8.1"`, `">=8.0"`, `"~8.2"`, `"7.4.*"`, `">=8.0 <9.0"`, or
+/// `"^7.4 || ^8.1"`.
+///
+/// For OR-constraints we take the **maximum** lower bound: a project that
+/// declares `"^7.4 || ^8.1"` is most likely running on 8.1 locally, so using
+/// the highest version gives the best LSP experience.
 fn parse_php_version_constraint(constraint: &str) -> Option<String> {
-    // Take the first OR-clause: ">=7.4 || ^8.0" → ">=7.4"
-    let clause = constraint.split("||").next().unwrap_or(constraint).trim();
-    // Strip leading comparison/range operators
-    let stripped = clause.trim_start_matches(['^', '~', '>', '<', '=', ' ']);
-    // Take the first whitespace-delimited token: "8.0 <9.0" → "8.0"
-    let token = stripped.split_whitespace().next().unwrap_or(stripped);
-    // Split on '.' to get major and minor, stripping trailing wildcards
-    let mut parts = token.split('.');
-    let major = parts.next()?;
-    let minor_raw = parts.next().unwrap_or("0");
-    let minor = minor_raw.trim_end_matches('*');
-    let minor = if minor.is_empty() { "0" } else { minor };
-    major.parse::<u32>().ok()?;
-    minor.parse::<u32>().ok()?;
-    Some(format!("{}.{}", major, minor))
+    constraint
+        .split("||")
+        .filter_map(|clause| {
+            // Strip leading comparison/range operators from the clause.
+            let stripped = clause
+                .trim()
+                .trim_start_matches(['^', '~', '>', '<', '=', ' ']);
+            // Take the first whitespace-delimited token: "8.0 <9.0" → "8.0"
+            let token = stripped.split_whitespace().next().unwrap_or(stripped);
+            // Split on '.' to get major and minor, stripping trailing wildcards.
+            let mut parts = token.split('.');
+            let major = parts.next()?;
+            let minor_raw = parts.next().unwrap_or("0");
+            let minor = minor_raw.trim_end_matches('*');
+            let minor = if minor.is_empty() { "0" } else { minor };
+            let maj: u32 = major.parse().ok()?;
+            let min: u32 = minor.parse().ok()?;
+            Some((maj, min, format!("{}.{}", major, minor)))
+        })
+        .max_by_key(|&(maj, min, _)| (maj, min))
+        .map(|(_, _, ver)| ver)
 }
 
 #[cfg(test)]
@@ -394,9 +437,19 @@ mod tests {
             r#"{"config": {"platform": {"php": "8.1.27"}}}"#,
         );
         assert_eq!(
-            detect_php_version_from_composer(dir.path()),
+            detect_php_platform_version_from_composer(dir.path()),
             Some(PHP_8_1.to_string())
         );
+    }
+
+    #[test]
+    fn detect_platform_version_returns_none_when_no_platform_config() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            &dir.path().join("composer.json"),
+            r#"{"require": {"php": "^8.2"}}"#,
+        );
+        assert!(detect_php_platform_version_from_composer(dir.path()).is_none());
     }
 
     #[test]
@@ -407,7 +460,7 @@ mod tests {
             r#"{"require": {"php": "^8.2"}}"#,
         );
         assert_eq!(
-            detect_php_version_from_composer(dir.path()),
+            detect_php_require_version_from_composer(dir.path()),
             Some(PHP_8_2.to_string())
         );
     }
@@ -420,7 +473,7 @@ mod tests {
             r#"{"require": {"php": ">=8.0"}}"#,
         );
         assert_eq!(
-            detect_php_version_from_composer(dir.path()),
+            detect_php_require_version_from_composer(dir.path()),
             Some(PHP_8_0.to_string())
         );
     }
@@ -433,7 +486,7 @@ mod tests {
             r#"{"require": {"php": ">=8.1 <9.0"}}"#,
         );
         assert_eq!(
-            detect_php_version_from_composer(dir.path()),
+            detect_php_require_version_from_composer(dir.path()),
             Some(PHP_8_1.to_string())
         );
     }
@@ -446,28 +499,16 @@ mod tests {
             r#"{"require": {"php": "7.4.*"}}"#,
         );
         assert_eq!(
-            detect_php_version_from_composer(dir.path()),
+            detect_php_require_version_from_composer(dir.path()),
             Some(PHP_7_4.to_string())
-        );
-    }
-
-    #[test]
-    fn platform_config_takes_priority_over_require() {
-        let dir = tempfile::tempdir().unwrap();
-        write(
-            &dir.path().join("composer.json"),
-            r#"{"config": {"platform": {"php": "8.0.0"}}, "require": {"php": "^8.2"}}"#,
-        );
-        assert_eq!(
-            detect_php_version_from_composer(dir.path()),
-            Some(PHP_8_0.to_string())
         );
     }
 
     #[test]
     fn detect_version_returns_none_when_no_composer_json() {
         let dir = tempfile::tempdir().unwrap();
-        assert!(detect_php_version_from_composer(dir.path()).is_none());
+        assert!(detect_php_platform_version_from_composer(dir.path()).is_none());
+        assert!(detect_php_require_version_from_composer(dir.path()).is_none());
     }
 
     #[test]
@@ -477,6 +518,178 @@ mod tests {
             &dir.path().join("composer.json"),
             r#"{"require": {"some/package": "^1.0"}}"#,
         );
-        assert!(detect_php_version_from_composer(dir.path()).is_none());
+        assert!(detect_php_require_version_from_composer(dir.path()).is_none());
+    }
+
+    #[test]
+    fn detect_version_or_constraint_picks_highest() {
+        // "^7.4 || ^8.1" — should return 8.1, not 7.4
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            &dir.path().join("composer.json"),
+            r#"{"require": {"php": "^7.4 || ^8.1"}}"#,
+        );
+        assert_eq!(
+            detect_php_require_version_from_composer(dir.path()),
+            Some(PHP_8_1.to_string())
+        );
+    }
+
+    #[test]
+    fn detect_version_or_constraint_three_clauses() {
+        // "^7.4 || ^8.0 || ^8.2" — should return 8.2
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            &dir.path().join("composer.json"),
+            r#"{"require": {"php": "^7.4 || ^8.0 || ^8.2"}}"#,
+        );
+        assert_eq!(
+            detect_php_require_version_from_composer(dir.path()),
+            Some(PHP_8_2.to_string())
+        );
+    }
+
+    #[test]
+    fn detect_version_or_constraint_unsorted() {
+        // Clauses in non-ascending order — should still return the maximum
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            &dir.path().join("composer.json"),
+            r#"{"require": {"php": "^8.0 || ^7.4 || ^8.1"}}"#,
+        );
+        assert_eq!(
+            detect_php_require_version_from_composer(dir.path()),
+            Some(PHP_8_1.to_string())
+        );
+    }
+
+    // --- resolve_php_version_from_roots ---
+
+    #[test]
+    fn resolve_explicit_overrides_composer() {
+        // Explicit version wins even when composer.json has a different platform version.
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            &dir.path().join("composer.json"),
+            r#"{"config": {"platform": {"php": "8.0.0"}}}"#,
+        );
+        let (ver, source) =
+            resolve_php_version_from_roots(&[dir.path().to_path_buf()], Some("8.2"));
+        assert_eq!(ver, "8.2");
+        assert_eq!(source, "set by editor");
+    }
+
+    #[test]
+    fn resolve_platform_beats_require() {
+        // config.platform.php takes priority over require.php in the same composer.json.
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            &dir.path().join("composer.json"),
+            r#"{"config": {"platform": {"php": "8.0.0"}}, "require": {"php": "^8.2"}}"#,
+        );
+        let (ver, source) = resolve_php_version_from_roots(&[dir.path().to_path_buf()], None);
+        assert_eq!(ver, PHP_8_0);
+        assert_eq!(source, "composer.json config.platform.php");
+    }
+
+    #[test]
+    fn resolve_require_used_as_last_resort() {
+        // require.php is used when there is no platform config and the php binary
+        // is absent. We simulate "no binary" by having a roots list that provides
+        // a require constraint and asserting the source is "composer.json require"
+        // OR "php binary" (if PHP happens to be installed in CI).
+        //
+        // We can only assert that the version is at least the require lower bound
+        // since we cannot prevent the binary from being found.
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            &dir.path().join("composer.json"),
+            r#"{"require": {"php": "^8.3"}}"#,
+        );
+        let (ver, source) = resolve_php_version_from_roots(&[dir.path().to_path_buf()], None);
+        // If the binary was found its version may differ; what we can guarantee is
+        // that the source is one of the expected values and the version parses.
+        assert!(
+            source == "php binary" || source == "composer.json require" || source == "default",
+            "unexpected source: {source}"
+        );
+        assert!(ver.contains('.'), "version should be X.Y format, got {ver}");
+    }
+
+    #[test]
+    fn resolve_tilde_constraint() {
+        // "~8.1" means >=8.1 <9.0 — should detect 8.1.
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            &dir.path().join("composer.json"),
+            r#"{"require": {"php": "~8.1"}}"#,
+        );
+        assert_eq!(
+            detect_php_require_version_from_composer(dir.path()),
+            Some(PHP_8_1.to_string())
+        );
+    }
+
+    #[test]
+    fn resolve_default_when_no_composer_json_and_no_roots() {
+        // With no roots at all and no binary we fall back to the default.
+        // Since the binary may be present, accept either "php binary" or "default".
+        let (ver, source) = resolve_php_version_from_roots(&[], None);
+        assert!(
+            source == "php binary" || source == "default",
+            "unexpected source: {source}"
+        );
+        assert!(ver.contains('.'), "version should be X.Y format, got {ver}");
+    }
+
+    // --- parse_php_version_constraint edge cases ---
+
+    #[test]
+    fn constraint_empty_string_returns_none() {
+        assert!(parse_php_version_constraint("").is_none());
+    }
+
+    #[test]
+    fn constraint_wildcard_returns_none() {
+        // "*" means any version — we can't pin to a specific one.
+        assert!(parse_php_version_constraint("*").is_none());
+    }
+
+    #[test]
+    fn constraint_major_only_without_minor() {
+        // ">=8" has no minor component — treated as "8.0".
+        assert_eq!(parse_php_version_constraint(">=8"), Some("8.0".to_string()));
+    }
+
+    // --- extract_major_minor edge cases ---
+
+    #[test]
+    fn platform_version_major_only_returns_none() {
+        // "8" in config.platform.php has no minor — should not parse.
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            &dir.path().join("composer.json"),
+            r#"{"config": {"platform": {"php": "8"}}}"#,
+        );
+        assert!(detect_php_platform_version_from_composer(dir.path()).is_none());
+    }
+
+    // --- unsupported version ---
+
+    #[test]
+    fn resolve_unsupported_old_version_is_returned_from_require() {
+        // ">=5.6" parses to "5.6" — not in SUPPORTED_PHP_VERSIONS.
+        // resolve_php_version_from_roots still returns it; the caller is
+        // responsible for emitting a warning (tested at the backend level).
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            &dir.path().join("composer.json"),
+            r#"{"require": {"php": ">=5.6"}}"#,
+        );
+        assert_eq!(
+            detect_php_require_version_from_composer(dir.path()),
+            Some("5.6".to_string())
+        );
+        assert!(!is_valid_php_version("5.6"));
     }
 }

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -185,6 +185,13 @@ impl Backend {
             .map(|r| r.clone())
             .unwrap_or_default()
     }
+
+    /// Resolve the PHP version to use. See `autoload::resolve_php_version_from_roots`
+    /// for the full priority order.
+    fn resolve_php_version(&self, explicit: Option<&str>) -> (String, &'static str) {
+        let roots = self.root_paths.read().unwrap().clone();
+        crate::autoload::resolve_php_version_from_roots(&roots, explicit)
+    }
 }
 
 #[async_trait]
@@ -228,16 +235,29 @@ impl LanguageServer for Backend {
                     )
                     .await;
             }
-            // Auto-detect PHP version from composer.json / php binary when the
-            // client has not set it explicitly (or set it to an invalid value).
-            if cfg.php_version.is_none() {
-                let roots = self.root_paths.read().unwrap().clone();
-                cfg.php_version = roots
-                    .iter()
-                    .find_map(|root| crate::autoload::detect_php_version_from_composer(root))
-                    .or_else(crate::autoload::detect_php_binary_version)
-                    .or_else(|| Some(LspConfig::DEFAULT_PHP_VERSION.to_string()));
+            // Resolve the PHP version and log what was chosen and why.
+            let (ver, source) = self.resolve_php_version(cfg.php_version.as_deref());
+            self.client
+                .log_message(
+                    tower_lsp::lsp_types::MessageType::INFO,
+                    format!("php-lsp: using PHP {ver} ({source})"),
+                )
+                .await;
+            // Show a visible warning when auto-detection yields a version outside
+            // our supported range (e.g. a legacy project with ">=5.6" in composer.json).
+            if source != "set by editor" && !crate::autoload::is_valid_php_version(&ver) {
+                self.client
+                    .show_message(
+                        tower_lsp::lsp_types::MessageType::WARNING,
+                        format!(
+                            "php-lsp: detected PHP {ver} is outside the supported range ({}); \
+                             analysis may be inaccurate",
+                            crate::autoload::SUPPORTED_PHP_VERSIONS.join(", ")
+                        ),
+                    )
+                    .await;
             }
+            cfg.php_version = Some(ver);
             *self.config.write().unwrap() = cfg;
         }
 
@@ -503,14 +523,27 @@ impl LanguageServer for Backend {
                     )
                     .await;
             }
-            if cfg.php_version.is_none() {
-                let roots = self.root_paths.read().unwrap().clone();
-                cfg.php_version = roots
-                    .iter()
-                    .find_map(|root| crate::autoload::detect_php_version_from_composer(root))
-                    .or_else(crate::autoload::detect_php_binary_version)
-                    .or_else(|| Some(LspConfig::DEFAULT_PHP_VERSION.to_string()));
+            // Resolve the PHP version and log what was chosen and why.
+            let (ver, source) = self.resolve_php_version(cfg.php_version.as_deref());
+            self.client
+                .log_message(
+                    tower_lsp::lsp_types::MessageType::INFO,
+                    format!("php-lsp: using PHP {ver} ({source})"),
+                )
+                .await;
+            if source != "set by editor" && !crate::autoload::is_valid_php_version(&ver) {
+                self.client
+                    .show_message(
+                        tower_lsp::lsp_types::MessageType::WARNING,
+                        format!(
+                            "php-lsp: detected PHP {ver} is outside the supported range ({}); \
+                             analysis may be inaccurate",
+                            crate::autoload::SUPPORTED_PHP_VERSIONS.join(", ")
+                        ),
+                    )
+                    .await;
             }
+            cfg.php_version = Some(ver);
             *self.config.write().unwrap() = cfg;
         }
     }
@@ -1520,8 +1553,12 @@ impl LanguageServer for Backend {
                 ));
             }
         };
-        let diag_cfg = self.config.read().unwrap().diagnostics.clone();
-        let sem_diags = semantic_diagnostics(uri, &doc, &self.codebase, &diag_cfg);
+        let (diag_cfg, php_version) = {
+            let cfg = self.config.read().unwrap();
+            (cfg.diagnostics.clone(), cfg.php_version.clone())
+        };
+        let sem_diags =
+            semantic_diagnostics(uri, &doc, &self.codebase, &diag_cfg, php_version.as_deref());
         let dup_diags = duplicate_declaration_diagnostics(&source, &doc, &diag_cfg);
 
         let mut items = parse_diags;
@@ -1544,7 +1581,10 @@ impl LanguageServer for Backend {
         _params: WorkspaceDiagnosticParams,
     ) -> Result<WorkspaceDiagnosticReportResult> {
         let all_parse_diags = self.docs.all_diagnostics();
-        let diag_cfg = self.config.read().unwrap().diagnostics.clone();
+        let (diag_cfg, php_version) = {
+            let cfg = self.config.read().unwrap();
+            (cfg.diagnostics.clone(), cfg.php_version.clone())
+        };
 
         let items: Vec<WorkspaceDocumentDiagnosticReport> = all_parse_diags
             .into_iter()
@@ -1552,7 +1592,13 @@ impl LanguageServer for Backend {
                 let doc = self.docs.get_doc(&uri)?;
 
                 let source = doc.source().to_string();
-                let sem_diags = semantic_diagnostics(&uri, &doc, &self.codebase, &diag_cfg);
+                let sem_diags = semantic_diagnostics(
+                    &uri,
+                    &doc,
+                    &self.codebase,
+                    &diag_cfg,
+                    php_version.as_deref(),
+                );
                 let dup_diags = duplicate_declaration_diagnostics(&source, &doc, &diag_cfg);
 
                 let mut all_diags = parse_diags;
@@ -1587,8 +1633,12 @@ impl LanguageServer for Backend {
         let other_docs = self.docs.other_docs(uri);
 
         // Semantic diagnostics — collect undefined symbols and offer "Add use import"
-        let diag_cfg = self.config.read().unwrap().diagnostics.clone();
-        let sem_diags = semantic_diagnostics(uri, &doc, &self.codebase, &diag_cfg);
+        let (diag_cfg, php_version) = {
+            let cfg = self.config.read().unwrap();
+            (cfg.diagnostics.clone(), cfg.php_version.clone())
+        };
+        let sem_diags =
+            semantic_diagnostics(uri, &doc, &self.codebase, &diag_cfg, php_version.as_deref());
 
         // Publish semantic diagnostics merged with existing parse diagnostics
         if !sem_diags.is_empty() {

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -242,6 +242,8 @@ impl LanguageServer for Backend {
                 .await;
             // Show a visible warning when auto-detection yields a version outside
             // our supported range (e.g. a legacy project with ">=5.6" in composer.json).
+            // TODO: instead of storing and using the unsupported version, consider clamping
+            // it to the nearest supported version so analysis stays meaningful.
             if source != "set by editor" && !crate::autoload::is_valid_php_version(&ver) {
                 self.client
                     .show_message(
@@ -528,6 +530,8 @@ impl LanguageServer for Backend {
                     format!("php-lsp: using PHP {ver} ({source})"),
                 )
                 .await;
+            // TODO: instead of storing and using the unsupported version, consider clamping
+            // it to the nearest supported version so analysis stays meaningful.
             if source != "set by editor" && !crate::autoload::is_valid_php_version(&ver) {
                 self.client
                     .show_message(

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -2726,4 +2726,661 @@ mod integration {
         );
         assert!(resp["result"].is_null(), "shutdown result should be null");
     }
+
+    /// Open a document and wait for the async parser to finish.
+    async fn open_doc(client: &mut TestClient, uri: &str, text: &str) {
+        client
+            .notify(
+                "textDocument/didOpen",
+                serde_json::json!({
+                    "textDocument": {
+                        "uri": uri,
+                        "languageId": "php",
+                        "version": 1,
+                        "text": text
+                    }
+                }),
+            )
+            .await;
+        // Parser is debounced 100 ms; give it a little extra.
+        tokio::time::sleep(tokio::time::Duration::from_millis(150)).await;
+    }
+
+    // ── go-to-definition ─────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn definition_returns_location_for_function() {
+        let mut client = start_server();
+        initialize(&mut client).await;
+
+        open_doc(
+            &mut client,
+            "file:///def.php",
+            "<?php\nfunction greet(string $name): string { return $name; }\ngreet('world');\n",
+        )
+        .await;
+
+        // Cursor on `greet` in the call on line 2, char 0.
+        let resp = client
+            .request(
+                "textDocument/definition",
+                serde_json::json!({
+                    "textDocument": { "uri": "file:///def.php" },
+                    "position": { "line": 2, "character": 1 }
+                }),
+            )
+            .await;
+
+        assert!(resp["error"].is_null(), "definition error: {:?}", resp);
+        // Result is either a Location object or an array of Locations.
+        let result = &resp["result"];
+        assert!(
+            !result.is_null(),
+            "expected a definition location, got null"
+        );
+        let loc = if result.is_array() {
+            result[0].clone()
+        } else {
+            result.clone()
+        };
+        assert_eq!(
+            loc["uri"].as_str().unwrap(),
+            "file:///def.php",
+            "definition should point to same file"
+        );
+        assert_eq!(
+            loc["range"]["start"]["line"].as_u64().unwrap(),
+            1,
+            "definition should point to line 1 (the declaration)"
+        );
+    }
+
+    #[tokio::test]
+    async fn definition_for_class_returns_location() {
+        let mut client = start_server();
+        initialize(&mut client).await;
+
+        open_doc(
+            &mut client,
+            "file:///cls.php",
+            "<?php\nclass Dog {}\n$d = new Dog();\n",
+        )
+        .await;
+
+        // Cursor on `Dog` in `new Dog()` — line 2, char 9 ('D').
+        let resp = client
+            .request(
+                "textDocument/definition",
+                serde_json::json!({
+                    "textDocument": { "uri": "file:///cls.php" },
+                    "position": { "line": 2, "character": 9 }
+                }),
+            )
+            .await;
+
+        assert!(resp["error"].is_null(), "definition error: {:?}", resp);
+        let result = &resp["result"];
+        assert!(!result.is_null(), "expected a location for class Dog");
+        let loc = if result.is_array() {
+            result[0].clone()
+        } else {
+            result.clone()
+        };
+        assert_eq!(
+            loc["range"]["start"]["line"].as_u64().unwrap(),
+            1,
+            "Dog declared on line 1"
+        );
+    }
+
+    // ── go-to-declaration ────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn declaration_returns_location_for_abstract_method() {
+        let mut client = start_server();
+        initialize(&mut client).await;
+
+        open_doc(
+            &mut client,
+            "file:///abs.php",
+            "<?php\nabstract class Animal {\n    abstract public function speak(): string;\n}\nclass Cat extends Animal {\n    public function speak(): string { return 'meow'; }\n}\n",
+        )
+        .await;
+
+        // Cursor on concrete `speak` on line 5, char 20.
+        let resp = client
+            .request(
+                "textDocument/declaration",
+                serde_json::json!({
+                    "textDocument": { "uri": "file:///abs.php" },
+                    "position": { "line": 5, "character": 20 }
+                }),
+            )
+            .await;
+
+        assert!(resp["error"].is_null(), "declaration error: {:?}", resp);
+        // A null result is acceptable (not all LSPs support this); a non-null result
+        // must point at a valid location in the same file.
+        if !resp["result"].is_null() {
+            let result = &resp["result"];
+            let loc = if result.is_array() {
+                result[0].clone()
+            } else {
+                result.clone()
+            };
+            assert_eq!(loc["uri"].as_str().unwrap(), "file:///abs.php");
+        }
+    }
+
+    // ── find references ──────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn references_finds_all_usages_of_function() {
+        let mut client = start_server();
+        initialize(&mut client).await;
+
+        // One declaration (line 1) + two call sites (lines 2, 3).
+        open_doc(
+            &mut client,
+            "file:///refs.php",
+            "<?php\nfunction add(int $a, int $b): int { return $a + $b; }\nadd(1, 2);\nadd(3, 4);\n",
+        )
+        .await;
+
+        // Cursor on `add` declaration — line 1, char 9.
+        let resp = client
+            .request(
+                "textDocument/references",
+                serde_json::json!({
+                    "textDocument": { "uri": "file:///refs.php" },
+                    "position": { "line": 1, "character": 9 },
+                    "context": { "includeDeclaration": true }
+                }),
+            )
+            .await;
+
+        assert!(resp["error"].is_null(), "references error: {:?}", resp);
+        let result = &resp["result"];
+        assert!(
+            result.is_array(),
+            "references should return an array, got: {:?}",
+            result
+        );
+        let locs = result.as_array().unwrap();
+        // Must include the declaration (line 1) AND both call sites (lines 2, 3).
+        assert_eq!(
+            locs.len(),
+            3,
+            "expected 3 references (1 declaration + 2 calls), got: {:?}",
+            locs
+        );
+        let lines: Vec<u64> = locs
+            .iter()
+            .map(|l| l["range"]["start"]["line"].as_u64().unwrap())
+            .collect();
+        assert!(
+            lines.contains(&1),
+            "declaration on line 1 must be included with includeDeclaration=true, got lines: {:?}",
+            lines
+        );
+        assert!(lines.contains(&2), "call on line 2 must be included");
+        assert!(lines.contains(&3), "call on line 3 must be included");
+    }
+
+    #[tokio::test]
+    async fn references_with_exclude_declaration() {
+        let mut client = start_server();
+        initialize(&mut client).await;
+
+        open_doc(
+            &mut client,
+            "file:///refs2.php",
+            "<?php\nfunction sub(int $a, int $b): int { return $a - $b; }\nsub(10, 3);\n",
+        )
+        .await;
+
+        let resp = client
+            .request(
+                "textDocument/references",
+                serde_json::json!({
+                    "textDocument": { "uri": "file:///refs2.php" },
+                    "position": { "line": 1, "character": 9 },
+                    "context": { "includeDeclaration": false }
+                }),
+            )
+            .await;
+
+        assert!(resp["error"].is_null(), "references error: {:?}", resp);
+        let result = &resp["result"];
+        // With includeDeclaration: false we should get only call sites.
+        if result.is_array() {
+            let locs = result.as_array().unwrap();
+            for loc in locs {
+                // None of them should be on line 1 (the declaration line).
+                assert_ne!(
+                    loc["range"]["start"]["line"].as_u64().unwrap(),
+                    1,
+                    "declaration line should be excluded: {:?}",
+                    loc
+                );
+            }
+        }
+    }
+
+    // ── go-to-type-definition ────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn type_definition_for_typed_variable() {
+        let mut client = start_server();
+        initialize(&mut client).await;
+
+        open_doc(
+            &mut client,
+            "file:///typedef.php",
+            "<?php\nclass Point { public int $x; public int $y; }\n$p = new Point();\n$p->x;\n",
+        )
+        .await;
+
+        // Cursor on `$p` in `$p->x` — line 3, char 1.
+        let resp = client
+            .request(
+                "textDocument/typeDefinition",
+                serde_json::json!({
+                    "textDocument": { "uri": "file:///typedef.php" },
+                    "position": { "line": 3, "character": 1 }
+                }),
+            )
+            .await;
+
+        assert!(resp["error"].is_null(), "typeDefinition error: {:?}", resp);
+        // Null is acceptable if type inference doesn't resolve here; a location must be valid.
+        if !resp["result"].is_null() {
+            let result = &resp["result"];
+            let loc = if result.is_array() {
+                result[0].clone()
+            } else {
+                result.clone()
+            };
+            // Should point at the `Point` class declaration on line 1.
+            assert_eq!(
+                loc["range"]["start"]["line"].as_u64().unwrap(),
+                1,
+                "type definition should point to Point class"
+            );
+        }
+    }
+
+    // ── implementation ───────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn implementation_finds_concrete_class() {
+        let mut client = start_server();
+        initialize(&mut client).await;
+
+        open_doc(
+            &mut client,
+            "file:///impl.php",
+            "<?php\ninterface Drawable {\n    public function draw(): void;\n}\nclass Circle implements Drawable {\n    public function draw(): void {}\n}\n",
+        )
+        .await;
+
+        // Cursor on `Drawable` interface — line 1, char 10.
+        let resp = client
+            .request(
+                "textDocument/implementation",
+                serde_json::json!({
+                    "textDocument": { "uri": "file:///impl.php" },
+                    "position": { "line": 1, "character": 10 }
+                }),
+            )
+            .await;
+
+        assert!(resp["error"].is_null(), "implementation error: {:?}", resp);
+        if !resp["result"].is_null() {
+            let result = &resp["result"];
+            let locs = if result.is_array() {
+                result.as_array().unwrap().clone()
+            } else {
+                vec![result.clone()]
+            };
+            assert!(
+                !locs.is_empty(),
+                "expected at least one implementation (Circle)"
+            );
+        }
+    }
+
+    // ── signature help ───────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn signature_help_inside_function_call() {
+        let mut client = start_server();
+        initialize(&mut client).await;
+
+        open_doc(
+            &mut client,
+            "file:///sig.php",
+            "<?php\nfunction multiply(int $a, int $b): int { return $a * $b; }\nmultiply(2, \n",
+        )
+        .await;
+
+        // Cursor inside the argument list — line 2, char 11 (after the comma).
+        let resp = client
+            .request(
+                "textDocument/signatureHelp",
+                serde_json::json!({
+                    "textDocument": { "uri": "file:///sig.php" },
+                    "position": { "line": 2, "character": 11 }
+                }),
+            )
+            .await;
+
+        assert!(resp["error"].is_null(), "signatureHelp error: {:?}", resp);
+        if !resp["result"].is_null() {
+            let sigs = &resp["result"]["signatures"];
+            assert!(
+                sigs.is_array() && !sigs.as_array().unwrap().is_empty(),
+                "expected at least one signature"
+            );
+        }
+    }
+
+    // ── document symbols ─────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn document_symbols_lists_functions_and_classes() {
+        let mut client = start_server();
+        initialize(&mut client).await;
+
+        open_doc(
+            &mut client,
+            "file:///syms.php",
+            "<?php\nfunction hello(): void {}\nclass World {}\n",
+        )
+        .await;
+
+        let resp = client
+            .request(
+                "textDocument/documentSymbol",
+                serde_json::json!({
+                    "textDocument": { "uri": "file:///syms.php" }
+                }),
+            )
+            .await;
+
+        assert!(resp["error"].is_null(), "documentSymbol error: {:?}", resp);
+        let result = &resp["result"];
+        assert!(
+            result.is_array(),
+            "documentSymbol should return an array, got: {:?}",
+            result
+        );
+        let syms = result.as_array().unwrap();
+        assert!(
+            syms.len() >= 2,
+            "expected at least 2 symbols (hello, World), got {}",
+            syms.len()
+        );
+        let names: Vec<&str> = syms.iter().filter_map(|s| s["name"].as_str()).collect();
+        assert!(names.contains(&"hello"), "missing symbol 'hello'");
+        assert!(names.contains(&"World"), "missing symbol 'World'");
+    }
+
+    // ── document highlight ────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn document_highlight_marks_occurrences() {
+        let mut client = start_server();
+        initialize(&mut client).await;
+
+        open_doc(
+            &mut client,
+            "file:///hl.php",
+            "<?php\nfunction run(): void {}\nrun();\nrun();\n",
+        )
+        .await;
+
+        // Cursor on `run` declaration — line 1, char 9.
+        let resp = client
+            .request(
+                "textDocument/documentHighlight",
+                serde_json::json!({
+                    "textDocument": { "uri": "file:///hl.php" },
+                    "position": { "line": 1, "character": 9 }
+                }),
+            )
+            .await;
+
+        assert!(
+            resp["error"].is_null(),
+            "documentHighlight error: {:?}",
+            resp
+        );
+        if !resp["result"].is_null() {
+            let result = &resp["result"];
+            let empty = vec![];
+            let highlights = result.as_array().unwrap_or(&empty);
+            assert!(
+                highlights.len() >= 2,
+                "expected at least 2 highlights (declaration + 2 calls), got {}",
+                highlights.len()
+            );
+        }
+    }
+
+    // ── inlay hints ──────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn inlay_hints_returned_for_function_call() {
+        let mut client = start_server();
+        initialize(&mut client).await;
+
+        open_doc(
+            &mut client,
+            "file:///hints.php",
+            "<?php\nfunction divide(int $dividend, int $divisor): float { return $dividend / $divisor; }\ndivide(10, 2);\n",
+        )
+        .await;
+
+        let resp = client
+            .request(
+                "textDocument/inlayHint",
+                serde_json::json!({
+                    "textDocument": { "uri": "file:///hints.php" },
+                    "range": {
+                        "start": { "line": 0, "character": 0 },
+                        "end":   { "line": 3, "character": 0 }
+                    }
+                }),
+            )
+            .await;
+
+        assert!(resp["error"].is_null(), "inlayHint error: {:?}", resp);
+        // Result is either null or an array — both are valid.
+        let result = &resp["result"];
+        assert!(
+            result.is_null() || result.is_array(),
+            "unexpected inlayHint result shape: {:?}",
+            result
+        );
+    }
+
+    // ── rename ───────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn rename_function_produces_workspace_edit() {
+        let mut client = start_server();
+        initialize(&mut client).await;
+
+        open_doc(
+            &mut client,
+            "file:///ren.php",
+            "<?php\nfunction oldName(): void {}\noldName();\n",
+        )
+        .await;
+
+        // Cursor on `oldName` declaration — line 1, char 9.
+        let resp = client
+            .request(
+                "textDocument/rename",
+                serde_json::json!({
+                    "textDocument": { "uri": "file:///ren.php" },
+                    "position": { "line": 1, "character": 9 },
+                    "newName": "newName"
+                }),
+            )
+            .await;
+
+        assert!(resp["error"].is_null(), "rename error: {:?}", resp);
+        if !resp["result"].is_null() {
+            // WorkspaceEdit must have either `changes` or `documentChanges`.
+            let result = &resp["result"];
+            assert!(
+                result.get("changes").is_some() || result.get("documentChanges").is_some(),
+                "rename result should be a WorkspaceEdit: {:?}",
+                result
+            );
+        }
+    }
+
+    // ── folding ranges ────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn folding_ranges_returned_for_class() {
+        let mut client = start_server();
+        initialize(&mut client).await;
+
+        open_doc(
+            &mut client,
+            "file:///fold.php",
+            "<?php\nclass Folded {\n    public function method(): void {\n        // body\n    }\n}\n",
+        )
+        .await;
+
+        let resp = client
+            .request(
+                "textDocument/foldingRange",
+                serde_json::json!({
+                    "textDocument": { "uri": "file:///fold.php" }
+                }),
+            )
+            .await;
+
+        assert!(resp["error"].is_null(), "foldingRange error: {:?}", resp);
+        let result = &resp["result"];
+        assert!(
+            result.is_null() || result.is_array(),
+            "foldingRange should return an array or null: {:?}",
+            result
+        );
+        if result.is_array() {
+            assert!(
+                !result.as_array().unwrap().is_empty(),
+                "expected at least one fold range for class/method"
+            );
+        }
+    }
+
+    // ── semantic tokens ───────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn semantic_tokens_full_returned() {
+        let mut client = start_server();
+        initialize(&mut client).await;
+
+        open_doc(
+            &mut client,
+            "file:///tokens.php",
+            "<?php\nfunction tokenized(int $x): int { return $x; }\n",
+        )
+        .await;
+
+        let resp = client
+            .request(
+                "textDocument/semanticTokens/full",
+                serde_json::json!({
+                    "textDocument": { "uri": "file:///tokens.php" }
+                }),
+            )
+            .await;
+
+        assert!(
+            resp["error"].is_null(),
+            "semanticTokens/full error: {:?}",
+            resp
+        );
+        if !resp["result"].is_null() {
+            let data = &resp["result"]["data"];
+            assert!(
+                data.is_array(),
+                "semantic tokens data should be an array: {:?}",
+                data
+            );
+        }
+    }
+
+    // ── code lens ─────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn code_lens_returned_for_function() {
+        let mut client = start_server();
+        initialize(&mut client).await;
+
+        open_doc(
+            &mut client,
+            "file:///lens.php",
+            "<?php\nfunction lensed(): void {}\nlensed();\n",
+        )
+        .await;
+
+        let resp = client
+            .request(
+                "textDocument/codeLens",
+                serde_json::json!({
+                    "textDocument": { "uri": "file:///lens.php" }
+                }),
+            )
+            .await;
+
+        assert!(resp["error"].is_null(), "codeLens error: {:?}", resp);
+        let result = &resp["result"];
+        assert!(
+            result.is_null() || result.is_array(),
+            "codeLens should return an array or null: {:?}",
+            result
+        );
+    }
+
+    // ── selection range ───────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn selection_range_expands_from_position() {
+        let mut client = start_server();
+        initialize(&mut client).await;
+
+        open_doc(
+            &mut client,
+            "file:///sel.php",
+            "<?php\nfunction select(int $x): int { return $x + 1; }\n",
+        )
+        .await;
+
+        let resp = client
+            .request(
+                "textDocument/selectionRange",
+                serde_json::json!({
+                    "textDocument": { "uri": "file:///sel.php" },
+                    "positions": [{ "line": 1, "character": 30 }]
+                }),
+            )
+            .await;
+
+        assert!(resp["error"].is_null(), "selectionRange error: {:?}", resp);
+        let result = &resp["result"];
+        assert!(
+            result.is_null() || result.is_array(),
+            "selectionRange should return an array or null: {:?}",
+            result
+        );
+    }
 }

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -124,9 +124,6 @@ pub struct LspConfig {
 }
 
 impl LspConfig {
-    /// PHP version used when auto-detection yields no result.
-    const DEFAULT_PHP_VERSION: &str = crate::autoload::PHP_8_5;
-
     fn from_value(v: &serde_json::Value) -> Self {
         let mut cfg = LspConfig::default();
         if let Some(ver) = v.get("phpVersion").and_then(|x| x.as_str())

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -2788,10 +2788,16 @@ mod integration {
             "file:///def.php",
             "definition should point to same file"
         );
+        // `function greet` — `function ` is 9 chars, so `greet` starts at char 9.
         assert_eq!(
             loc["range"]["start"]["line"].as_u64().unwrap(),
             1,
             "definition should point to line 1 (the declaration)"
+        );
+        assert_eq!(
+            loc["range"]["start"]["character"].as_u64().unwrap(),
+            9,
+            "definition should point to the function name at char 9, not the 'function' keyword"
         );
     }
 
@@ -2826,10 +2832,16 @@ mod integration {
         } else {
             result.clone()
         };
+        // `class Dog {}` — `class ` is 6 chars, so `Dog` starts at char 6.
         assert_eq!(
             loc["range"]["start"]["line"].as_u64().unwrap(),
             1,
             "Dog declared on line 1"
+        );
+        assert_eq!(
+            loc["range"]["start"]["character"].as_u64().unwrap(),
+            6,
+            "Dog name starts at char 6, not at the 'class' keyword"
         );
     }
 
@@ -2859,17 +2871,30 @@ mod integration {
             .await;
 
         assert!(resp["error"].is_null(), "declaration error: {:?}", resp);
-        // A null result is acceptable (not all LSPs support this); a non-null result
-        // must point at a valid location in the same file.
-        if !resp["result"].is_null() {
-            let result = &resp["result"];
-            let loc = if result.is_array() {
-                result[0].clone()
-            } else {
-                result.clone()
-            };
-            assert_eq!(loc["uri"].as_str().unwrap(), "file:///abs.php");
-        }
+        // go-to-declaration from a concrete override must return the abstract declaration.
+        let result = &resp["result"];
+        assert!(
+            !result.is_null(),
+            "expected a declaration location for concrete speak(), got null"
+        );
+        let loc = if result.is_array() {
+            result[0].clone()
+        } else {
+            result.clone()
+        };
+        assert_eq!(loc["uri"].as_str().unwrap(), "file:///abs.php");
+        // Abstract `speak` is on line 2: `    abstract public function speak()…`
+        // `    abstract public function ` = 4+9+7+9 = 29 chars → char 29.
+        assert_eq!(
+            loc["range"]["start"]["line"].as_u64().unwrap(),
+            2,
+            "should point to the abstract declaration on line 2"
+        );
+        assert_eq!(
+            loc["range"]["start"]["character"].as_u64().unwrap(),
+            29,
+            "should point to the method name, not the 'abstract' keyword"
+        );
     }
 
     // ── find references ──────────────────────────────────────────────────────
@@ -2952,19 +2977,29 @@ mod integration {
 
         assert!(resp["error"].is_null(), "references error: {:?}", resp);
         let result = &resp["result"];
-        // With includeDeclaration: false we should get only call sites.
-        if result.is_array() {
-            let locs = result.as_array().unwrap();
-            for loc in locs {
-                // None of them should be on line 1 (the declaration line).
-                assert_ne!(
-                    loc["range"]["start"]["line"].as_u64().unwrap(),
-                    1,
-                    "declaration line should be excluded: {:?}",
-                    loc
-                );
-            }
-        }
+        // With includeDeclaration: false, the only result must be the call on line 2.
+        assert!(
+            result.is_array(),
+            "expected an array of references, got: {:?}",
+            result
+        );
+        let locs = result.as_array().unwrap();
+        assert_eq!(
+            locs.len(),
+            1,
+            "expected exactly 1 call-site reference (sub on line 2), got: {:?}",
+            locs
+        );
+        assert_eq!(
+            locs[0]["range"]["start"]["line"].as_u64().unwrap(),
+            2,
+            "call site should be on line 2, not the declaration line 1"
+        );
+        assert_eq!(
+            locs[0]["range"]["start"]["character"].as_u64().unwrap(),
+            0,
+            "call starts at char 0"
+        );
     }
 
     // ── go-to-type-definition ────────────────────────────────────────────────
@@ -2993,21 +3028,28 @@ mod integration {
             .await;
 
         assert!(resp["error"].is_null(), "typeDefinition error: {:?}", resp);
-        // Null is acceptable if type inference doesn't resolve here; a location must be valid.
-        if !resp["result"].is_null() {
-            let result = &resp["result"];
-            let loc = if result.is_array() {
-                result[0].clone()
-            } else {
-                result.clone()
-            };
-            // Should point at the `Point` class declaration on line 1.
-            assert_eq!(
-                loc["range"]["start"]["line"].as_u64().unwrap(),
-                1,
-                "type definition should point to Point class"
-            );
-        }
+        // Type inference resolves `$p` to `Point`; result must be non-null.
+        let result = &resp["result"];
+        assert!(
+            !result.is_null(),
+            "expected typeDefinition to resolve $p to Point, got null"
+        );
+        let loc = if result.is_array() {
+            result[0].clone()
+        } else {
+            result.clone()
+        };
+        // `class Point` — `class ` is 6 chars, `Point` starts at char 6 on line 1.
+        assert_eq!(
+            loc["range"]["start"]["line"].as_u64().unwrap(),
+            1,
+            "type definition should point to Point class on line 1"
+        );
+        assert_eq!(
+            loc["range"]["start"]["character"].as_u64().unwrap(),
+            6,
+            "type definition should point to the class name, not the 'class' keyword"
+        );
     }
 
     // ── implementation ───────────────────────────────────────────────────────
@@ -3036,18 +3078,27 @@ mod integration {
             .await;
 
         assert!(resp["error"].is_null(), "implementation error: {:?}", resp);
-        if !resp["result"].is_null() {
-            let result = &resp["result"];
-            let locs = if result.is_array() {
-                result.as_array().unwrap().clone()
-            } else {
-                vec![result.clone()]
-            };
-            assert!(
-                !locs.is_empty(),
-                "expected at least one implementation (Circle)"
-            );
-        }
+        let result = &resp["result"];
+        assert!(
+            result.is_array(),
+            "implementation must return an array: {:?}",
+            result
+        );
+        let locs = result.as_array().unwrap();
+        assert!(
+            !locs.is_empty(),
+            "expected at least one implementation (Circle)"
+        );
+        // `class Circle` — `class ` is 6 chars, `Circle` starts at char 6 on line 4.
+        let circle = locs
+            .iter()
+            .find(|l| l["range"]["start"]["line"].as_u64() == Some(4))
+            .expect("expected an implementation result on line 4 (class Circle)");
+        assert_eq!(
+            circle["range"]["start"]["character"].as_u64().unwrap(),
+            6,
+            "Circle class name should start at char 6, not the 'class' keyword"
+        );
     }
 
     // ── signature help ───────────────────────────────────────────────────────
@@ -3076,13 +3127,23 @@ mod integration {
             .await;
 
         assert!(resp["error"].is_null(), "signatureHelp error: {:?}", resp);
-        if !resp["result"].is_null() {
-            let sigs = &resp["result"]["signatures"];
-            assert!(
-                sigs.is_array() && !sigs.as_array().unwrap().is_empty(),
-                "expected at least one signature"
-            );
-        }
+        // Cursor is after the comma in `multiply(2, ` → second parameter (index 1).
+        let result = &resp["result"];
+        assert!(!result.is_null(), "expected signatureHelp result, got null");
+        let sigs = result["signatures"]
+            .as_array()
+            .expect("signatures must be an array");
+        assert!(!sigs.is_empty(), "expected at least one signature");
+        assert_eq!(
+            sigs[0]["label"].as_str().unwrap(),
+            "multiply(int $a, int $b)",
+            "signature label should show the full parameter list"
+        );
+        assert_eq!(
+            result["activeParameter"].as_u64().unwrap(),
+            1,
+            "cursor after first comma → activeParameter should be 1"
+        );
     }
 
     // ── document symbols ─────────────────────────────────────────────────────
@@ -3156,16 +3217,30 @@ mod integration {
             "documentHighlight error: {:?}",
             resp
         );
-        if !resp["result"].is_null() {
-            let result = &resp["result"];
-            let empty = vec![];
-            let highlights = result.as_array().unwrap_or(&empty);
-            assert!(
-                highlights.len() >= 2,
-                "expected at least 2 highlights (declaration + 2 calls), got {}",
-                highlights.len()
-            );
-        }
+        // Declaration on line 1 + two calls on lines 2 and 3 = 3 highlights.
+        let result = &resp["result"];
+        assert!(
+            result.is_array(),
+            "documentHighlight must return an array: {:?}",
+            result
+        );
+        let highlights = result.as_array().unwrap();
+        assert_eq!(
+            highlights.len(),
+            3,
+            "expected 3 highlights (1 declaration + 2 calls), got: {:?}",
+            highlights
+        );
+        let lines: Vec<u64> = highlights
+            .iter()
+            .map(|h| h["range"]["start"]["line"].as_u64().unwrap())
+            .collect();
+        assert!(
+            lines.contains(&1),
+            "declaration highlight missing on line 1"
+        );
+        assert!(lines.contains(&2), "call highlight missing on line 2");
+        assert!(lines.contains(&3), "call highlight missing on line 3");
     }
 
     // ── inlay hints ──────────────────────────────────────────────────────────
@@ -3196,12 +3271,30 @@ mod integration {
             .await;
 
         assert!(resp["error"].is_null(), "inlayHint error: {:?}", resp);
-        // Result is either null or an array — both are valid.
+        // `divide(10, 2)` has two named params → expect two hints: `dividend:` and `divisor:`.
         let result = &resp["result"];
         assert!(
-            result.is_null() || result.is_array(),
-            "unexpected inlayHint result shape: {:?}",
+            result.is_array(),
+            "expected inlayHint array, got: {:?}",
             result
+        );
+        let hints = result.as_array().unwrap();
+        assert_eq!(
+            hints.len(),
+            2,
+            "expected 2 inlay hints (dividend and divisor), got: {:?}",
+            hints
+        );
+        let labels: Vec<&str> = hints.iter().filter_map(|h| h["label"].as_str()).collect();
+        assert!(
+            labels.contains(&"dividend:"),
+            "missing hint 'dividend:', got: {:?}",
+            labels
+        );
+        assert!(
+            labels.contains(&"divisor:"),
+            "missing hint 'divisor:', got: {:?}",
+            labels
         );
     }
 
@@ -3232,15 +3325,39 @@ mod integration {
             .await;
 
         assert!(resp["error"].is_null(), "rename error: {:?}", resp);
-        if !resp["result"].is_null() {
-            // WorkspaceEdit must have either `changes` or `documentChanges`.
-            let result = &resp["result"];
-            assert!(
-                result.get("changes").is_some() || result.get("documentChanges").is_some(),
-                "rename result should be a WorkspaceEdit: {:?}",
-                result
-            );
-        }
+        let result = &resp["result"];
+        assert!(
+            !result.is_null(),
+            "expected rename to produce a WorkspaceEdit, got null"
+        );
+        // WorkspaceEdit must have either `changes` or `documentChanges`.
+        assert!(
+            result.get("changes").is_some() || result.get("documentChanges").is_some(),
+            "rename result should be a WorkspaceEdit: {:?}",
+            result
+        );
+        // One declaration (line 1) + one call (line 2) = 2 edits in the same file.
+        let file_edits = result["changes"]["file:///ren.php"]
+            .as_array()
+            .expect("expected edits for file:///ren.php");
+        assert_eq!(
+            file_edits.len(),
+            2,
+            "expected 2 edits (declaration + call), got: {:?}",
+            file_edits
+        );
+        let edited_lines: Vec<u64> = file_edits
+            .iter()
+            .map(|e| e["range"]["start"]["line"].as_u64().unwrap())
+            .collect();
+        assert!(
+            edited_lines.contains(&1),
+            "declaration on line 1 must be renamed"
+        );
+        assert!(
+            edited_lines.contains(&2),
+            "call site on line 2 must be renamed"
+        );
     }
 
     // ── folding ranges ────────────────────────────────────────────────────────
@@ -3267,18 +3384,32 @@ mod integration {
             .await;
 
         assert!(resp["error"].is_null(), "foldingRange error: {:?}", resp);
+        // Class (lines 1–5) + method (lines 2–4) = 2 fold ranges.
         let result = &resp["result"];
         assert!(
-            result.is_null() || result.is_array(),
-            "foldingRange should return an array or null: {:?}",
+            result.is_array(),
+            "foldingRange must return an array: {:?}",
             result
         );
-        if result.is_array() {
-            assert!(
-                !result.as_array().unwrap().is_empty(),
-                "expected at least one fold range for class/method"
-            );
-        }
+        let ranges = result.as_array().unwrap();
+        assert_eq!(
+            ranges.len(),
+            2,
+            "expected 2 fold ranges (class + method), got: {:?}",
+            ranges
+        );
+        let start_lines: Vec<u64> = ranges
+            .iter()
+            .map(|r| r["startLine"].as_u64().unwrap())
+            .collect();
+        assert!(
+            start_lines.contains(&1),
+            "missing class fold starting at line 1"
+        );
+        assert!(
+            start_lines.contains(&2),
+            "missing method fold starting at line 2"
+        );
     }
 
     // ── semantic tokens ───────────────────────────────────────────────────────
@@ -3309,14 +3440,17 @@ mod integration {
             "semanticTokens/full error: {:?}",
             resp
         );
-        if !resp["result"].is_null() {
-            let data = &resp["result"]["data"];
-            assert!(
-                data.is_array(),
-                "semantic tokens data should be an array: {:?}",
-                data
-            );
-        }
+        // A file with a function and typed parameters must produce non-empty token data.
+        let result = &resp["result"];
+        assert!(
+            !result.is_null(),
+            "expected semanticTokens result, got null"
+        );
+        let data = result["data"].as_array().expect("data must be an array");
+        assert!(
+            !data.is_empty(),
+            "expected non-empty semantic token data for a file with a typed function"
+        );
     }
 
     // ── code lens ─────────────────────────────────────────────────────────────
@@ -3343,11 +3477,25 @@ mod integration {
             .await;
 
         assert!(resp["error"].is_null(), "codeLens error: {:?}", resp);
+        // `lensed` has 1 call site → expect a "1 references" lens on the declaration.
         let result = &resp["result"];
         assert!(
-            result.is_null() || result.is_array(),
-            "codeLens should return an array or null: {:?}",
+            result.is_array(),
+            "codeLens must return an array: {:?}",
             result
+        );
+        let lenses = result.as_array().unwrap();
+        assert!(!lenses.is_empty(), "expected at least one code lens");
+        let has_ref_lens = lenses.iter().any(|l| {
+            l["command"]["title"]
+                .as_str()
+                .map(|t| t.contains("reference"))
+                .unwrap_or(false)
+        });
+        assert!(
+            has_ref_lens,
+            "expected a reference-count lens, got: {:?}",
+            lenses
         );
     }
 
@@ -3376,11 +3524,208 @@ mod integration {
             .await;
 
         assert!(resp["error"].is_null(), "selectionRange error: {:?}", resp);
+        // Cursor is inside the function body — must return at least one range.
+        // The outermost range must NOT use u32::MAX as the end character (Bug #2 fix).
         let result = &resp["result"];
         assert!(
-            result.is_null() || result.is_array(),
-            "selectionRange should return an array or null: {:?}",
+            result.is_array(),
+            "selectionRange must return an array: {:?}",
             result
         );
+        let items = result.as_array().unwrap();
+        assert!(
+            !items.is_empty(),
+            "expected at least one selectionRange entry"
+        );
+
+        // Walk to the outermost parent and verify its end character is spec-compliant.
+        let mut node = &items[0];
+        loop {
+            let end_char = node["range"]["end"]["character"].as_u64().unwrap_or(0);
+            assert_ne!(
+                end_char,
+                u32::MAX as u64,
+                "selectionRange end character must not be u32::MAX — use real line length"
+            );
+            if node["parent"].is_null() || !node["parent"].is_object() {
+                break;
+            }
+            node = &node["parent"];
+        }
+    }
+
+    // ── full probe (disabled; restore #[tokio::test] + run with --nocapture to inspect) ──
+
+    #[allow(dead_code)]
+    async fn probe_all_features() {
+        macro_rules! dump {
+            ($label:expr, $r:expr) => {
+                eprintln!(
+                    "\n=== {} ===\n{}",
+                    $label,
+                    serde_json::to_string_pretty(&$r["result"]).unwrap_or_default()
+                );
+            };
+        }
+
+        let mut client = start_server();
+        initialize(&mut client).await;
+
+        // ── definition ──────────────────────────────────────────────────────
+        open_doc(
+            &mut client,
+            "file:///p_def.php",
+            "<?php\nfunction greet(string $name): string { return $name; }\ngreet('world');\n",
+        )
+        .await;
+        dump!("definition/function (cursor on call line 2 char 1)",
+            client.request("textDocument/definition",
+                serde_json::json!({"textDocument":{"uri":"file:///p_def.php"},"position":{"line":2,"character":1}})).await);
+
+        // ── definition on cursor ON the declaration name ─────────────────────
+        dump!("definition/function (cursor on decl line 1 char 9)",
+            client.request("textDocument/definition",
+                serde_json::json!({"textDocument":{"uri":"file:///p_def.php"},"position":{"line":1,"character":9}})).await);
+
+        // ── references (now fixed) ───────────────────────────────────────────
+        dump!("references includeDeclaration=true",
+            client.request("textDocument/references",
+                serde_json::json!({"textDocument":{"uri":"file:///p_def.php"},"position":{"line":1,"character":9},"context":{"includeDeclaration":true}})).await);
+
+        dump!("references includeDeclaration=false",
+            client.request("textDocument/references",
+                serde_json::json!({"textDocument":{"uri":"file:///p_def.php"},"position":{"line":1,"character":9},"context":{"includeDeclaration":false}})).await);
+
+        // ── document symbols ─────────────────────────────────────────────────
+        open_doc(&mut client, "file:///p_syms.php",
+            "<?php\nfunction hello(): void {}\nclass World {}\nenum Color { case Red; }\ninterface Runnable {}\n").await;
+        dump!(
+            "documentSymbol",
+            client
+                .request(
+                    "textDocument/documentSymbol",
+                    serde_json::json!({"textDocument":{"uri":"file:///p_syms.php"}})
+                )
+                .await
+        );
+
+        // ── type definition ──────────────────────────────────────────────────
+        open_doc(
+            &mut client,
+            "file:///p_type.php",
+            "<?php\nclass Point { public int $x; public int $y; }\n$p = new Point();\n$p->x;\n",
+        )
+        .await;
+        dump!("typeDefinition ($p->x, cursor on $p line 3 char 1)",
+            client.request("textDocument/typeDefinition",
+                serde_json::json!({"textDocument":{"uri":"file:///p_type.php"},"position":{"line":3,"character":1}})).await);
+
+        // ── declaration ──────────────────────────────────────────────────────
+        open_doc(&mut client, "file:///p_decl.php",
+            "<?php\nabstract class Animal {\n    abstract public function speak(): string;\n}\nclass Cat extends Animal {\n    public function speak(): string { return 'meow'; }\n}\n").await;
+        dump!("declaration (concrete speak at line 5 char 20 -> abstract)",
+            client.request("textDocument/declaration",
+                serde_json::json!({"textDocument":{"uri":"file:///p_decl.php"},"position":{"line":5,"character":20}})).await);
+
+        // ── implementation ───────────────────────────────────────────────────
+        open_doc(&mut client, "file:///p_impl.php",
+            "<?php\ninterface Drawable {\n    public function draw(): void;\n}\nclass Circle implements Drawable {\n    public function draw(): void {}\n}\nclass Square implements Drawable {\n    public function draw(): void {}\n}\n").await;
+        dump!("implementation (Drawable interface line 1 char 10)",
+            client.request("textDocument/implementation",
+                serde_json::json!({"textDocument":{"uri":"file:///p_impl.php"},"position":{"line":1,"character":10}})).await);
+
+        // ── signature help ───────────────────────────────────────────────────
+        open_doc(&mut client, "file:///p_sig.php",
+            "<?php\nfunction divide(int $dividend, int $divisor): float { return $dividend / $divisor; }\ndivide(10, \n").await;
+        dump!("signatureHelp (inside second arg)",
+            client.request("textDocument/signatureHelp",
+                serde_json::json!({"textDocument":{"uri":"file:///p_sig.php"},"position":{"line":2,"character":10}})).await);
+
+        // ── document highlight ───────────────────────────────────────────────
+        open_doc(
+            &mut client,
+            "file:///p_hl.php",
+            "<?php\nfunction run(): void {}\nrun();\nrun();\n",
+        )
+        .await;
+        dump!("documentHighlight (run decl line 1 char 9)",
+            client.request("textDocument/documentHighlight",
+                serde_json::json!({"textDocument":{"uri":"file:///p_hl.php"},"position":{"line":1,"character":9}})).await);
+
+        // ── rename ───────────────────────────────────────────────────────────
+        open_doc(
+            &mut client,
+            "file:///p_ren.php",
+            "<?php\nfunction oldName(): void {}\noldName();\noldName();\n",
+        )
+        .await;
+        dump!("rename (oldName -> newName, decl at line 1 char 9)",
+            client.request("textDocument/rename",
+                serde_json::json!({"textDocument":{"uri":"file:///p_ren.php"},"position":{"line":1,"character":9},"newName":"newName"})).await);
+
+        // ── folding ranges ────────────────────────────────────────────────────
+        open_doc(&mut client, "file:///p_fold.php",
+            "<?php\nclass Folded {\n    public function method(): void {\n        // body\n    }\n}\n").await;
+        dump!(
+            "foldingRange",
+            client
+                .request(
+                    "textDocument/foldingRange",
+                    serde_json::json!({"textDocument":{"uri":"file:///p_fold.php"}})
+                )
+                .await
+        );
+
+        // ── semantic tokens ───────────────────────────────────────────────────
+        open_doc(
+            &mut client,
+            "file:///p_tok.php",
+            "<?php\nfunction tokenized(int $x): int { return $x; }\n",
+        )
+        .await;
+        dump!(
+            "semanticTokens/full (raw data)",
+            client
+                .request(
+                    "textDocument/semanticTokens/full",
+                    serde_json::json!({"textDocument":{"uri":"file:///p_tok.php"}})
+                )
+                .await
+        );
+
+        // ── code lens ────────────────────────────────────────────────────────
+        open_doc(
+            &mut client,
+            "file:///p_lens.php",
+            "<?php\nfunction lensed(): void {}\nlensed();\nlensed();\n",
+        )
+        .await;
+        dump!(
+            "codeLens",
+            client
+                .request(
+                    "textDocument/codeLens",
+                    serde_json::json!({"textDocument":{"uri":"file:///p_lens.php"}})
+                )
+                .await
+        );
+
+        // ── inlay hints ───────────────────────────────────────────────────────
+        open_doc(&mut client, "file:///p_hints.php",
+            "<?php\nfunction divide2(int $dividend, int $divisor): float { return $dividend / $divisor; }\ndivide2(10, 2);\n").await;
+        dump!("inlayHint",
+            client.request("textDocument/inlayHint",
+                serde_json::json!({"textDocument":{"uri":"file:///p_hints.php"},"range":{"start":{"line":0,"character":0},"end":{"line":3,"character":0}}})).await);
+
+        // ── selection range ───────────────────────────────────────────────────
+        open_doc(
+            &mut client,
+            "file:///p_sel.php",
+            "<?php\nfunction select(int $x): int { return $x + 1; }\n",
+        )
+        .await;
+        dump!("selectionRange (cursor inside return expr)",
+            client.request("textDocument/selectionRange",
+                serde_json::json!({"textDocument":{"uri":"file:///p_sel.php"},"positions":[{"line":1,"character":38}]})).await);
     }
 }

--- a/src/references.rs
+++ b/src/references.rs
@@ -63,7 +63,14 @@ fn find_references_inner(
         if include_use {
             // Rename path: always use the general walker so `use` imports are included.
             refs_in_stmts_with_use(source, stmts, word, &mut spans);
+        } else if include_declaration {
+            // The typed walkers only collect call sites and never emit declaration spans.
+            // When the caller wants declarations included, use the general walker which
+            // covers both declaration sites and call sites.
+            refs_in_stmts(source, stmts, word, &mut spans);
         } else {
+            // include_declaration=false: use typed walkers for precision.  They never
+            // emit declarations so no post-filtering is required.
             match kind {
                 Some(SymbolKind::Function) => function_refs_in_stmts(stmts, word, &mut spans),
                 Some(SymbolKind::Method) => method_refs_in_stmts(stmts, word, &mut spans),
@@ -73,6 +80,7 @@ fn find_references_inner(
         }
 
         if !include_declaration {
+            // Only reached via the general walker (kind=None) or include_use path.
             spans.retain(|span| !is_declaration_span(source, stmts, word, span));
         }
 

--- a/src/references.rs
+++ b/src/references.rs
@@ -60,28 +60,30 @@ fn find_references_inner(
         let source = doc.source();
         let stmts = &doc.program().stmts;
         let mut spans = Vec::new();
+
         if include_use {
-            // Rename path: always use the general walker so `use` imports are included.
+            // Rename path: general walker covers call sites, `use` imports, and declarations.
             refs_in_stmts_with_use(source, stmts, word, &mut spans);
-        } else if include_declaration {
-            // The typed walkers only collect call sites and never emit declaration spans.
-            // When the caller wants declarations included, use the general walker which
-            // covers both declaration sites and call sites.
-            refs_in_stmts(source, stmts, word, &mut spans);
+            if !include_declaration {
+                spans.retain(|span| !is_declaration_span(source, stmts, word, span));
+            }
         } else {
-            // include_declaration=false: use typed walkers for precision.  They never
-            // emit declarations so no post-filtering is required.
             match kind {
                 Some(SymbolKind::Function) => function_refs_in_stmts(stmts, word, &mut spans),
                 Some(SymbolKind::Method) => method_refs_in_stmts(stmts, word, &mut spans),
                 Some(SymbolKind::Class) => class_refs_in_stmts(stmts, word, &mut spans),
-                None => refs_in_stmts(source, stmts, word, &mut spans),
+                // General walker already includes declarations; filter them out if unwanted.
+                None => {
+                    refs_in_stmts(source, stmts, word, &mut spans);
+                    if !include_declaration {
+                        spans.retain(|span| !is_declaration_span(source, stmts, word, span));
+                    }
+                }
             }
-        }
-
-        if !include_declaration {
-            // Only reached via the general walker (kind=None) or include_use path.
-            spans.retain(|span| !is_declaration_span(source, stmts, word, span));
+            // Typed walkers never emit declaration spans, so add them separately when wanted.
+            if include_declaration && kind.is_some() {
+                collect_declaration_spans(source, stmts, word, &mut spans);
+            }
         }
 
         for span in spans {
@@ -101,101 +103,90 @@ fn find_references_inner(
     locations
 }
 
+/// Build a span covering exactly the declared name (not the keyword before it).
+fn declaration_name_span(source: &str, name: &str) -> Span {
+    let start = str_offset(source, name);
+    Span {
+        start,
+        end: start + name.len() as u32,
+    }
+}
+
+/// Collect every span where `word` is *declared* within `stmts` (function/class/
+/// interface/trait/enum name, or method name inside those).  The typed walkers
+/// (`function_refs_in_stmts`, etc.) never emit declaration spans, so callers that
+/// need declarations can call this separately and append the results.
+fn collect_declaration_spans(
+    source: &str,
+    stmts: &[Stmt<'_, '_>],
+    word: &str,
+    out: &mut Vec<Span>,
+) {
+    for stmt in stmts {
+        match &stmt.kind {
+            StmtKind::Function(f) if f.name == word => {
+                out.push(declaration_name_span(source, f.name));
+            }
+            StmtKind::Class(c) if c.name == Some(word) => {
+                let name = c.name.expect("match guard ensures Some");
+                out.push(declaration_name_span(source, name));
+            }
+            StmtKind::Class(c) => {
+                for member in c.members.iter() {
+                    if let ClassMemberKind::Method(m) = &member.kind
+                        && m.name == word
+                    {
+                        out.push(declaration_name_span(source, m.name));
+                    }
+                }
+            }
+            StmtKind::Interface(i) if i.name == word => {
+                out.push(declaration_name_span(source, i.name));
+            }
+            StmtKind::Trait(t) if t.name == word => {
+                out.push(declaration_name_span(source, t.name));
+            }
+            StmtKind::Trait(t) => {
+                for member in t.members.iter() {
+                    if let ClassMemberKind::Method(m) = &member.kind
+                        && m.name == word
+                    {
+                        out.push(declaration_name_span(source, m.name));
+                    }
+                }
+            }
+            StmtKind::Enum(e) if e.name == word => {
+                out.push(declaration_name_span(source, e.name));
+            }
+            StmtKind::Enum(e) => {
+                for member in e.members.iter() {
+                    match &member.kind {
+                        EnumMemberKind::Method(m) if m.name == word => {
+                            out.push(declaration_name_span(source, m.name));
+                        }
+                        EnumMemberKind::Case(c) if c.name == word => {
+                            out.push(declaration_name_span(source, c.name));
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            StmtKind::Namespace(ns) => {
+                if let NamespaceBody::Braced(inner) = &ns.body {
+                    collect_declaration_spans(source, inner, word, out);
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
 /// Returns true if this span is the declaration site (function/class/method name).
 /// Compares against the name's own span (not the whole statement span).
 fn is_declaration_span(source: &str, stmts: &[Stmt<'_, '_>], word: &str, span: &Span) -> bool {
-    fn name_span(source: &str, name: &str) -> Span {
-        let start = str_offset(source, name);
-        Span {
-            start,
-            end: start + name.len() as u32,
-        }
-    }
-
-    fn check(source: &str, stmts: &[Stmt<'_, '_>], word: &str, span: &Span) -> bool {
-        for stmt in stmts {
-            match &stmt.kind {
-                StmtKind::Function(f) if f.name == word => {
-                    if spans_equal(&name_span(source, f.name), span) {
-                        return true;
-                    }
-                }
-                StmtKind::Class(c) if c.name == Some(word) => {
-                    // c.name is Some(word) per the guard; extract to get the
-                    // arena-allocated slice so str_offset uses pointer arithmetic.
-                    let name = c.name.expect("match guard ensures Some");
-                    if spans_equal(&name_span(source, name), span) {
-                        return true;
-                    }
-                }
-                StmtKind::Class(c) => {
-                    for member in c.members.iter() {
-                        if let ClassMemberKind::Method(m) = &member.kind
-                            && m.name == word
-                            && spans_equal(&name_span(source, m.name), span)
-                        {
-                            return true;
-                        }
-                    }
-                }
-                StmtKind::Interface(i) if i.name == word => {
-                    if spans_equal(&name_span(source, i.name), span) {
-                        return true;
-                    }
-                }
-                StmtKind::Trait(t) if t.name == word => {
-                    if spans_equal(&name_span(source, t.name), span) {
-                        return true;
-                    }
-                }
-                StmtKind::Trait(t) => {
-                    for member in t.members.iter() {
-                        if let ClassMemberKind::Method(m) = &member.kind
-                            && m.name == word
-                            && spans_equal(&name_span(source, m.name), span)
-                        {
-                            return true;
-                        }
-                    }
-                }
-                StmtKind::Enum(e) if e.name == word => {
-                    if spans_equal(&name_span(source, e.name), span) {
-                        return true;
-                    }
-                }
-                StmtKind::Enum(e) => {
-                    for member in e.members.iter() {
-                        match &member.kind {
-                            EnumMemberKind::Method(m)
-                                if m.name == word
-                                    && spans_equal(&name_span(source, m.name), span) =>
-                            {
-                                return true;
-                            }
-                            EnumMemberKind::Case(c)
-                                if c.name == word
-                                    && spans_equal(&name_span(source, c.name), span) =>
-                            {
-                                return true;
-                            }
-                            _ => {}
-                        }
-                    }
-                }
-                StmtKind::Namespace(ns) => {
-                    if let NamespaceBody::Braced(inner) = &ns.body
-                        && check(source, inner, word, span)
-                    {
-                        return true;
-                    }
-                }
-                _ => {}
-            }
-        }
-        false
-    }
-
-    check(source, stmts, word, span)
+    let mut decl_spans = Vec::new();
+    collect_declaration_spans(source, stmts, word, &mut decl_spans);
+    decl_spans.iter().any(|s| spans_equal(s, span))
 }
 
 fn spans_equal(a: &Span, b: &Span) -> bool {
@@ -580,6 +571,64 @@ mod tests {
         assert_eq!(
             decl_ref.range.start.character, 20,
             "method declaration should start at the method name, not 'public function'"
+        );
+    }
+
+    #[test]
+    fn method_kind_with_include_declaration_does_not_return_free_function() {
+        // Regression: the old fix used the general walker when include_declaration=true,
+        // losing the precision of the typed walker.  A free function `get` and a method
+        // `get` coexist; searching with SymbolKind::Method + include_declaration=true must
+        // NOT return the free function call.
+        let src =
+            "<?php\nfunction get() {}\nget();\nclass C { public function get() {} }\n$c->get();";
+        let docs = vec![doc("/a.php", src)];
+        let refs = find_references("get", &docs, true, Some(SymbolKind::Method));
+        let lines: Vec<u32> = refs.iter().map(|r| r.range.start.line).collect();
+        // Method declaration on line 3, method call on line 4 — both expected.
+        assert!(
+            lines.contains(&3),
+            "method declaration (line 3) must be present, got: {:?}",
+            lines
+        );
+        assert!(
+            lines.contains(&4),
+            "method call site (line 4) must be present, got: {:?}",
+            lines
+        );
+        // Free function call on line 2 must NOT appear.
+        assert!(
+            !lines.contains(&2),
+            "free function call (line 2) must not appear when kind=Method, got: {:?}",
+            lines
+        );
+    }
+
+    #[test]
+    fn function_kind_with_include_declaration_does_not_return_method_call() {
+        // Symmetric regression test: SymbolKind::Function + include_declaration=true must
+        // not return method calls with the same name.
+        let src =
+            "<?php\nfunction add() {}\nadd();\nclass C { public function add() {} }\n$c->add();";
+        let docs = vec![doc("/a.php", src)];
+        let refs = find_references("add", &docs, true, Some(SymbolKind::Function));
+        let lines: Vec<u32> = refs.iter().map(|r| r.range.start.line).collect();
+        // Free function declaration on line 1, free call on line 2 — both expected.
+        assert!(
+            lines.contains(&1),
+            "function declaration (line 1) must be present, got: {:?}",
+            lines
+        );
+        assert!(
+            lines.contains(&2),
+            "function call site (line 2) must be present, got: {:?}",
+            lines
+        );
+        // Method call on line 4 must NOT appear.
+        assert!(
+            !lines.contains(&4),
+            "method call (line 4) must not appear when kind=Function, got: {:?}",
+            lines
         );
     }
 }

--- a/src/references.rs
+++ b/src/references.rs
@@ -81,8 +81,10 @@ fn find_references_inner(
                 }
             }
             // Typed walkers never emit declaration spans, so add them separately when wanted.
+            // Pass `kind` so only declarations of the matching category are appended —
+            // a Method search must not return a free-function declaration with the same name.
             if include_declaration && kind.is_some() {
-                collect_declaration_spans(source, stmts, word, &mut spans);
+                collect_declaration_spans(source, stmts, word, kind, &mut spans);
             }
         }
 
@@ -112,59 +114,72 @@ fn declaration_name_span(source: &str, name: &str) -> Span {
     }
 }
 
-/// Collect every span where `word` is *declared* within `stmts` (function/class/
-/// interface/trait/enum name, or method name inside those).  The typed walkers
-/// (`function_refs_in_stmts`, etc.) never emit declaration spans, so callers that
-/// need declarations can call this separately and append the results.
+/// Collect every span where `word` is *declared* within `stmts`.
+///
+/// When `kind` is `Some`, only declarations of the matching category are collected:
+/// - `Function` → free (`StmtKind::Function`) declarations only
+/// - `Method`   → method declarations inside classes / traits / enums only
+/// - `Class`    → class / interface / trait / enum type declarations only
+///
+/// `None` collects every declaration kind (used by `is_declaration_span`).
 fn collect_declaration_spans(
     source: &str,
     stmts: &[Stmt<'_, '_>],
     word: &str,
+    kind: Option<SymbolKind>,
     out: &mut Vec<Span>,
 ) {
+    let want_free = matches!(kind, None | Some(SymbolKind::Function));
+    let want_method = matches!(kind, None | Some(SymbolKind::Method));
+    let want_type = matches!(kind, None | Some(SymbolKind::Class));
+
     for stmt in stmts {
         match &stmt.kind {
-            StmtKind::Function(f) if f.name == word => {
+            StmtKind::Function(f) if f.name == word && want_free => {
                 out.push(declaration_name_span(source, f.name));
             }
-            StmtKind::Class(c) if c.name == Some(word) => {
+            StmtKind::Class(c) if c.name == Some(word) && want_type => {
                 let name = c.name.expect("match guard ensures Some");
                 out.push(declaration_name_span(source, name));
             }
             StmtKind::Class(c) => {
-                for member in c.members.iter() {
-                    if let ClassMemberKind::Method(m) = &member.kind
-                        && m.name == word
-                    {
-                        out.push(declaration_name_span(source, m.name));
+                if want_method {
+                    for member in c.members.iter() {
+                        if let ClassMemberKind::Method(m) = &member.kind
+                            && m.name == word
+                        {
+                            out.push(declaration_name_span(source, m.name));
+                        }
                     }
                 }
             }
-            StmtKind::Interface(i) if i.name == word => {
+            StmtKind::Interface(i) if i.name == word && want_type => {
                 out.push(declaration_name_span(source, i.name));
             }
-            StmtKind::Trait(t) if t.name == word => {
+            StmtKind::Trait(t) if t.name == word && want_type => {
                 out.push(declaration_name_span(source, t.name));
             }
             StmtKind::Trait(t) => {
-                for member in t.members.iter() {
-                    if let ClassMemberKind::Method(m) = &member.kind
-                        && m.name == word
-                    {
-                        out.push(declaration_name_span(source, m.name));
+                if want_method {
+                    for member in t.members.iter() {
+                        if let ClassMemberKind::Method(m) = &member.kind
+                            && m.name == word
+                        {
+                            out.push(declaration_name_span(source, m.name));
+                        }
                     }
                 }
             }
-            StmtKind::Enum(e) if e.name == word => {
+            StmtKind::Enum(e) if e.name == word && want_type => {
                 out.push(declaration_name_span(source, e.name));
             }
             StmtKind::Enum(e) => {
                 for member in e.members.iter() {
                     match &member.kind {
-                        EnumMemberKind::Method(m) if m.name == word => {
+                        EnumMemberKind::Method(m) if m.name == word && want_method => {
                             out.push(declaration_name_span(source, m.name));
                         }
-                        EnumMemberKind::Case(c) if c.name == word => {
+                        EnumMemberKind::Case(c) if c.name == word && want_type => {
                             out.push(declaration_name_span(source, c.name));
                         }
                         _ => {}
@@ -173,7 +188,7 @@ fn collect_declaration_spans(
             }
             StmtKind::Namespace(ns) => {
                 if let NamespaceBody::Braced(inner) = &ns.body {
-                    collect_declaration_spans(source, inner, word, out);
+                    collect_declaration_spans(source, inner, word, kind, out);
                 }
             }
             _ => {}
@@ -185,7 +200,7 @@ fn collect_declaration_spans(
 /// Compares against the name's own span (not the whole statement span).
 fn is_declaration_span(source: &str, stmts: &[Stmt<'_, '_>], word: &str, span: &Span) -> bool {
     let mut decl_spans = Vec::new();
-    collect_declaration_spans(source, stmts, word, &mut decl_spans);
+    collect_declaration_spans(source, stmts, word, None, &mut decl_spans);
     decl_spans.iter().any(|s| spans_equal(s, span))
 }
 
@@ -576,16 +591,20 @@ mod tests {
 
     #[test]
     fn method_kind_with_include_declaration_does_not_return_free_function() {
-        // Regression: the old fix used the general walker when include_declaration=true,
-        // losing the precision of the typed walker.  A free function `get` and a method
-        // `get` coexist; searching with SymbolKind::Method + include_declaration=true must
-        // NOT return the free function call.
+        // Regression: kind precision must be preserved even when include_declaration=true.
+        // A free function `get` and a method `get` coexist; searching with
+        // SymbolKind::Method must NOT return either the free function call or its declaration.
+        //
+        // Line 0: <?php
+        // Line 1: function get() {}          ← free function declaration
+        // Line 2: get();                     ← free function call
+        // Line 3: class C { public function get() {} }  ← method declaration
+        // Line 4: $c->get();                 ← method call
         let src =
             "<?php\nfunction get() {}\nget();\nclass C { public function get() {} }\n$c->get();";
         let docs = vec![doc("/a.php", src)];
         let refs = find_references("get", &docs, true, Some(SymbolKind::Method));
         let lines: Vec<u32> = refs.iter().map(|r| r.range.start.line).collect();
-        // Method declaration on line 3, method call on line 4 — both expected.
         assert!(
             lines.contains(&3),
             "method declaration (line 3) must be present, got: {:?}",
@@ -593,10 +612,14 @@ mod tests {
         );
         assert!(
             lines.contains(&4),
-            "method call site (line 4) must be present, got: {:?}",
+            "method call (line 4) must be present, got: {:?}",
             lines
         );
-        // Free function call on line 2 must NOT appear.
+        assert!(
+            !lines.contains(&1),
+            "free function declaration (line 1) must not appear when kind=Method, got: {:?}",
+            lines
+        );
         assert!(
             !lines.contains(&2),
             "free function call (line 2) must not appear when kind=Method, got: {:?}",
@@ -606,14 +629,19 @@ mod tests {
 
     #[test]
     fn function_kind_with_include_declaration_does_not_return_method_call() {
-        // Symmetric regression test: SymbolKind::Function + include_declaration=true must
-        // not return method calls with the same name.
+        // Symmetric: SymbolKind::Function + include_declaration=true must not return method
+        // calls or method declarations with the same name.
+        //
+        // Line 0: <?php
+        // Line 1: function add() {}          ← free function declaration
+        // Line 2: add();                     ← free function call
+        // Line 3: class C { public function add() {} }  ← method declaration
+        // Line 4: $c->add();                 ← method call
         let src =
             "<?php\nfunction add() {}\nadd();\nclass C { public function add() {} }\n$c->add();";
         let docs = vec![doc("/a.php", src)];
         let refs = find_references("add", &docs, true, Some(SymbolKind::Function));
         let lines: Vec<u32> = refs.iter().map(|r| r.range.start.line).collect();
-        // Free function declaration on line 1, free call on line 2 — both expected.
         assert!(
             lines.contains(&1),
             "function declaration (line 1) must be present, got: {:?}",
@@ -621,10 +649,14 @@ mod tests {
         );
         assert!(
             lines.contains(&2),
-            "function call site (line 2) must be present, got: {:?}",
+            "function call (line 2) must be present, got: {:?}",
             lines
         );
-        // Method call on line 4 must NOT appear.
+        assert!(
+            !lines.contains(&3),
+            "method declaration (line 3) must not appear when kind=Function, got: {:?}",
+            lines
+        );
         assert!(
             !lines.contains(&4),
             "method call (line 4) must not appear when kind=Function, got: {:?}",

--- a/src/references.rs
+++ b/src/references.rs
@@ -135,14 +135,18 @@ fn collect_declaration_spans(
 
     for stmt in stmts {
         match &stmt.kind {
-            StmtKind::Function(f) if f.name == word && want_free => {
-                out.push(declaration_name_span(source, f.name));
-            }
-            StmtKind::Class(c) if c.name == Some(word) && want_type => {
-                let name = c.name.expect("match guard ensures Some");
-                out.push(declaration_name_span(source, name));
+            StmtKind::Function(f) => {
+                if want_free && f.name == word {
+                    out.push(declaration_name_span(source, f.name));
+                }
             }
             StmtKind::Class(c) => {
+                if want_type
+                    && let Some(name) = c.name
+                    && name == word
+                {
+                    out.push(declaration_name_span(source, name));
+                }
                 if want_method {
                     for member in c.members.iter() {
                         if let ClassMemberKind::Method(m) = &member.kind
@@ -153,13 +157,15 @@ fn collect_declaration_spans(
                     }
                 }
             }
-            StmtKind::Interface(i) if i.name == word && want_type => {
-                out.push(declaration_name_span(source, i.name));
-            }
-            StmtKind::Trait(t) if t.name == word && want_type => {
-                out.push(declaration_name_span(source, t.name));
+            StmtKind::Interface(i) => {
+                if want_type && i.name == word {
+                    out.push(declaration_name_span(source, i.name));
+                }
             }
             StmtKind::Trait(t) => {
+                if want_type && t.name == word {
+                    out.push(declaration_name_span(source, t.name));
+                }
                 if want_method {
                     for member in t.members.iter() {
                         if let ClassMemberKind::Method(m) = &member.kind
@@ -170,16 +176,16 @@ fn collect_declaration_spans(
                     }
                 }
             }
-            StmtKind::Enum(e) if e.name == word && want_type => {
-                out.push(declaration_name_span(source, e.name));
-            }
             StmtKind::Enum(e) => {
+                if want_type && e.name == word {
+                    out.push(declaration_name_span(source, e.name));
+                }
                 for member in e.members.iter() {
                     match &member.kind {
-                        EnumMemberKind::Method(m) if m.name == word && want_method => {
+                        EnumMemberKind::Method(m) if want_method && m.name == word => {
                             out.push(declaration_name_span(source, m.name));
                         }
-                        EnumMemberKind::Case(c) if c.name == word && want_type => {
+                        EnumMemberKind::Case(c) if want_type && c.name == word => {
                             out.push(declaration_name_span(source, c.name));
                         }
                         _ => {}
@@ -661,6 +667,45 @@ mod tests {
             !lines.contains(&4),
             "method call (line 4) must not appear when kind=Function, got: {:?}",
             lines
+        );
+    }
+
+    #[test]
+    fn declaration_filter_finds_method_inside_same_named_class() {
+        // Edge case: a class named `get` contains a method also named `get`.
+        // collect_declaration_spans(kind=None) must find BOTH the class declaration
+        // and the method declaration so is_declaration_span correctly filters both
+        // when include_declaration=false.
+        //
+        // Line 0: <?php
+        // Line 1: class get { public function get() {} }
+        // Line 2: $obj->get();
+        let src = "<?php\nclass get { public function get() {} }\n$obj->get();";
+        let docs = vec![doc("/a.php", src)];
+
+        // With include_declaration=false, neither the class name nor the method
+        // declaration should appear — only the call site on line 2.
+        let refs = find_references("get", &docs, false, None);
+        let lines: Vec<u32> = refs.iter().map(|r| r.range.start.line).collect();
+        assert!(
+            !lines.contains(&1),
+            "declaration line (1) must not appear when include_declaration=false, got: {:?}",
+            lines
+        );
+        assert!(
+            lines.contains(&2),
+            "call site (line 2) must be present, got: {:?}",
+            lines
+        );
+
+        // With include_declaration=true, the class declaration AND method declaration
+        // are both on line 1; the call site is on line 2.
+        let refs_with = find_references("get", &docs, true, None);
+        assert_eq!(
+            refs_with.len(),
+            3,
+            "expected 3 refs (class decl + method decl + call), got: {:?}",
+            refs_with
         );
     }
 }

--- a/src/selection_range.rs
+++ b/src/selection_range.rs
@@ -19,8 +19,14 @@ pub fn selection_ranges(
 
 /// The entire file as a single range.
 fn file_range(source: &str) -> Range {
-    let total_lines = source.lines().count() as u32;
-    let last_line = total_lines.saturating_sub(1);
+    let lines: Vec<&str> = source.lines().collect();
+    let last_line = lines.len().saturating_sub(1) as u32;
+    // Use the actual UTF-16 length of the last line rather than u32::MAX.
+    // u32::MAX is not LSP-spec-compliant; stricter clients may reject it.
+    let last_char = lines
+        .last()
+        .map(|l| l.chars().map(|c| c.len_utf16() as u32).sum::<u32>())
+        .unwrap_or(0);
     Range {
         start: Position {
             line: 0,
@@ -28,7 +34,7 @@ fn file_range(source: &str) -> Range {
         },
         end: Position {
             line: last_line,
-            character: u32::MAX,
+            character: last_char,
         },
     }
 }
@@ -445,5 +451,28 @@ mod tests {
                 character: 999
             }
         ));
+    }
+
+    #[test]
+    fn file_range_end_character_is_actual_line_length_not_u32_max() {
+        // The outermost range must use the real UTF-16 column length of the last
+        // line, not u32::MAX.  u32::MAX is not LSP-spec-compliant and causes
+        // issues with stricter clients.
+        let src = "<?php\nfunction hello(): void {}";
+        //         line 0             line 1 (30 chars)
+        let d = doc(src);
+        let result = selection_ranges(src, &d, &[pos(1, 10)]);
+        let ranges = chain_ranges(&result[0]);
+        let outermost = ranges.last().expect("should have at least one range");
+        assert_ne!(
+            outermost.end.character,
+            u32::MAX,
+            "end character must not be u32::MAX — use real line length"
+        );
+        // "function hello(): void {}" is 25 chars; the file-level range should end there.
+        assert_eq!(
+            outermost.end.character, 25,
+            "file-level end character should be the actual last-line length"
+        );
     }
 }

--- a/src/semantic_diagnostics.rs
+++ b/src/semantic_diagnostics.rs
@@ -14,11 +14,18 @@ use crate::docblock::{docblock_before, parse_docblock};
 /// Run semantic checks on `doc` using the backend's persistent codebase.
 /// The codebase is updated incrementally: the current file's definitions are
 /// evicted and re-collected, then `finalize()` rebuilds inheritance tables.
+///
+/// `php_version` is a version string like `"8.1"` sourced from `LspConfig`.
+/// It is threaded through here so callers are already wired correctly once
+/// `mir_analyzer` gains version-gating support.
+///
+/// TODO: pass `php_version` to `mir_analyzer` once it exposes a version API.
 pub fn semantic_diagnostics(
     uri: &Url,
     doc: &ParsedDoc,
     codebase: &mir_codebase::Codebase,
     cfg: &DiagnosticsConfig,
+    _php_version: Option<&str>,
 ) -> Vec<Diagnostic> {
     if !cfg.enabled {
         return vec![];

--- a/src/semantic_tokens.rs
+++ b/src/semantic_tokens.rs
@@ -182,6 +182,28 @@ fn push_name(out: &mut Vec<RawToken>, source: &str, name: &str, token_type: u32,
     );
 }
 
+/// Like `push_name` but also includes the leading `$` sigil when one immediately
+/// precedes the name in the source.  PHP parameter names in the AST are stored
+/// without `$`, but the sigil is part of the syntax and must be highlighted
+/// consistently with variable-expression tokens which include it.
+fn push_param(out: &mut Vec<RawToken>, source: &str, name: &str, token_type: u32, modifiers: u32) {
+    let name_offset = str_offset(source, name);
+    let (offset, extra_len) =
+        if name_offset > 0 && source.as_bytes().get(name_offset as usize - 1) == Some(&b'$') {
+            (name_offset - 1, 1u32)
+        } else {
+            (name_offset, 0u32)
+        };
+    push_at(
+        out,
+        source,
+        offset,
+        extra_len + name.chars().map(|c| c.len_utf16() as u32).sum::<u32>(),
+        token_type,
+        modifiers,
+    );
+}
+
 fn push_attributes(out: &mut Vec<RawToken>, source: &str, attrs: &[Attribute<'_, '_>]) {
     for attr in attrs.iter() {
         let span = attr.name.span();
@@ -364,7 +386,7 @@ fn collect_stmt(source: &str, stmt: &Stmt<'_, '_>, out: &mut Vec<RawToken>) {
                 if let Some(th) = &p.type_hint {
                     push_type_hint(out, source, th);
                 }
-                push_name(out, source, p.name, TT_PARAMETER, MOD_DECLARATION);
+                push_param(out, source, p.name, TT_PARAMETER, MOD_DECLARATION);
             }
             if let Some(rt) = &f.return_type {
                 push_type_hint(out, source, rt);
@@ -410,7 +432,7 @@ fn collect_stmt(source: &str, stmt: &Stmt<'_, '_>, out: &mut Vec<RawToken>) {
                         if let Some(th) = &p.type_hint {
                             push_type_hint(out, source, th);
                         }
-                        push_name(out, source, p.name, TT_PARAMETER, MOD_DECLARATION);
+                        push_param(out, source, p.name, TT_PARAMETER, MOD_DECLARATION);
                     }
                     if let Some(rt) = &m.return_type {
                         push_type_hint(out, source, rt);
@@ -500,7 +522,7 @@ fn collect_class_member(
             if let Some(th) = &p.type_hint {
                 push_type_hint(out, source, th);
             }
-            push_name(out, source, p.name, TT_PARAMETER, MOD_DECLARATION);
+            push_param(out, source, p.name, TT_PARAMETER, MOD_DECLARATION);
         }
         if let Some(rt) = &m.return_type {
             push_type_hint(out, source, rt);
@@ -647,7 +669,7 @@ fn collect_expr(source: &str, expr: &php_ast::Expr<'_, '_>, out: &mut Vec<RawTok
                 if let Some(th) = &p.type_hint {
                     push_type_hint(out, source, th);
                 }
-                push_name(out, source, p.name, TT_PARAMETER, MOD_DECLARATION);
+                push_param(out, source, p.name, TT_PARAMETER, MOD_DECLARATION);
             }
             if let Some(rt) = &c.return_type {
                 push_type_hint(out, source, rt);
@@ -659,7 +681,7 @@ fn collect_expr(source: &str, expr: &php_ast::Expr<'_, '_>, out: &mut Vec<RawTok
                 if let Some(th) = &p.type_hint {
                     push_type_hint(out, source, th);
                 }
-                push_name(out, source, p.name, TT_PARAMETER, MOD_DECLARATION);
+                push_param(out, source, p.name, TT_PARAMETER, MOD_DECLARATION);
             }
             if let Some(rt) = &af.return_type {
                 push_type_hint(out, source, rt);
@@ -809,6 +831,53 @@ mod tests {
                 .any(|t| t.token_type == TT_PARAMETER
                     && t.token_modifiers_bitset & MOD_DECLARATION != 0),
             "expected parameter+declaration token"
+        );
+    }
+
+    #[test]
+    fn parameter_token_includes_dollar_sign() {
+        // Parameter tokens must cover `$name` (including the `$`), not just `name`.
+        // Variable-expression tokens already include `$`; parameters must be consistent.
+        //
+        // Source: "<?php\nfunction greet(string $name) {}"
+        // Line 1: "function greet(string $name) {}"
+        //          0         1         2         3
+        //          0123456789012345678901234567890
+        //                                ^ char 22 = '$', char 23 = 'n'
+        let src = "<?php\nfunction greet(string $name) {}";
+        let d = doc(src);
+        let tokens = semantic_tokens(src, &d);
+
+        // Decode delta encoding to find the absolute char of the PARAMETER token.
+        let mut abs_char: u32 = 0;
+        let mut last_line: u32 = 0;
+        let mut param_abs_char: Option<u32> = None;
+        let mut param_len: Option<u32> = None;
+        for t in &tokens {
+            if t.delta_line > 0 {
+                abs_char = 0;
+                last_line += t.delta_line;
+            }
+            abs_char += t.delta_start;
+            if t.token_type == TT_PARAMETER {
+                param_abs_char = Some(abs_char);
+                param_len = Some(t.length);
+                break;
+            }
+        }
+        let _ = last_line; // suppress unused-variable warning
+
+        let abs = param_abs_char.expect("expected a TT_PARAMETER token");
+        // `function greet(string ` = 22 chars → `$` at char 22.
+        assert_eq!(
+            abs, 22,
+            "parameter token must start at `$` (char 22), not at the bare identifier (char 23)"
+        );
+        // `$name` = 5 chars
+        assert_eq!(
+            param_len.unwrap(),
+            5,
+            "parameter token length must cover `$name` (5 chars)"
         );
     }
 


### PR DESCRIPTION
## Summary

- **Fix OR-constraint parsing** — `"^7.4 || ^8.1"` now returns `8.1` (highest lower bound) instead of `7.4` (first clause), matching the version developers most likely run locally
- **Correct detection priority order** — `php --version` binary now takes precedence over `require.php` constraint (which is just a compatibility range, not the actual runtime); `config.platform.php` remains highest
- **Split detection functions** — `detect_php_version_from_composer` replaced by focused `detect_php_platform_version_from_composer` and `detect_php_require_version_from_composer`; priority logic lives in a standalone testable `resolve_php_version_from_roots`
- **Startup log** — INFO message on `initialize` and `workspace/didChangeConfiguration` showing which version was chosen and why (e.g. `php-lsp: using PHP 8.1 (composer.json require)`)
- **Visible warning for unsupported versions** — `window/showMessage` WARNING popup when auto-detected version is outside the supported range (e.g. a legacy `">=5.6"` project); previously silently ignored
- **Wire `php_version` through diagnostics** — all three `semantic_diagnostics` call sites now read and pass `php_version` from config; `_php_version` parameter added with a TODO for when `mir_analyzer` exposes a version API
- **Remove dead constant** — `LspConfig::DEFAULT_PHP_VERSION` removed; default now lives alongside the detection logic in `autoload.rs`

## Test plan

- 17 new tests covering OR-constraints, detection priority, tilde operator (`~8.1`), edge cases (empty string, `*` wildcard, major-only version), and unsupported version handling
- All 750 existing tests continue to pass