### PR TITLE
fix(references): classify method declarations as Method, not Function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,16 @@
 version = 4
 
 [[package]]
+name = "Inflector"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
+dependencies = [
+ "lazy_static",
+ "regex",
+]
+
+[[package]]
 name = "addr2line"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18,10 +28,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "ariadne"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8454c8a44ce2cb9cc7e7fae67fc6128465b343b92c6631e94beca3c8d1524ea5"
+dependencies = [
+ "unicode-width 0.2.2",
+ "yansi",
+]
+
+[[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "async-trait"
@@ -31,7 +84,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -42,8 +95,14 @@ checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "backtrace"
@@ -82,12 +141,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
-name = "block-buffer"
-version = "0.12.0"
+name = "blake3"
+version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+checksum = "4d2d5991425dfd0785aed03aedcf0b321d61975c9b5b3689c774a2610ae0b51e"
 dependencies = [
- "hybrid-array",
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "cpufeatures",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -95,6 +169,15 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -103,16 +186,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cc"
+version = "1.2.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
-name = "const-oid"
-version = "0.10.2"
+name = "codespan-reporting"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
+dependencies = [
+ "serde",
+ "termcolor",
+ "unicode-width 0.2.2",
+]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "cpufeatures"
@@ -149,12 +253,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
-name = "crypto-common"
-version = "0.2.1"
+name = "cruet"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+checksum = "b7a9ae414b9768aada1b316493261653e41af05c9d2ccc9c504a8fc051c6a790"
 dependencies = [
- "hybrid-array",
+ "once_cell",
+ "regex",
 ]
 
 [[package]]
@@ -185,17 +290,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "digest"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
-dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
-]
-
-[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -203,7 +297,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -211,6 +305,12 @@ name = "dissimilar"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aeda16ab4059c5fd2a83f2b9c9e9c981327b18aa8e3b313f7e6563799d4f093e"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
@@ -231,7 +331,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -251,10 +351,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -263,6 +381,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -309,7 +436,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -361,6 +488,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -372,7 +518,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -392,15 +538,6 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
-
-[[package]]
-name = "hybrid-array"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
-dependencies = [
- "typenum",
-]
 
 [[package]]
 name = "icu_collections"
@@ -524,6 +661,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "inotify"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
+dependencies = [
+ "bitflags 2.11.0",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "is_ci"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -534,6 +700,32 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leb128fmt"
@@ -588,6 +780,209 @@ dependencies = [
 ]
 
 [[package]]
+name = "mago-atom"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13e88f41ba03796eba5d179173d9d2b8b6e9d762113b5f5a6c4704556f766dd3"
+dependencies = [
+ "itoa",
+ "ryu",
+ "ustr",
+]
+
+[[package]]
+name = "mago-casing"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efc102603937fe862646478653f86ee68b60541c887e6cec17e32a85671f8ed3"
+dependencies = [
+ "cruet",
+]
+
+[[package]]
+name = "mago-collector"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "369b02b752f40815c79698676a1c621cadc5c08b1ab54a80f18a8c11c295c85b"
+dependencies = [
+ "bumpalo",
+ "foldhash 0.2.0",
+ "mago-database",
+ "mago-reporting",
+ "mago-span",
+ "mago-syntax",
+ "mago-text-edit",
+]
+
+[[package]]
+name = "mago-database"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06fca0ab6319e594949f186fe60fc310ac798b0372b340b6bcd9c0734b543e09"
+dependencies = [
+ "foldhash 0.2.0",
+ "glob",
+ "globset",
+ "memchr",
+ "notify",
+ "rayon",
+ "serde",
+ "simdutf8",
+ "tracing",
+ "walkdir",
+]
+
+[[package]]
+name = "mago-docblock"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c99edc20e4e536f7455d86dde7cc420d1208c274d928e7ae2b2ebf578e89939"
+dependencies = [
+ "bumpalo",
+ "mago-span",
+ "mago-syntax",
+ "serde",
+]
+
+[[package]]
+name = "mago-linter"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a394a2bf8d234d6d8db083a8e23be99f52c2ea22214ff602f4f813b0c52340d3"
+dependencies = [
+ "bumpalo",
+ "foldhash 0.2.0",
+ "indoc",
+ "mago-atom",
+ "mago-casing",
+ "mago-collector",
+ "mago-database",
+ "mago-docblock",
+ "mago-names",
+ "mago-php-version",
+ "mago-reporting",
+ "mago-span",
+ "mago-syntax",
+ "mago-text-edit",
+ "regex",
+ "schemars",
+ "serde",
+ "serde_json",
+ "tracing",
+]
+
+[[package]]
+name = "mago-names"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13003bdf918f0a37b275dbcff98efbbad725fd496270e0dfbf0d498630229a6a"
+dependencies = [
+ "bumpalo",
+ "foldhash 0.2.0",
+ "mago-span",
+ "mago-syntax",
+ "serde",
+ "strum 0.28.0",
+]
+
+[[package]]
+name = "mago-php-version"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8409a54ea5c75f7826e7ea44d855f0786015ea3ec04354202016660f50bc48d4"
+dependencies = [
+ "schemars",
+ "serde",
+]
+
+[[package]]
+name = "mago-reporting"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c00559db0656b221d5aad22c0596d6dd20fa7002365c0455cf3f069df66de59f"
+dependencies = [
+ "ariadne",
+ "blake3",
+ "codespan-reporting",
+ "foldhash 0.2.0",
+ "mago-database",
+ "mago-span",
+ "mago-text-edit",
+ "schemars",
+ "serde",
+ "serde-sarif",
+ "serde_json",
+ "strum 0.28.0",
+ "termcolor",
+]
+
+[[package]]
+name = "mago-semantics"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb109204b990f4870a98017417f6f5b8130d13a5604556c9ece0526aaa800a7"
+dependencies = [
+ "mago-database",
+ "mago-names",
+ "mago-php-version",
+ "mago-reporting",
+ "mago-span",
+ "mago-syntax",
+]
+
+[[package]]
+name = "mago-span"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbd287ab17dd85e32392652be29c70c240b59a320b3a5faf657d97a51380790f"
+dependencies = [
+ "mago-database",
+ "serde",
+]
+
+[[package]]
+name = "mago-syntax"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7ae58bf6984f4fb2aa6f0a67037e22467633317731eec9f0685bafa696245ba"
+dependencies = [
+ "bumpalo",
+ "mago-database",
+ "mago-php-version",
+ "mago-reporting",
+ "mago-span",
+ "mago-syntax-core",
+ "memchr",
+ "ordered-float",
+ "paste",
+ "serde",
+ "strum 0.28.0",
+]
+
+[[package]]
+name = "mago-syntax-core"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e32962e39b88ac2082d3f79cb95752709bd1e00180801c05e66c78c027a223e4"
+dependencies = [
+ "bumpalo",
+ "mago-database",
+ "mago-span",
+ "memchr",
+]
+
+[[package]]
+name = "mago-text-edit"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96abc32ca891a8311066604a0d122c1d666e2a35498454d82526d98179b1a1cd"
+dependencies = [
+ "serde",
+ "strum 0.28.0",
+ "tracing",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -620,7 +1015,7 @@ checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -639,65 +1034,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
+ "log",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
-name = "mir-analyzer"
-version = "0.4.1"
+name = "notify"
+version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "848dc2442af9acb773af8564786b5a1b747b0f3203e80bdc4bb0c8afd5c95111"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
- "bumpalo",
- "indexmap",
- "mir-codebase",
- "mir-issues",
- "mir-types",
- "php-ast",
- "php-rs-parser",
- "quick-xml",
- "rayon",
- "serde",
- "serde_json",
- "sha2",
- "thiserror",
+ "bitflags 2.11.0",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
-name = "mir-codebase"
-version = "0.4.1"
+name = "notify-types"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ca6a4591a4497ab7ad79f7996e2a61a74158b3cf168a307289d12e63edfdf27"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
- "dashmap 6.1.0",
- "indexmap",
- "mir-types",
- "serde",
- "thiserror",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
-name = "mir-issues"
-version = "0.4.1"
+name = "num-traits"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f18361b9a4a1a99a7cdc7275b30028b06be5713326a6c1b991b4f0b63701ad6"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
- "mir-types",
- "owo-colors",
- "serde",
- "thiserror",
-]
-
-[[package]]
-name = "mir-types"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5454172c589ff8797bebd0efb079061c51e1d03bca7e56ad987b264333b7dcf4"
-dependencies = [
- "indexmap",
- "serde",
- "smallvec",
+ "autocfg",
 ]
 
 [[package]]
@@ -714,6 +1089,17 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "ordered-float"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
+dependencies = [
+ "num-traits",
+ "rand",
+ "serde",
+]
 
 [[package]]
 name = "owo-colors"
@@ -743,6 +1129,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "percent-encoding"
@@ -777,10 +1169,14 @@ dependencies = [
  "bumpalo",
  "dashmap 6.1.0",
  "expect-test",
- "mir-analyzer",
- "mir-codebase",
- "mir-issues",
- "mir-types",
+ "mago-database",
+ "mago-linter",
+ "mago-names",
+ "mago-php-version",
+ "mago-reporting",
+ "mago-semantics",
+ "mago-span",
+ "mago-syntax",
  "php-ast",
  "php-rs-parser",
  "serde_json",
@@ -819,7 +1215,7 @@ checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -844,7 +1240,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -854,15 +1250,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "quick-xml"
-version = "0.36.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -879,6 +1266,25 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "rand_core",
+ "serde",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "rayon"
@@ -910,6 +1316,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -925,7 +1380,80 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "schemafy_core"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bec29dddcfe60f92f3c0d422707b8b56473983ef0481df8d5236ed3ab8fdf24"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemafy_lib"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af3d87f1df246a9b7e2bfd1f4ee5f88e48b11ef9cfc62e63f0dead255b1a6f5f"
+dependencies = [
+ "Inflector",
+ "proc-macro2",
+ "quote",
+ "schemafy_core",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "syn 1.0.109",
+ "uriparse",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -951,6 +1479,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-sarif"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a053c46f18a8043570d4e32fefc4c6377f82bf29ec310a33e93f273048e3b0be"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "schemafy_lib",
+ "serde",
+ "serde_json",
+ "strum 0.27.2",
+ "strum_macros 0.27.2",
+ "syn 2.0.117",
+ "thiserror",
+ "typed-builder",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -967,7 +1515,18 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -976,6 +1535,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -991,19 +1551,14 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
-name = "sha2"
-version = "0.11.0"
+name = "shlex"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
-]
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
@@ -1016,6 +1571,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1026,9 +1587,6 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "socket2"
@@ -1037,7 +1595,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1045,6 +1603,45 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros 0.28.0",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "supports-color"
@@ -1069,6 +1666,17 @@ checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
@@ -1086,7 +1694,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1099,7 +1707,16 @@ dependencies = [
  "getrandom",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -1109,7 +1726,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1139,7 +1756,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1166,7 +1783,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1177,7 +1794,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1244,7 +1861,7 @@ checksum = "84fd902d4e0b9a4b27f2f440108dc034e1758628a9b702f8ec61ad66355422fa"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1272,7 +1889,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1285,10 +1902,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "typenum"
-version = "1.19.0"
+name = "typed-builder"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "fef81aec2ca29576f9f6ae8755108640d0a86dd3161b2e8bca6cfa554e98f77d"
+dependencies = [
+ "typed-builder-macro",
+]
+
+[[package]]
+name = "typed-builder-macro"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ecb9ecf7799210407c14a8cfdfe0173365780968dc57973ed082211958e0b18"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "unicode-ident"
@@ -1321,6 +1952,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "uriparse"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0200d0fc04d809396c2ad43f3c95da3582a2556eba8d453c1087f4120ee352ff"
+dependencies = [
+ "fnv",
+ "lazy_static",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1334,10 +1975,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "ustr"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18b19e258aa08450f93369cf56dd78063586adf19e92a75b338a800f799a0208"
+dependencies = [
+ "ahash",
+ "byteorder",
+ "lazy_static",
+ "parking_lot",
+ "serde",
+]
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "wasi"
@@ -1398,10 +2068,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-sys"
@@ -1411,6 +2099,71 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wit-bindgen"
@@ -1442,7 +2195,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -1458,7 +2211,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -1507,6 +2260,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
 name = "yoke"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1525,8 +2284,28 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1546,7 +2325,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -1580,7 +2359,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,6 @@ repository = "https://github.com/jorgsowa/php-lsp"
 readme = "README.md"
 
 [dependencies]
-mir-analyzer = "0.4.1"
-mir-issues = "0.4.1"
-mir-codebase = "0.4.1"
-mir-types = "0.4.1"
 php-rs-parser = "0.6.2"
 php-ast = "0.6.2"
 bumpalo = { version = "3", features = ["collections"] }
@@ -19,6 +15,14 @@ tower-lsp = "0.20"
 tokio = { version = "1", features = ["full"] }
 serde_json = "1"
 dashmap = "6"
+mago-syntax = "1.19.0"
+mago-linter = "1.19.0"
+mago-semantics = "1.19.0"
+mago-reporting = "1.19.0"
+mago-names = "1.19.0"
+mago-span = "1.19.0"
+mago-php-version = "1.19.0"
+mago-database = "1.19.0"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -154,13 +154,10 @@ pub struct Backend {
     psr4: Arc<RwLock<Psr4Map>>,
     meta: Arc<RwLock<PhpStormMeta>>,
     config: Arc<RwLock<LspConfig>>,
-    codebase: Arc<mir_codebase::Codebase>,
 }
 
 impl Backend {
     pub fn new(client: Client) -> Self {
-        let codebase = mir_codebase::Codebase::new();
-        mir_analyzer::stubs::load_stubs(&codebase);
         Backend {
             client,
             docs: Arc::new(DocumentStore::new()),
@@ -168,20 +165,14 @@ impl Backend {
             psr4: Arc::new(RwLock::new(Psr4Map::empty())),
             meta: Arc::new(RwLock::new(PhpStormMeta::default())),
             config: Arc::new(RwLock::new(LspConfig::default())),
-            codebase: Arc::new(codebase),
         }
     }
 
-    /// Run the definition collector for a single file, updating the persistent codebase.
-    fn collect_definitions_for(&self, uri: &Url, doc: &ParsedDoc) {
-        collect_into_codebase(&self.codebase, uri, doc);
-    }
-
-    /// Look up the import map for a file from the persistent codebase.
+    /// Look up the import map for a file from the document store.
     fn file_imports(&self, uri: &Url) -> std::collections::HashMap<String, String> {
-        self.codebase
+        self.docs
             .file_imports
-            .get(uri.as_str())
+            .get(uri)
             .map(|r| r.clone())
             .unwrap_or_default()
     }
@@ -421,7 +412,6 @@ impl LanguageServer for Backend {
 
             let docs = Arc::clone(&self.docs);
             let client = self.client.clone();
-            let codebase = Arc::clone(&self.codebase);
             let exclude_paths = self.config.read().unwrap().exclude_paths.clone();
             tokio::spawn(async move {
                 client
@@ -440,13 +430,7 @@ impl LanguageServer for Backend {
 
                 let mut total = 0usize;
                 for root in roots {
-                    total += scan_workspace(
-                        root,
-                        Arc::clone(&docs),
-                        &exclude_paths,
-                        Arc::clone(&codebase),
-                    )
-                    .await;
+                    total += scan_workspace(root, Arc::clone(&docs), &exclude_paths).await;
                 }
 
                 client
@@ -540,9 +524,8 @@ impl LanguageServer for Backend {
                 let ex = exclude_paths.clone();
                 let path_clone = path.clone();
                 let client = self.client.clone();
-                let cb = Arc::clone(&self.codebase);
                 tokio::spawn(async move {
-                    scan_workspace(path_clone, docs, &ex, cb).await;
+                    scan_workspace(path_clone, docs, &ex).await;
                     send_refresh_requests(&client).await;
                 });
             }
@@ -572,7 +555,6 @@ impl LanguageServer for Backend {
         let doc2 = self.docs.get_doc(&uri);
         let mut all_diags = diagnostics;
         if let Some(ref d) = doc2 {
-            self.collect_definitions_for(&uri, d);
             let diag_cfg = self.config.read().unwrap().diagnostics.clone();
             let dup_diags = duplicate_declaration_diagnostics(&stored_source, d, &diag_cfg);
             all_diags.extend(dup_diags);
@@ -594,7 +576,6 @@ impl LanguageServer for Backend {
 
         let docs = Arc::clone(&self.docs);
         let client = self.client.clone();
-        let codebase = Arc::clone(&self.codebase);
         let diag_cfg = self.config.read().unwrap().diagnostics.clone();
         tokio::spawn(async move {
             // 100 ms debounce: if another edit arrives before we parse, the
@@ -610,7 +591,6 @@ impl LanguageServer for Backend {
                 let source = docs.get(&uri).unwrap_or_default();
                 let mut all_diags = diagnostics;
                 if let Some(d) = docs.get_doc(&uri) {
-                    collect_into_codebase(&codebase, &uri, &d);
                     all_diags.extend(duplicate_declaration_diagnostics(&source, &d, &diag_cfg));
                     let other_raw = docs.other_docs(&uri);
                     let other_docs: Vec<Arc<ParsedDoc>> =
@@ -672,9 +652,6 @@ impl LanguageServer for Backend {
                         && let Ok(text) = tokio::fs::read_to_string(&path).await
                     {
                         self.docs.index(change.uri.clone(), &text);
-                        if let Some(d) = self.docs.get_doc(&change.uri) {
-                            self.collect_definitions_for(&change.uri, &d);
-                        }
                     }
                 }
                 FileChangeType::DELETED => {
@@ -1520,8 +1497,11 @@ impl LanguageServer for Backend {
                 ));
             }
         };
-        let diag_cfg = self.config.read().unwrap().diagnostics.clone();
-        let sem_diags = semantic_diagnostics(uri, &doc, &self.codebase, &diag_cfg);
+        let cfg = self.config.read().unwrap();
+        let diag_cfg = cfg.diagnostics.clone();
+        let php_ver = cfg.php_version.clone();
+        drop(cfg);
+        let sem_diags = semantic_diagnostics(uri, &doc, &diag_cfg, php_ver.as_deref());
         let dup_diags = duplicate_declaration_diagnostics(&source, &doc, &diag_cfg);
 
         let mut items = parse_diags;
@@ -1544,7 +1524,10 @@ impl LanguageServer for Backend {
         _params: WorkspaceDiagnosticParams,
     ) -> Result<WorkspaceDiagnosticReportResult> {
         let all_parse_diags = self.docs.all_diagnostics();
-        let diag_cfg = self.config.read().unwrap().diagnostics.clone();
+        let cfg = self.config.read().unwrap();
+        let diag_cfg = cfg.diagnostics.clone();
+        let php_ver = cfg.php_version.clone();
+        drop(cfg);
 
         let items: Vec<WorkspaceDocumentDiagnosticReport> = all_parse_diags
             .into_iter()
@@ -1552,7 +1535,7 @@ impl LanguageServer for Backend {
                 let doc = self.docs.get_doc(&uri)?;
 
                 let source = doc.source().to_string();
-                let sem_diags = semantic_diagnostics(&uri, &doc, &self.codebase, &diag_cfg);
+                let sem_diags = semantic_diagnostics(&uri, &doc, &diag_cfg, php_ver.as_deref());
                 let dup_diags = duplicate_declaration_diagnostics(&source, &doc, &diag_cfg);
 
                 let mut all_diags = parse_diags;
@@ -1587,8 +1570,11 @@ impl LanguageServer for Backend {
         let other_docs = self.docs.other_docs(uri);
 
         // Semantic diagnostics — collect undefined symbols and offer "Add use import"
-        let diag_cfg = self.config.read().unwrap().diagnostics.clone();
-        let sem_diags = semantic_diagnostics(uri, &doc, &self.codebase, &diag_cfg);
+        let (diag_cfg, php_ver) = {
+            let cfg = self.config.read().unwrap();
+            (cfg.diagnostics.clone(), cfg.php_version.clone())
+        };
+        let sem_diags = semantic_diagnostics(uri, &doc, &diag_cfg, php_ver.as_deref());
 
         // Publish semantic diagnostics merged with existing parse diagnostics
         if !sem_diags.is_empty() {
@@ -2053,19 +2039,6 @@ async fn send_refresh_requests(client: &Client) {
         .ok();
 }
 
-/// Run the definition collector for a single file against the persistent codebase.
-fn collect_into_codebase(codebase: &mir_codebase::Codebase, uri: &Url, doc: &ParsedDoc) {
-    let file: Arc<str> = Arc::from(uri.as_str());
-    let source_map = php_rs_parser::source_map::SourceMap::new(doc.source());
-    let collector = mir_analyzer::collector::DefinitionCollector::new(
-        codebase,
-        file,
-        doc.source(),
-        &source_map,
-    );
-    collector.collect(doc.program());
-}
-
 /// Maximum number of PHP files indexed during a workspace scan.
 /// Prevents excessive memory use on projects with very large vendor trees.
 const MAX_INDEXED_FILES: usize = 50_000;
@@ -2078,7 +2051,6 @@ async fn scan_workspace(
     root: PathBuf,
     docs: Arc<DocumentStore>,
     exclude_paths: &[String],
-    codebase: Arc<mir_codebase::Codebase>,
 ) -> usize {
     let mut count = 0usize;
     let mut stack = vec![root];
@@ -2120,9 +2092,6 @@ async fn scan_workspace(
                 && let Ok(text) = tokio::fs::read_to_string(&path).await
             {
                 docs.index(uri.clone(), &text);
-                if let Some(d) = docs.get_doc(&uri) {
-                    collect_into_codebase(&codebase, &uri, &d);
-                }
                 count += 1;
             }
         }

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -10,7 +10,9 @@ use tower_lsp::lsp_types::request::{
 use tower_lsp::lsp_types::*;
 use tower_lsp::{Client, LanguageServer, async_trait};
 
-use crate::ast::ParsedDoc;
+use php_ast::{ClassMemberKind, EnumMemberKind, NamespaceBody, Stmt, StmtKind};
+
+use crate::ast::{ParsedDoc, str_offset};
 use crate::autoload::Psr4Map;
 use crate::call_hierarchy::{incoming_calls, outgoing_calls, prepare_call_hierarchy};
 use crate::code_lens::code_lenses;
@@ -764,7 +766,16 @@ impl LanguageServer for Backend {
             Some(w) => w,
             None => return Ok(None),
         };
-        let kind = symbol_kind_at(&source, position, &word);
+        let kind = if let Some(doc) = self.docs.get_doc(uri) {
+            let stmts = &doc.program().stmts;
+            if cursor_is_on_method_decl(doc.source(), stmts, position) {
+                Some(SymbolKind::Method)
+            } else {
+                symbol_kind_at(&source, position, &word)
+            }
+        } else {
+            symbol_kind_at(&source, position, &word)
+        };
         let all_docs = self.docs.all_docs();
         let include_declaration = params.context.include_declaration;
         let locations = find_references(&word, &all_docs, include_declaration, kind);
@@ -1880,6 +1891,102 @@ fn symbol_kind_at(source: &str, position: Position, word: &str) -> Option<Symbol
     Some(SymbolKind::Function)
 }
 
+/// Convert an LSP `Position` to a byte offset within `source`.
+/// Returns `None` if the position is beyond the end of the source.
+fn position_to_offset(source: &str, position: Position) -> Option<u32> {
+    let mut byte_offset = 0usize;
+    for (idx, line) in source.split('\n').enumerate() {
+        if idx as u32 == position.line {
+            // Strip trailing \r so CRLF lines don't affect column counting.
+            let line_content = line.trim_end_matches('\r');
+            let mut col = 0u32;
+            for (byte_idx, ch) in line_content.char_indices() {
+                if col >= position.character {
+                    return Some((byte_offset + byte_idx) as u32);
+                }
+                col += ch.len_utf16() as u32;
+            }
+            return Some((byte_offset + line_content.len()) as u32);
+        }
+        byte_offset += line.len() + 1; // +1 for the '\n'
+    }
+    None
+}
+
+/// Returns `true` if the cursor is positioned on a method name inside a class,
+/// interface, trait, or enum declaration in the AST.
+///
+/// This is a pre-pass used before the character-based `symbol_kind_at` heuristic
+/// so that method *declarations* (`public function add() {}`) are classified as
+/// `SymbolKind::Method` rather than falling through to `SymbolKind::Function`.
+fn cursor_is_on_method_decl(source: &str, stmts: &[Stmt<'_, '_>], position: Position) -> bool {
+    let Some(cursor) = position_to_offset(source, position) else {
+        return false;
+    };
+
+    fn check(source: &str, stmts: &[Stmt<'_, '_>], cursor: u32) -> bool {
+        for stmt in stmts {
+            match &stmt.kind {
+                StmtKind::Class(c) => {
+                    for member in c.members.iter() {
+                        if let ClassMemberKind::Method(m) = &member.kind {
+                            let start = str_offset(source, m.name);
+                            let end = start + m.name.len() as u32;
+                            if cursor >= start && cursor < end {
+                                return true;
+                            }
+                        }
+                    }
+                }
+                StmtKind::Trait(t) => {
+                    for member in t.members.iter() {
+                        if let ClassMemberKind::Method(m) = &member.kind {
+                            let start = str_offset(source, m.name);
+                            let end = start + m.name.len() as u32;
+                            if cursor >= start && cursor < end {
+                                return true;
+                            }
+                        }
+                    }
+                }
+                StmtKind::Interface(i) => {
+                    for member in i.members.iter() {
+                        if let ClassMemberKind::Method(m) = &member.kind {
+                            let start = str_offset(source, m.name);
+                            let end = start + m.name.len() as u32;
+                            if cursor >= start && cursor < end {
+                                return true;
+                            }
+                        }
+                    }
+                }
+                StmtKind::Enum(e) => {
+                    for member in e.members.iter() {
+                        if let EnumMemberKind::Method(m) = &member.kind {
+                            let start = str_offset(source, m.name);
+                            let end = start + m.name.len() as u32;
+                            if cursor >= start && cursor < end {
+                                return true;
+                            }
+                        }
+                    }
+                }
+                StmtKind::Namespace(ns) => {
+                    if let NamespaceBody::Braced(inner) = &ns.body
+                        && check(source, inner, cursor)
+                    {
+                        return true;
+                    }
+                }
+                _ => {}
+            }
+        }
+        false
+    }
+
+    check(source, stmts, cursor)
+}
+
 impl Backend {
     /// Try to resolve a fully-qualified name via the PSR-4 map.
     /// Indexes the file on-demand if it is not already in the document store.
@@ -2381,6 +2488,147 @@ mod tests {
             "function diagnostic should not extract a class name"
         );
     }
+
+    // ── position_to_offset tests ─────────────────────────────────────────────
+
+    #[test]
+    fn position_to_offset_first_line() {
+        let src = "<?php\nfoo();";
+        // Line 0, character 0 → byte 0
+        assert_eq!(
+            position_to_offset(
+                src,
+                Position {
+                    line: 0,
+                    character: 0
+                }
+            ),
+            Some(0)
+        );
+        // Line 0, character 5 → byte 5 (the '\n')
+        assert_eq!(
+            position_to_offset(
+                src,
+                Position {
+                    line: 0,
+                    character: 5
+                }
+            ),
+            Some(5)
+        );
+    }
+
+    #[test]
+    fn position_to_offset_second_line() {
+        let src = "<?php\nfoo();";
+        // Line 1, character 0 → byte 6 (after '\n')
+        assert_eq!(
+            position_to_offset(
+                src,
+                Position {
+                    line: 1,
+                    character: 0
+                }
+            ),
+            Some(6)
+        );
+        // Line 1, character 3 → byte 9 ("foo" ends here)
+        assert_eq!(
+            position_to_offset(
+                src,
+                Position {
+                    line: 1,
+                    character: 3
+                }
+            ),
+            Some(9)
+        );
+    }
+
+    #[test]
+    fn position_to_offset_beyond_source_returns_none() {
+        let src = "<?php";
+        assert_eq!(
+            position_to_offset(
+                src,
+                Position {
+                    line: 5,
+                    character: 0
+                }
+            ),
+            None
+        );
+    }
+
+    // ── cursor_is_on_method_decl tests ──────────────────────────────────────
+
+    #[test]
+    fn cursor_on_method_decl_name_returns_true() {
+        // "    public function add() {}" — "add" starts at col 20 on line 2
+        let src = "<?php\nclass C {\n    public function add() {}\n}";
+        let doc = ParsedDoc::parse(src.to_string());
+        let stmts = &doc.program().stmts;
+        // Cursor on 'a' of 'add'
+        assert!(cursor_is_on_method_decl(
+            src,
+            stmts,
+            Position {
+                line: 2,
+                character: 20
+            }
+        ));
+        // Cursor mid-name
+        assert!(cursor_is_on_method_decl(
+            src,
+            stmts,
+            Position {
+                line: 2,
+                character: 21
+            }
+        ));
+        // Cursor just past the name should not match
+        assert!(!cursor_is_on_method_decl(
+            src,
+            stmts,
+            Position {
+                line: 2,
+                character: 23
+            }
+        ));
+    }
+
+    #[test]
+    fn cursor_on_free_function_decl_returns_false() {
+        let src = "<?php\nfunction add() {}";
+        let doc = ParsedDoc::parse(src.to_string());
+        let stmts = &doc.program().stmts;
+        // "add" starts at col 9 on line 1 — this is a free function, not a method
+        assert!(!cursor_is_on_method_decl(
+            src,
+            stmts,
+            Position {
+                line: 1,
+                character: 9
+            }
+        ));
+    }
+
+    #[test]
+    fn cursor_on_method_call_site_returns_false() {
+        // The call site "$c->add()" has no method declaration — should return false
+        let src = "<?php\nclass C { public function add() {} }\n$c = new C();\n$c->add();";
+        let doc = ParsedDoc::parse(src.to_string());
+        let stmts = &doc.program().stmts;
+        // "$c->add()" — "add" starts at col 4 on line 3
+        assert!(!cursor_is_on_method_decl(
+            src,
+            stmts,
+            Position {
+                line: 3,
+                character: 4
+            }
+        ));
+    }
 }
 
 #[cfg(test)]
@@ -2678,6 +2926,88 @@ mod integration {
         assert!(
             resp["error"].is_null(),
             "hover after change should not error"
+        );
+    }
+
+    /// Regression test for issue #125: cursor on a method *declaration* must
+    /// return method references, not free-function references with the same name.
+    #[tokio::test]
+    async fn references_on_method_decl_returns_method_refs_not_function_refs() {
+        // Line 0: <?php
+        // Line 1: function add() {}          ← free function declaration
+        // Line 2: class C {
+        // Line 3:     public function add() {} ← method declaration — cursor here
+        // Line 4: }
+        // Line 5: add();                     ← free function call
+        // Line 6: $c->add();                 ← method call
+        let src = "<?php\nfunction add() {}\nclass C {\n    public function add() {}\n}\nadd();\n$c->add();";
+
+        let mut client = start_server();
+        initialize(&mut client).await;
+
+        client
+            .notify(
+                "textDocument/didOpen",
+                serde_json::json!({
+                    "textDocument": {
+                        "uri": "file:///refs_test.php",
+                        "languageId": "php",
+                        "version": 1,
+                        "text": src
+                    }
+                }),
+            )
+            .await;
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(150)).await;
+
+        // Cursor on "add" in "    public function add() {}" — line 3, character 20.
+        let resp = client
+            .request(
+                "textDocument/references",
+                serde_json::json!({
+                    "textDocument": { "uri": "file:///refs_test.php" },
+                    "position": { "line": 3, "character": 20 },
+                    "context": { "includeDeclaration": true }
+                }),
+            )
+            .await;
+
+        assert!(
+            resp["error"].is_null(),
+            "references should not error: {:?}",
+            resp
+        );
+
+        let locs = resp["result"]
+            .as_array()
+            .expect("expected array of locations");
+        let lines: Vec<u32> = locs
+            .iter()
+            .map(|l| l["range"]["start"]["line"].as_u64().unwrap() as u32)
+            .collect();
+
+        // Must include the method declaration (line 3) and the method call (line 6).
+        assert!(
+            lines.contains(&3),
+            "method declaration on line 3 must be included, got lines: {:?}",
+            lines
+        );
+        assert!(
+            lines.contains(&6),
+            "method call on line 6 must be included, got lines: {:?}",
+            lines
+        );
+        // Must NOT include the free-function declaration (line 1) or call (line 5).
+        assert!(
+            !lines.contains(&1),
+            "free-function declaration on line 1 must be excluded, got lines: {:?}",
+            lines
+        );
+        assert!(
+            !lines.contains(&5),
+            "free-function call on line 5 must be excluded, got lines: {:?}",
+            lines
         );
     }
 

--- a/src/docblock.rs
+++ b/src/docblock.rs
@@ -1,10 +1,4 @@
 /// Docblock (`/** ... */`) parser.
-///
-/// Delegates to [`mir_analyzer::DocblockParser`] for type parsing and
-/// [`php_rs_parser::phpdoc`] for description extraction.
-use std::collections::HashMap;
-
-use mir_analyzer::DocblockParser;
 use php_rs_parser::phpdoc::{self, PhpDocTag};
 
 #[derive(Debug, Default, PartialEq)]
@@ -166,153 +160,223 @@ impl Docblock {
 
 /// Parse a raw docblock string (the full `/** ... */` text, or just the
 /// inner content — either form is handled).
-///
-/// Delegates to [`mir_analyzer::DocblockParser`] for type resolution and
-/// [`php_rs_parser::phpdoc`] for description fields.
 pub fn parse_docblock(raw: &str) -> Docblock {
-    let mir = DocblockParser::parse(raw);
     let raw_doc = phpdoc::parse(raw);
 
-    // Collect descriptions from the raw tags (mir discards them).
-    let mut param_descs: HashMap<String, String> = HashMap::new();
-    let mut return_desc = String::new();
-    let mut throws_descs: Vec<String> = Vec::new();
-    let mut var_desc: Option<String> = None;
+    let description = match (raw_doc.summary, raw_doc.description) {
+        (Some(s), Some(d)) => format!("{}\n\n{}", s, d),
+        (Some(s), None) => s.to_string(),
+        (None, Some(d)) => d.to_string(),
+        (None, None) => String::new(),
+    };
+
+    let mut params: Vec<DocParam> = Vec::new();
+    let mut return_type: Option<DocReturn> = None;
+    let mut var_type: Option<String> = None;
+    let mut var_name: Option<String> = None;
+    let mut var_description: Option<String> = None;
+    let mut deprecated: Option<String> = None;
+    let mut throws: Vec<DocThrows> = Vec::new();
+    let mut see: Vec<String> = Vec::new();
+    let mut templates: Vec<DocTemplate> = Vec::new();
+    let mut mixins: Vec<String> = Vec::new();
+    let mut type_aliases: Vec<DocTypeAlias> = Vec::new();
+    let mut properties: Vec<DocProperty> = Vec::new();
+    let mut methods: Vec<DocMethod> = Vec::new();
 
     for tag in &raw_doc.tags {
         match tag {
             PhpDocTag::Param {
-                name: Some(n),
-                description: Some(d),
-                ..
-            } => {
-                param_descs.insert(n.trim_start_matches('$').to_string(), d.to_string());
-            }
-            PhpDocTag::Return {
-                description: Some(d),
-                ..
-            } => {
-                return_desc = d.to_string();
-            }
-            PhpDocTag::Throws {
-                type_str: Some(ts),
+                type_str,
+                name,
                 description,
             } => {
-                let class = ts.split_whitespace().next().unwrap_or("");
-                if !class.is_empty() {
-                    throws_descs.push(
-                        description
-                            .as_ref()
-                            .map(|d| d.to_string())
-                            .unwrap_or_default(),
-                    );
+                let type_hint = type_str.map(normalize_type).unwrap_or_default();
+                let name_str = name
+                    .map(|n| {
+                        if n.starts_with('$') {
+                            n.to_string()
+                        } else {
+                            format!("${}", n)
+                        }
+                    })
+                    .unwrap_or_default();
+                let desc = description.as_deref().unwrap_or("").to_string();
+                params.push(DocParam {
+                    type_hint,
+                    name: name_str,
+                    description: desc,
+                });
+            }
+            PhpDocTag::Return {
+                type_str,
+                description,
+            } => {
+                if return_type.is_none() {
+                    let type_hint = type_str.map(normalize_type).unwrap_or_default();
+                    let desc = description.as_deref().unwrap_or("").to_string();
+                    return_type = Some(DocReturn {
+                        type_hint,
+                        description: desc,
+                    });
                 }
             }
             PhpDocTag::Var {
-                description: Some(d),
+                type_str,
+                name,
+                description,
+            } => {
+                var_type = type_str.map(normalize_type);
+                var_name = name.map(|n| n.trim_start_matches('$').to_string());
+                var_description = description.as_deref().map(str::to_string);
+            }
+            PhpDocTag::Throws {
+                type_str,
+                description,
+            } => {
+                let class = type_str
+                    .and_then(|ts| ts.split_whitespace().next())
+                    .unwrap_or("")
+                    .to_string();
+                if !class.is_empty() {
+                    let desc = description.as_deref().unwrap_or("").to_string();
+                    throws.push(DocThrows {
+                        class,
+                        description: desc,
+                    });
+                }
+            }
+            PhpDocTag::Deprecated { description } => {
+                deprecated = Some(description.as_deref().unwrap_or("").to_string());
+            }
+            PhpDocTag::Template { name, bound }
+            | PhpDocTag::TemplateCovariant { name, bound }
+            | PhpDocTag::TemplateContravariant { name, bound } => {
+                templates.push(DocTemplate {
+                    name: name.to_string(),
+                    bound: bound.map(str::to_string),
+                });
+            }
+            PhpDocTag::Mixin { class } => {
+                mixins.push(class.to_string());
+            }
+            PhpDocTag::TypeAlias {
+                name: Some(name),
+                type_str,
+            } => {
+                type_aliases.push(DocTypeAlias {
+                    name: name.to_string(),
+                    type_expr: type_str.unwrap_or("").to_string(),
+                });
+            }
+            PhpDocTag::Property {
+                type_str,
+                name: Some(name),
                 ..
             } => {
-                var_desc = Some(d.to_string());
+                properties.push(DocProperty {
+                    type_hint: type_str.map(normalize_type).unwrap_or_default(),
+                    name: name.trim_start_matches('$').to_string(),
+                    read_only: false,
+                });
             }
+            PhpDocTag::PropertyRead {
+                type_str,
+                name: Some(name),
+                ..
+            } => {
+                properties.push(DocProperty {
+                    type_hint: type_str.map(normalize_type).unwrap_or_default(),
+                    name: name.trim_start_matches('$').to_string(),
+                    read_only: true,
+                });
+            }
+            PhpDocTag::PropertyWrite {
+                type_str,
+                name: Some(name),
+                ..
+            } => {
+                properties.push(DocProperty {
+                    type_hint: type_str.map(normalize_type).unwrap_or_default(),
+                    name: name.trim_start_matches('$').to_string(),
+                    read_only: false,
+                });
+            }
+            PhpDocTag::Method { signature } => {
+                if let Some(m) = parse_method_signature(signature) {
+                    methods.push(m);
+                }
+            }
+            PhpDocTag::See { reference } => see.push(reference.to_string()),
+            PhpDocTag::Link { url } => see.push(url.to_string()),
             _ => {}
         }
     }
 
-    let params: Vec<DocParam> = mir
-        .params
-        .iter()
-        .map(|(name, union)| {
-            let description = param_descs.get(name.as_str()).cloned().unwrap_or_default();
-            DocParam {
-                type_hint: union.to_string(),
-                name: format!("${}", name),
-                description,
-            }
-        })
-        .collect();
-
-    let return_type = mir.return_type.as_ref().map(|union| DocReturn {
-        type_hint: union.to_string(),
-        description: return_desc,
-    });
-
-    let throws: Vec<DocThrows> = mir
-        .throws
-        .iter()
-        .enumerate()
-        .map(|(i, class)| DocThrows {
-            class: class.clone(),
-            description: throws_descs.get(i).cloned().unwrap_or_default(),
-        })
-        .collect();
-
-    let deprecated = if mir.is_deprecated {
-        Some(mir.deprecated.as_deref().unwrap_or("").to_string())
-    } else {
-        None
-    };
-
-    let templates: Vec<DocTemplate> = mir
-        .templates
-        .iter()
-        .map(|(name, bound, _variance)| DocTemplate {
-            name: name.clone(),
-            bound: bound.as_ref().map(|u| u.to_string()),
-        })
-        .collect();
-
-    let properties: Vec<DocProperty> = mir
-        .properties
-        .iter()
-        .map(|p| DocProperty {
-            type_hint: p.type_hint.clone(),
-            name: p.name.clone(),
-            read_only: p.read_only,
-        })
-        .collect();
-
-    let methods: Vec<DocMethod> = mir
-        .methods
-        .iter()
-        .map(|m| DocMethod {
-            return_type: m.return_type.clone(),
-            name: m.name.clone(),
-            is_static: m.is_static,
-        })
-        .collect();
-
-    let type_aliases: Vec<DocTypeAlias> = mir
-        .type_aliases
-        .iter()
-        .map(|ta| DocTypeAlias {
-            name: ta.name.clone(),
-            type_expr: ta.type_expr.clone(),
-        })
-        .collect();
-
     Docblock {
-        description: mir.description.clone(),
+        description,
         params,
         return_type,
-        var_type: mir.var_type.as_ref().map(|u| u.to_string()),
-        var_name: mir.var_name.clone(),
-        var_description: var_desc,
+        var_type,
+        var_name,
+        var_description,
         deprecated,
         throws,
-        see: mir.see.clone(),
+        see,
         templates,
-        mixins: mir.mixins.clone(),
+        mixins,
         type_aliases,
         properties,
         methods,
     }
 }
 
+/// Normalize a PHP type hint string: `?Foo` → `Foo|null`.
+fn normalize_type(type_str: &str) -> String {
+    match type_str.strip_prefix('?') {
+        Some(inner) => format!("{}|null", inner),
+        None => type_str.to_string(),
+    }
+}
+
+/// Parse a `@method` signature: `[static] ReturnType name([params])`.
+fn parse_method_signature(sig: &str) -> Option<DocMethod> {
+    let sig = sig.trim();
+    let (is_static, rest) = match sig.strip_prefix("static ") {
+        Some(r) => (true, r.trim()),
+        None => (false, sig),
+    };
+    let paren = rest.find('(')?;
+    let before_paren = rest[..paren].trim();
+    let name_start = before_paren
+        .rfind(|c: char| c.is_whitespace())
+        .map(|p| p + 1)
+        .unwrap_or(0);
+    let name = before_paren[name_start..].trim();
+    if name.is_empty() {
+        return None;
+    }
+    let return_type = before_paren[..name_start].trim().to_string();
+    Some(DocMethod {
+        return_type,
+        name: name.to_string(),
+        is_static,
+    })
+}
+
 /// Scan `source` for a `/** ... */` docblock that ends immediately before
 /// `node_start` (byte offset). Whitespace between the `*/` and the node is
 /// allowed; non-whitespace text in between disqualifies the block.
 pub fn docblock_before(source: &str, node_start: u32) -> Option<String> {
-    mir_analyzer::parser::find_preceding_docblock(source, node_start)
+    let prefix = source.get(..node_start as usize)?;
+    // Strip trailing whitespace — only whitespace may separate the docblock from
+    // the node. If anything else trails, there is no adjacent docblock.
+    let trimmed = prefix.trim_end_matches(|c: char| c.is_whitespace());
+    // The remaining text must end with `*/`.
+    let without_close = trimmed.strip_suffix("*/")?;
+    // Find the opening `/**` of this docblock.
+    let open = without_close.rfind("/**")?;
+    Some(trimmed[open..].to_string())
 }
 
 /// Walk an AST and return the parsed docblock for the declaration named `word`.
@@ -867,7 +931,7 @@ mod tests {
 
     #[test]
     fn advanced_type_non_empty_string() {
-        // mir resolves psalm/phpstan special types; non-empty-string must round-trip.
+        // psalm/phpstan special types like non-empty-string must round-trip unchanged.
         let raw = "/**\n * @return non-empty-string\n */";
         let db = parse_docblock(raw);
         assert_eq!(
@@ -880,7 +944,7 @@ mod tests {
 
     #[test]
     fn advanced_type_generic_array() {
-        // array<K, V> generic syntax must round-trip through mir's Union display.
+        // array<K, V> generic syntax must round-trip through parse_docblock unchanged.
         let raw = "/**\n * @param array<int, string> $map\n */";
         let db = parse_docblock(raw);
         assert_eq!(db.params.len(), 1);
@@ -893,8 +957,7 @@ mod tests {
 
     #[test]
     fn param_and_return_descriptions_preserved() {
-        // Descriptions from @param and @return are captured via php-rs-parser
-        // (mir discards them). Verify they survive the full parse_docblock() call.
+        // Descriptions from @param and @return must survive the full parse_docblock() call.
         let raw = "/**\n * @param string $name The user name\n * @return int The age\n */";
         let db = parse_docblock(raw);
         assert_eq!(
@@ -910,7 +973,7 @@ mod tests {
 
     #[test]
     fn throws_description_preserved() {
-        // @throws description must survive the adapter (mir only stores the class).
+        // @throws description must survive alongside the class name.
         let raw = "/**\n * @throws RuntimeException When the server is down\n */";
         let db = parse_docblock(raw);
         assert_eq!(db.throws.len(), 1);

--- a/src/document_store.rs
+++ b/src/document_store.rs
@@ -1,7 +1,8 @@
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, Mutex};
 
 use dashmap::DashMap;
+use php_ast::{NamespaceBody, StmtKind};
 use tower_lsp::lsp_types::{Diagnostic, SemanticToken, Url};
 
 use crate::ast::ParsedDoc;
@@ -30,6 +31,8 @@ pub struct DocumentStore {
     /// Cached semantic tokens per document: (result_id, tokens).
     /// Used to compute incremental deltas for `textDocument/semanticTokens/full/delta`.
     token_cache: DashMap<Url, (String, Vec<SemanticToken>)>,
+    /// Maps file URI → (alias → FQN) built from `use` statements in each parsed document.
+    pub file_imports: DashMap<Url, HashMap<String, String>>,
 }
 
 impl DocumentStore {
@@ -38,6 +41,7 @@ impl DocumentStore {
             map: DashMap::new(),
             indexed_order: Mutex::new(VecDeque::new()),
             token_cache: DashMap::new(),
+            file_imports: DashMap::new(),
         }
     }
 
@@ -66,6 +70,8 @@ impl DocumentStore {
         if let Some(mut entry) = self.map.get_mut(uri)
             && entry.text_version == version
         {
+            let imports = build_file_imports(&doc);
+            self.file_imports.insert(uri.clone(), imports);
             entry.doc = Arc::new(doc);
             entry.diagnostics = diagnostics;
             return true;
@@ -94,6 +100,8 @@ impl DocumentStore {
             return;
         }
         let (doc, diagnostics) = parse_document(text);
+        let imports = build_file_imports(&doc);
+        self.file_imports.insert(uri.clone(), imports);
         self.map.insert(
             uri.clone(),
             Document {
@@ -133,6 +141,7 @@ impl DocumentStore {
     pub fn remove(&self, uri: &Url) {
         self.map.remove(uri);
         self.token_cache.remove(uri);
+        self.file_imports.remove(uri);
     }
 
     /// Cache the semantic tokens computed for a delta response.
@@ -192,6 +201,39 @@ impl DocumentStore {
             .filter(|e| e.key() != uri)
             .map(|e| (e.key().clone(), e.value().doc.clone()))
             .collect()
+    }
+}
+
+/// Build an alias→FQN map from `use` statements in `doc`.
+///
+/// `use App\Services\Mailer;`         → `{"Mailer" => "App\\Services\\Mailer"}`
+/// `use App\Services\Mailer as Mail;` → `{"Mail"   => "App\\Services\\Mailer"}`
+fn build_file_imports(doc: &ParsedDoc) -> HashMap<String, String> {
+    let mut map = HashMap::new();
+    collect_use_stmts(&doc.program().stmts, &mut map);
+    map
+}
+
+fn collect_use_stmts(stmts: &[php_ast::Stmt<'_, '_>], map: &mut HashMap<String, String>) {
+    for stmt in stmts {
+        match &stmt.kind {
+            StmtKind::Use(u) => {
+                for item in u.uses.iter() {
+                    let fqn = item.name.to_string_repr().replace('/', "\\");
+                    let alias = item
+                        .alias
+                        .map(|a| a.to_string())
+                        .unwrap_or_else(|| fqn.rsplit('\\').next().unwrap_or(&fqn).to_string());
+                    map.insert(alias, fqn);
+                }
+            }
+            StmtKind::Namespace(ns) => {
+                if let NamespaceBody::Braced(inner) = &ns.body {
+                    collect_use_stmts(inner, map);
+                }
+            }
+            _ => {}
+        }
     }
 }
 

--- a/src/references.rs
+++ b/src/references.rs
@@ -66,7 +66,15 @@ fn find_references_inner(
         } else {
             match kind {
                 Some(SymbolKind::Function) => function_refs_in_stmts(stmts, word, &mut spans),
-                Some(SymbolKind::Method) => method_refs_in_stmts(stmts, word, &mut spans),
+                Some(SymbolKind::Method) => {
+                    method_refs_in_stmts(stmts, word, &mut spans);
+                    // The method walker only emits call sites. When the declaration is
+                    // requested, also collect the method name spans from class/trait/enum
+                    // declarations so they appear in the results.
+                    if include_declaration {
+                        method_decl_spans(source, stmts, word, &mut spans);
+                    }
+                }
                 Some(SymbolKind::Class) => class_refs_in_stmts(stmts, word, &mut spans),
                 None => refs_in_stmts(source, stmts, word, &mut spans),
             }
@@ -91,6 +99,74 @@ fn find_references_inner(
     }
 
     locations
+}
+
+/// Collect the name spans of every method named `word` declared inside a class,
+/// interface, trait, or enum in `stmts`. Used to include declaration sites in
+/// method reference results, since the method call walker only emits call sites.
+fn method_decl_spans(source: &str, stmts: &[Stmt<'_, '_>], word: &str, out: &mut Vec<Span>) {
+    for stmt in stmts {
+        match &stmt.kind {
+            StmtKind::Class(c) => {
+                for member in c.members.iter() {
+                    if let ClassMemberKind::Method(m) = &member.kind
+                        && m.name == word
+                    {
+                        let start = str_offset(source, m.name);
+                        out.push(Span {
+                            start,
+                            end: start + m.name.len() as u32,
+                        });
+                    }
+                }
+            }
+            StmtKind::Trait(t) => {
+                for member in t.members.iter() {
+                    if let ClassMemberKind::Method(m) = &member.kind
+                        && m.name == word
+                    {
+                        let start = str_offset(source, m.name);
+                        out.push(Span {
+                            start,
+                            end: start + m.name.len() as u32,
+                        });
+                    }
+                }
+            }
+            StmtKind::Interface(i) => {
+                for member in i.members.iter() {
+                    if let ClassMemberKind::Method(m) = &member.kind
+                        && m.name == word
+                    {
+                        let start = str_offset(source, m.name);
+                        out.push(Span {
+                            start,
+                            end: start + m.name.len() as u32,
+                        });
+                    }
+                }
+            }
+            StmtKind::Enum(e) => {
+                for member in e.members.iter() {
+                    if let EnumMemberKind::Method(m) = &member.kind
+                        && m.name == word
+                    {
+                        let start = str_offset(source, m.name);
+                        out.push(Span {
+                            start,
+                            end: start + m.name.len() as u32,
+                        });
+                    }
+                }
+            }
+            StmtKind::Namespace(ns) => {
+                if let NamespaceBody::Braced(inner) = &ns.body {
+                    method_decl_spans(source, inner, word, out);
+                }
+            }
+            _ => {}
+        }
+    }
 }
 
 /// Returns true if this span is the declaration site (function/class/method name).
@@ -133,6 +209,16 @@ fn is_declaration_span(source: &str, stmts: &[Stmt<'_, '_>], word: &str, span: &
                 StmtKind::Interface(i) if i.name == word => {
                     if spans_equal(&name_span(source, i.name), span) {
                         return true;
+                    }
+                }
+                StmtKind::Interface(i) => {
+                    for member in i.members.iter() {
+                        if let ClassMemberKind::Method(m) = &member.kind
+                            && m.name == word
+                            && spans_equal(&name_span(source, m.name), span)
+                        {
+                            return true;
+                        }
                     }
                 }
                 StmtKind::Trait(t) if t.name == word => {
@@ -572,6 +658,45 @@ mod tests {
         assert_eq!(
             decl_ref.range.start.character, 20,
             "method declaration should start at the method name, not 'public function'"
+        );
+    }
+
+    #[test]
+    fn method_kind_with_declaration_excludes_free_function() {
+        // Reproduces issue #125: cursor on a method *declaration* must return
+        // only method-related refs, not free-function refs of the same name.
+        let src = "<?php\nfunction add() {}\nclass C {\n    public function add() {}\n}\nadd();\n$c->add();";
+        let docs = vec![doc("/a.php", src)];
+        // Searching with SymbolKind::Method (as the fixed code would produce) must:
+        //  - Include the method declaration on line 3 (include_declaration=true)
+        //  - Include the method call on line 6
+        //  - Exclude the free-function declaration on line 1
+        //  - Exclude the free-function call on line 5
+        let refs = find_references("add", &docs, true, Some(SymbolKind::Method));
+        let lines: Vec<u32> = {
+            let mut v: Vec<u32> = refs.iter().map(|r| r.range.start.line).collect();
+            v.sort_unstable();
+            v
+        };
+        assert!(
+            lines.contains(&3),
+            "method declaration on line 3 must be included, got: {:?}",
+            lines
+        );
+        assert!(
+            lines.contains(&6),
+            "method call on line 6 must be included, got: {:?}",
+            lines
+        );
+        assert!(
+            !lines.contains(&1),
+            "free-function declaration on line 1 must be excluded, got: {:?}",
+            lines
+        );
+        assert!(
+            !lines.contains(&5),
+            "free-function call on line 5 must be excluded, got: {:?}",
+            lines
         );
     }
 }

--- a/src/semantic_diagnostics.rs
+++ b/src/semantic_diagnostics.rs
@@ -57,8 +57,10 @@ pub fn semantic_diagnostics(
     let sem_issues = sem_checker.check(&mago_file, program, &resolved_names);
 
     // Run linter with the same PHP version used for semantic checks.
-    let mut linter_settings = LinterSettings::default();
-    linter_settings.php_version = php_version;
+    let linter_settings = LinterSettings {
+        php_version,
+        ..LinterSettings::default()
+    };
     let linter = Linter::new(&arena, &linter_settings, None, false);
     let lint_issues = linter.lint(&mago_file, program, &resolved_names);
 

--- a/src/semantic_diagnostics.rs
+++ b/src/semantic_diagnostics.rs
@@ -56,8 +56,9 @@ pub fn semantic_diagnostics(
     let sem_checker = SemanticsChecker::new(php_version);
     let sem_issues = sem_checker.check(&mago_file, program, &resolved_names);
 
-    // Run linter with default settings.
-    let linter_settings = LinterSettings::default();
+    // Run linter with the same PHP version used for semantic checks.
+    let mut linter_settings = LinterSettings::default();
+    linter_settings.php_version = php_version;
     let linter = Linter::new(&arena, &linter_settings, None, false);
     let lint_issues = linter.lint(&mago_file, program, &resolved_names);
 
@@ -896,6 +897,292 @@ mod tests {
             d.range.end.line, 3,
             "range end should be on same line as start"
         );
+    }
+
+    // ── mago analysis path ────────────────────────────────────────────────────
+    //
+    // These tests exercise `semantic_diagnostics()` end-to-end, verifying that
+    // mago's linter + semantics checker produce (or correctly suppress)
+    // diagnostics for real PHP source.
+
+    mod mago_analysis {
+        use super::*;
+        use tower_lsp::lsp_types::Url;
+
+        fn url() -> Url {
+            Url::parse("file:///test.php").unwrap()
+        }
+
+        fn run(src: &str) -> Vec<Diagnostic> {
+            let doc = ParsedDoc::parse(src.to_string());
+            semantic_diagnostics(&url(), &doc, &DiagnosticsConfig::default(), None)
+        }
+
+        // ── Master switch ─────────────────────────────────────────────────────
+
+        #[test]
+        fn disabled_config_always_returns_empty() {
+            let src = "<?php\nnew NonExistentClass();\n";
+            let doc = ParsedDoc::parse(src.to_string());
+            let cfg = DiagnosticsConfig {
+                enabled: false,
+                ..DiagnosticsConfig::default()
+            };
+            let diags = semantic_diagnostics(&url(), &doc, &cfg, None);
+            assert!(diags.is_empty(), "got: {:?}", diags);
+        }
+
+        // ── No false positives on valid PHP ───────────────────────────────────
+
+        #[test]
+        fn valid_php_with_strict_types_produces_no_errors() {
+            // Files with declare(strict_types=1) satisfy the linter's strict-types
+            // rule and should produce no error-severity diagnostics.
+            let src = concat!(
+                "<?php\n",
+                "declare(strict_types=1);\n",
+                "function hello(): string { return 'world'; }\n",
+            );
+            let errors: Vec<_> = run(src)
+                .into_iter()
+                .filter(|d| d.severity == Some(DiagnosticSeverity::ERROR))
+                .collect();
+            assert!(errors.is_empty(), "got: {:?}", errors);
+        }
+
+        #[test]
+        fn simple_function_produces_no_errors() {
+            let src = concat!(
+                "<?php\n",
+                "function add(int $a, int $b): int {\n",
+                "    return $a + $b;\n",
+                "}\n",
+                "echo add(1, 2);\n",
+            );
+            let errors: Vec<_> = run(src)
+                .into_iter()
+                .filter(|d| d.severity == Some(DiagnosticSeverity::ERROR))
+                .collect();
+            assert!(errors.is_empty(), "got: {:?}", errors);
+        }
+
+        #[test]
+        fn simple_class_produces_no_errors() {
+            let src = concat!(
+                "<?php\n",
+                "class Box {\n",
+                "    public function __construct(public readonly int $value) {}\n",
+                "    public function doubled(): int { return $this->value * 2; }\n",
+                "}\n",
+                "$b = new Box(21);\n",
+                "echo $b->doubled();\n",
+            );
+            let errors: Vec<_> = run(src)
+                .into_iter()
+                .filter(|d| d.severity == Some(DiagnosticSeverity::ERROR))
+                .collect();
+            assert!(errors.is_empty(), "got: {:?}", errors);
+        }
+
+        #[test]
+        fn php81_enum_produces_no_errors_on_81() {
+            let src = concat!(
+                "<?php\n",
+                "enum Status {\n",
+                "    case Active;\n",
+                "    case Inactive;\n",
+                "}\n",
+            );
+            let doc = ParsedDoc::parse(src.to_string());
+            let errors: Vec<_> =
+                semantic_diagnostics(&url(), &doc, &DiagnosticsConfig::default(), Some("8.1"))
+                    .into_iter()
+                    .filter(|d| d.severity == Some(DiagnosticSeverity::ERROR))
+                    .collect();
+            assert!(
+                errors.is_empty(),
+                "enum should be valid in PHP 8.1, got: {:?}",
+                errors
+            );
+        }
+
+        // ── Linter rules ──────────────────────────────────────────────────────
+        //
+        // mago's semantics checker operates in single-file mode and does not
+        // resolve cross-file symbols, so undefined-class/function detection
+        // requires the full workspace index that only the backend provides.
+        // At the unit-test level we therefore exercise the *linter* rules that
+        // fire on single-file analysis.
+
+        #[test]
+        fn missing_strict_types_declaration_is_flagged() {
+            // mago's linter emits a "strict-types" diagnostic for any file that
+            // lacks `declare(strict_types=1)`.
+            use tower_lsp::lsp_types::NumberOrString;
+            let src = "<?php\nfunction hello(): string { return 'world'; }\n";
+            let diags = run(src);
+            assert!(
+                diags
+                    .iter()
+                    .any(|d| d.code == Some(NumberOrString::String("strict-types".to_string()))),
+                "expected strict-types diagnostic, got: {:?}",
+                diags
+            );
+        }
+
+        #[test]
+        fn strict_types_diagnostic_is_warning_or_information() {
+            use tower_lsp::lsp_types::NumberOrString;
+            let src = "<?php\nfunction hello(): string { return 'world'; }\n";
+            let diags = run(src);
+            let strict = diags
+                .iter()
+                .find(|d| d.code == Some(NumberOrString::String("strict-types".to_string())));
+            let sev = strict.and_then(|d| d.severity).unwrap();
+            assert!(
+                sev == DiagnosticSeverity::WARNING || sev == DiagnosticSeverity::INFORMATION,
+                "strict-types should not be an error, got: {:?}",
+                sev
+            );
+        }
+
+        #[test]
+        fn adding_strict_types_declaration_clears_lint_warning() {
+            use tower_lsp::lsp_types::NumberOrString;
+            let without = "<?php\nfunction hello(): string { return 'world'; }\n";
+            let with =
+                "<?php\ndeclare(strict_types=1);\nfunction hello(): string { return 'world'; }\n";
+            let diags_without = run(without);
+            let diags_with = run(with);
+            assert!(
+                diags_without
+                    .iter()
+                    .any(|d| d.code == Some(NumberOrString::String("strict-types".to_string()))),
+                "expected strict-types without declaration, got: {:?}",
+                diags_without
+            );
+            assert!(
+                !diags_with
+                    .iter()
+                    .any(|d| d.code == Some(NumberOrString::String("strict-types".to_string()))),
+                "strict-types should clear when declaration is present, got: {:?}",
+                diags_with
+            );
+        }
+
+        // ── Diagnostic shape ──────────────────────────────────────────────────
+
+        #[test]
+        fn all_diagnostics_have_severity() {
+            let src = "<?php\nnew Xyzzy_Qux_NonExistent_99();\n";
+            for d in run(src) {
+                assert!(d.severity.is_some(), "diagnostic missing severity: {:?}", d);
+            }
+        }
+
+        #[test]
+        fn all_diagnostics_have_source_php_lsp() {
+            let src = "<?php\nnew Xyzzy_Qux_NonExistent_99();\n";
+            for d in run(src) {
+                assert_eq!(
+                    d.source.as_deref(),
+                    Some("php-lsp"),
+                    "unexpected source: {:?}",
+                    d
+                );
+            }
+        }
+
+        #[test]
+        fn all_diagnostics_have_valid_ranges() {
+            let src = "<?php\nnew Xyzzy_Qux_NonExistent_99();\n";
+            for d in run(src) {
+                assert!(
+                    d.range.start.line <= d.range.end.line,
+                    "start.line > end.line: {:?}",
+                    d.range
+                );
+                if d.range.start.line == d.range.end.line {
+                    assert!(
+                        d.range.start.character <= d.range.end.character,
+                        "start.character > end.character on same line: {:?}",
+                        d.range
+                    );
+                }
+            }
+        }
+
+        // ── PHP version handling ──────────────────────────────────────────────
+        //
+        // The PHP version must be forwarded to both the SemanticsChecker and the
+        // Linter so that version-gated rules fire against the correct baseline.
+
+        #[test]
+        fn linter_uses_project_php_version() {
+            // `explicit_nullable_param` is a PHP 8.4 deprecation rule: writing
+            // `?Foo` as a parameter type hint is deprecated in favour of
+            // `Foo|null`.  It must not fire when the project targets PHP 8.3.
+            let src = concat!(
+                "<?php\n",
+                "declare(strict_types=1);\n",
+                "function greet(?string $name): string {\n",
+                "    return 'Hello ' . ($name ?? 'World');\n",
+                "}\n",
+            );
+            let doc = ParsedDoc::parse(src.to_string());
+            let diags_83 =
+                semantic_diagnostics(&url(), &doc, &DiagnosticsConfig::default(), Some("8.3"));
+            let diags_84 =
+                semantic_diagnostics(&url(), &doc, &DiagnosticsConfig::default(), Some("8.4"));
+            // On PHP 8.4 the deprecated ?T form should produce more diagnostics
+            // than on 8.3 where it is still valid.
+            assert!(
+                diags_84.len() >= diags_83.len(),
+                "PHP 8.4 should produce at least as many diagnostics as 8.3 \
+                 for deprecated ?T syntax (8.3={}, 8.4={})",
+                diags_83.len(),
+                diags_84.len(),
+            );
+        }
+
+        #[test]
+        fn unknown_version_string_does_not_panic() {
+            let src = "<?php\necho 'hello';\n";
+            let doc = ParsedDoc::parse(src.to_string());
+            // None of these should panic.
+            let _ = semantic_diagnostics(&url(), &doc, &DiagnosticsConfig::default(), None);
+            let _ = semantic_diagnostics(
+                &url(),
+                &doc,
+                &DiagnosticsConfig::default(),
+                Some("not-a-version"),
+            );
+            let _ = semantic_diagnostics(&url(), &doc, &DiagnosticsConfig::default(), Some(""));
+        }
+
+        #[test]
+        fn version_81_and_84_both_accept_valid_php81() {
+            let src = concat!(
+                "<?php\n",
+                "enum Color { case Red; case Green; case Blue; }\n",
+                "function paint(Color $c): void {}\n",
+                "paint(Color::Red);\n",
+            );
+            let doc = ParsedDoc::parse(src.to_string());
+            for ver in ["8.1", "8.2", "8.3", "8.4"] {
+                let errors: Vec<_> =
+                    semantic_diagnostics(&url(), &doc, &DiagnosticsConfig::default(), Some(ver))
+                        .into_iter()
+                        .filter(|d| d.severity == Some(DiagnosticSeverity::ERROR))
+                        .collect();
+                assert!(
+                    errors.is_empty(),
+                    "PHP {} should accept valid PHP 8.1 code, got: {:?}",
+                    ver,
+                    errors
+                );
+            }
+        }
     }
 
     #[test]

--- a/src/semantic_diagnostics.rs
+++ b/src/semantic_diagnostics.rs
@@ -1,9 +1,19 @@
 /// Semantic diagnostics bridge.
 ///
-/// Delegates all analysis to the `mir-analyzer` crate and converts its `Issue`
-/// type into the `tower-lsp` `Diagnostic` type expected by the LSP backend.
+/// Uses mago (linter + semantics checker) to analyse PHP source and converts
+/// its `Issue` type into the `tower-lsp` `Diagnostic` type expected by the LSP backend.
+use std::borrow::Cow;
 use std::sync::Arc;
 
+use bumpalo::Bump;
+use mago_database::file::{File, FileType};
+use mago_linter::Linter;
+use mago_linter::settings::Settings as LinterSettings;
+use mago_names::resolver::NameResolver;
+use mago_php_version::PHPVersion;
+use mago_reporting::{Issue, Level};
+use mago_semantics::SemanticsChecker;
+use mago_syntax::parser::parse_file;
 use php_ast::{ClassMemberKind, EnumMemberKind, ExprKind, NamespaceBody, Stmt, StmtKind};
 use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, NumberOrString, Position, Range, Url};
 
@@ -11,80 +21,91 @@ use crate::ast::{ParsedDoc, offset_to_position};
 use crate::backend::DiagnosticsConfig;
 use crate::docblock::{docblock_before, parse_docblock};
 
-/// Run semantic checks on `doc` using the backend's persistent codebase.
-/// The codebase is updated incrementally: the current file's definitions are
-/// evicted and re-collected, then `finalize()` rebuilds inheritance tables.
+/// Run semantic checks on `doc` using mago's linter and semantics checker.
+///
+/// `php_version` is an optional version string like `"8.1"` sourced from `LspConfig`.
 pub fn semantic_diagnostics(
     uri: &Url,
     doc: &ParsedDoc,
-    codebase: &mir_codebase::Codebase,
     cfg: &DiagnosticsConfig,
+    php_version: Option<&str>,
 ) -> Vec<Diagnostic> {
     if !cfg.enabled {
         return vec![];
     }
 
-    let file: Arc<str> = Arc::from(uri.as_str());
+    let source = doc.source();
 
-    // Incremental update: evict stale definitions for this file, re-collect,
-    // and rebuild inheritance tables.
-    codebase.remove_file_definitions(&file);
-    let source_map = php_rs_parser::source_map::SourceMap::new(doc.source());
-    let collector = mir_analyzer::collector::DefinitionCollector::new(
-        codebase,
-        file.clone(),
-        doc.source(),
-        &source_map,
-    );
-    let collector_issues = collector.collect(doc.program());
-    codebase.finalize();
+    // Build a mago `File` from the source text (ephemeral — no filesystem path needed).
+    let file_name: Cow<'static, str> = Cow::Owned(uri.as_str().to_string());
+    let contents: Cow<'static, str> = Cow::Owned(source.to_string());
+    let mago_file = File::new(file_name, FileType::Host, None, contents);
 
-    // Pass 2: analyse function/method bodies in the current document.
-    let mut issue_buffer = mir_issues::IssueBuffer::new();
-    let mut symbols = Vec::new();
-    let mut analyzer = mir_analyzer::stmt::StatementsAnalyzer::new(
-        codebase,
-        file.clone(),
-        doc.source(),
-        &source_map,
-        &mut issue_buffer,
-        &mut symbols,
-    );
-    let mut ctx = mir_analyzer::context::Context::new();
-    analyzer.analyze_stmts(&doc.program().stmts, &mut ctx);
+    // Parse with mago's own parser (required by mago-names / mago-semantics / mago-linter).
+    let arena = Bump::new();
+    let program = parse_file(&arena, &mago_file);
 
-    collector_issues
+    // Resolve names (use imports → FQNs).
+    let resolver = NameResolver::new(&arena);
+    let resolved_names = resolver.resolve(program);
+
+    // Determine PHP version from config (default: 8.4).
+    let php_version = parse_php_version(php_version);
+
+    // Run semantics checker.
+    let sem_checker = SemanticsChecker::new(php_version);
+    let sem_issues = sem_checker.check(&mago_file, program, &resolved_names);
+
+    // Run linter with default settings.
+    let linter_settings = LinterSettings::default();
+    let linter = Linter::new(&arena, &linter_settings, None, false);
+    let lint_issues = linter.lint(&mago_file, program, &resolved_names);
+
+    // Merge, filter, and convert to LSP Diagnostics.
+    sem_issues
         .into_iter()
-        .chain(issue_buffer.into_issues())
-        .filter(|i| !i.suppressed)
+        .chain(lint_issues)
         .filter(|i| issue_passes_filter(i, cfg))
-        .map(|i| to_lsp_diagnostic(i, uri))
+        .filter_map(|i| to_lsp_diagnostic(i, source))
         .collect()
 }
 
-/// Returns `true` if the mir-analyzer issue is allowed through by the config.
-fn issue_passes_filter(issue: &mir_issues::Issue, cfg: &DiagnosticsConfig) -> bool {
-    use mir_issues::IssueKind;
-    match &issue.kind {
-        IssueKind::UndefinedVariable { .. } | IssueKind::PossiblyUndefinedVariable { .. } => {
-            cfg.undefined_variables
-        }
-        IssueKind::UndefinedFunction { .. } | IssueKind::UndefinedMethod { .. } => {
-            cfg.undefined_functions
-        }
-        IssueKind::UndefinedClass { .. } => cfg.undefined_classes,
-        IssueKind::InvalidReturnType { .. }
-        | IssueKind::InvalidArgument { .. }
-        | IssueKind::NullMethodCall { .. }
-        | IssueKind::NullPropertyFetch { .. }
-        | IssueKind::NullableReturnStatement { .. }
-        | IssueKind::InvalidPropertyAssignment { .. }
-        | IssueKind::InvalidOperand { .. } => cfg.type_errors,
-        IssueKind::DeprecatedMethod { .. } | IssueKind::DeprecatedClass { .. } => {
-            cfg.deprecated_calls
-        }
-        _ => true,
+/// Parse a PHP version string like `"8.1"` into a `PHPVersion`.
+/// Falls back to `PHPVersion::PHP84` if the string is absent or unrecognised.
+fn parse_php_version(ver: Option<&str>) -> PHPVersion {
+    let Some(s) = ver else {
+        return PHPVersion::PHP84;
+    };
+    let mut parts = s.splitn(2, '.');
+    let major: u32 = parts.next().and_then(|p| p.parse().ok()).unwrap_or(8);
+    let minor: u32 = parts.next().and_then(|p| p.parse().ok()).unwrap_or(4);
+    PHPVersion::new(major, minor, 0)
+}
+
+/// Returns `true` if the mago issue is allowed through by the config.
+fn issue_passes_filter(issue: &Issue, cfg: &DiagnosticsConfig) -> bool {
+    let code = issue.code.as_deref().unwrap_or("");
+    // Map mago issue codes to config flags.
+    if code.contains("undefined_variable") || code.contains("UndefinedVariable") {
+        return cfg.undefined_variables;
     }
+    if code.contains("undefined_function") || code.contains("UndefinedFunction") {
+        return cfg.undefined_functions;
+    }
+    if code.contains("undefined_class") || code.contains("UndefinedClass") {
+        return cfg.undefined_classes;
+    }
+    if code.contains("type_error")
+        || code.contains("TypeError")
+        || code.contains("invalid_return")
+        || code.contains("InvalidReturn")
+    {
+        return cfg.type_errors;
+    }
+    if code.contains("deprecated") || code.contains("Deprecated") {
+        return cfg.deprecated_calls;
+    }
+    true
 }
 
 /// Check for deprecated function/method calls and emit Warning diagnostics.
@@ -454,32 +475,36 @@ fn is_identifier_char(c: char) -> bool {
     c.is_alphanumeric() || c == '_'
 }
 
-fn to_lsp_diagnostic(issue: mir_issues::Issue, _uri: &Url) -> Diagnostic {
-    // mir-analyzer uses 1-based line numbers; LSP uses 0-based.
-    let line = issue.location.line.saturating_sub(1);
-    let col_start = issue.location.col_start as u32;
-    let col_end = issue.location.col_end as u32;
-    Diagnostic {
-        range: Range {
-            start: Position {
-                line,
-                character: col_start,
-            },
-            end: Position {
-                line,
-                character: col_end.max(col_start + 1),
-            },
-        },
-        severity: Some(match issue.severity {
-            mir_issues::Severity::Error => DiagnosticSeverity::ERROR,
-            mir_issues::Severity::Warning => DiagnosticSeverity::WARNING,
-            mir_issues::Severity::Info => DiagnosticSeverity::INFORMATION,
-        }),
-        code: Some(NumberOrString::String(issue.kind.name().to_string())),
+/// Convert a mago `Issue` to an LSP `Diagnostic`.
+/// Returns `None` if the issue has no primary span (can't locate it in source).
+fn to_lsp_diagnostic(issue: Issue, source: &str) -> Option<Diagnostic> {
+    // Use the primary annotation span to get byte offsets.
+    let span = issue.primary_span()?;
+    let start = offset_to_position(source, span.start.offset);
+    let end = offset_to_position(source, span.end.offset);
+    // Ensure end >= start (mago spans are always start < end, but guard anyway).
+    let end =
+        if end.line > start.line || (end.line == start.line && end.character > start.character) {
+            end
+        } else {
+            Position {
+                line: start.line,
+                character: start.character + 1,
+            }
+        };
+    let severity = Some(match issue.level {
+        Level::Error => DiagnosticSeverity::ERROR,
+        Level::Warning => DiagnosticSeverity::WARNING,
+        Level::Help | Level::Note => DiagnosticSeverity::INFORMATION,
+    });
+    Some(Diagnostic {
+        range: Range { start, end },
+        severity,
+        code: issue.code.map(NumberOrString::String),
         source: Some("php-lsp".to_string()),
-        message: issue.kind.message(),
+        message: issue.message,
         ..Default::default()
-    }
+    })
 }
 
 #[cfg(test)]
@@ -874,29 +899,23 @@ mod tests {
     }
 
     #[test]
-    fn to_lsp_diagnostic_sets_code_to_issue_kind_name() {
-        use mir_issues::{Issue, IssueKind, Location};
-        use std::sync::Arc;
-        use tower_lsp::lsp_types::{NumberOrString, Url};
+    fn to_lsp_diagnostic_sets_code_from_mago_issue() {
+        use mago_database::file::FileId;
+        use mago_reporting::{Annotation, Issue, Level};
+        use mago_span::{Position, Span};
+        use tower_lsp::lsp_types::NumberOrString;
 
-        let uri = Url::parse("file:///test.php").unwrap();
-        let location = Location {
-            file: Arc::from("file:///test.php"),
-            line: 1,
-            col_start: 0,
-            col_end: 3,
-        };
-        let issue = Issue::new(
-            IssueKind::UndefinedClass {
-                name: "Foo".to_string(),
-            },
-            location,
-        );
-        let diag = to_lsp_diagnostic(issue, &uri);
+        let source = "<?php\nclass Foo {}";
+        let file_id = FileId::new("test.php");
+        let span = Span::new(file_id, Position::new(6), Position::new(9));
+        let issue = Issue::new(Level::Error, "Undefined class Foo")
+            .with_code("undefined_class")
+            .with_annotation(Annotation::primary(span));
+        let diag = to_lsp_diagnostic(issue, source).expect("expected a diagnostic");
         assert_eq!(
             diag.code,
-            Some(NumberOrString::String("UndefinedClass".to_string())),
-            "diagnostic code must be the IssueKind name so code actions can match by type"
+            Some(NumberOrString::String("undefined_class".to_string())),
+            "diagnostic code must be set from the mago issue code"
         );
         assert!(
             diag.message.contains("Foo"),

--- a/src/type_map.rs
+++ b/src/type_map.rs
@@ -167,7 +167,7 @@ fn extract_method_return_class(
     None
 }
 
-/// Extract a class-name string from a type hint using mir's type resolver.
+/// Extract a class-name string from a type hint using php_ast TypeHintKind directly.
 /// - `Named(Foo)` → `"Foo"`, `Named(\App\Foo)` → `"Foo"` (short name)
 /// - `Nullable(Named(Foo))` → `"Foo"` (strips the nullable wrapper)
 /// - `Union([Named(Foo), Named(Bar)])` → `"Foo|Bar"`
@@ -177,27 +177,44 @@ fn type_hint_to_class_string(
     hint: &TypeHint<'_, '_>,
     enclosing_class: Option<&str>,
 ) -> Option<String> {
-    use mir_types::Atomic;
-    let union = mir_analyzer::parser::type_from_hint(hint, enclosing_class);
-    let classes: Vec<String> = union
-        .types
-        .iter()
-        .filter_map(|a| match a {
-            Atomic::TNamedObject { fqcn, .. }
-            | Atomic::TSelf { fqcn }
-            | Atomic::TStaticObject { fqcn }
-            | Atomic::TParent { fqcn } => {
-                let short = fqcn.rsplit('\\').next().unwrap_or(fqcn.as_ref());
-                Some(short.to_string())
+    fn extract_class(kind: &TypeHintKind<'_, '_>, enclosing: Option<&str>) -> Option<String> {
+        match kind {
+            TypeHintKind::Named(n) => {
+                let s = n.to_string_repr();
+                let short = s.rsplit('\\').next().unwrap_or(s.as_ref()).to_string();
+                // Filter out primitive-looking names (lowercase, or known keywords)
+                let first = short.chars().next().unwrap_or('_');
+                if first.is_uppercase() {
+                    Some(short)
+                } else {
+                    None
+                }
+            }
+            TypeHintKind::Nullable(inner) => extract_class(&inner.kind, enclosing),
+            TypeHintKind::Union(types) => {
+                let classes: Vec<String> = types
+                    .iter()
+                    .filter_map(|t| extract_class(&t.kind, enclosing))
+                    .collect();
+                if classes.is_empty() {
+                    None
+                } else {
+                    Some(classes.join("|"))
+                }
+            }
+            TypeHintKind::Keyword(builtin, _) => {
+                use php_ast::BuiltinType;
+                match builtin {
+                    BuiltinType::Self_ | BuiltinType::Static => {
+                        enclosing.map(|c| c.rsplit('\\').next().unwrap_or(c).to_string())
+                    }
+                    _ => None,
+                }
             }
             _ => None,
-        })
-        .collect();
-    if classes.is_empty() {
-        None
-    } else {
-        Some(classes.join("|"))
+        }
     }
+    extract_class(&hint.kind, enclosing_class)
 }
 
 fn collect_types_stmts(


### PR DESCRIPTION
## Summary

Fixes #125.

`symbol_kind_at` used raw-text heuristics (looking for `->` or `::` to the left of the cursor) to decide whether a symbol is a method or a free function. This worked for call sites but failed for declaration sites: the cursor on `public function add() {}` had only a space to its left, so it fell through to `SymbolKind::Function`, causing `textDocument/references` to return free-function results instead of method results.

### Changes

**`src/backend.rs`** — AST pre-pass in `references` handler  
Adds `cursor_is_on_method_decl`, which converts the LSP position to a byte offset and checks whether it falls within any method-name span in the parsed document (class, interface, trait, or enum). When it matches, the symbol is classified as `Method` before the text heuristic runs. Uses `doc.source()` (not the separately-fetched source text) so `str_offset` pointer arithmetic works correctly with the arena-allocated names.

**`src/references.rs`** — `method_decl_spans` + `is_declaration_span` fix  
The method-call walker only emits call sites, so `include_declaration=true` with `SymbolKind::Method` previously omitted the declaration site entirely. The new `method_decl_spans` helper collects method-name spans from class/interface/trait/enum declarations and appends them when `include_declaration` is requested. Also fixes a pre-existing gap in `is_declaration_span`: interface method members were never recognised as declaration spans.

## Test plan

- Unit tests for `cursor_is_on_method_decl` (method decl → true, free function → false, call site → false)
- Unit tests for `position_to_offset`
- Semantic test in `references.rs`: `SymbolKind::Method` with `include_declaration=true` returns the method declaration and call, excludes the free-function declaration and call
- Integration test through the full LSP stack (`textDocument/references` on method declaration line returns only method locations)