### PR TITLE
ci: add cargo install (unlocked) job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,24 @@ jobs:
       - name: Run tests
         run: cargo test
 
+  install:
+    name: cargo install (unlocked)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: "1.94.0"
+
+      - name: cargo install without --locked
+        run: cargo install --path . --debug
+
+      - name: Verify binary
+        run: php-lsp --version
+
   lint:
     name: Lint
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Adds a `cargo install (unlocked)` CI job that runs `cargo install --path . --debug` without `--locked`
- Catches cases where newer transitive dependency versions break compilation for end users (as in #88)
- Verifies the installed binary responds to `--version`

Closes #88