### PR TITLE
perf(workspace-diagnostic): finalize codebase once instead of per file

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -47,6 +47,7 @@ use crate::rename::{prepare_rename, rename, rename_property, rename_variable};
 use crate::selection_range::selection_ranges;
 use crate::semantic_diagnostics::{
     deprecated_call_diagnostics, duplicate_declaration_diagnostics, semantic_diagnostics,
+    semantic_diagnostics_no_rebuild,
 };
 use crate::semantic_tokens::{
     compute_token_delta, legend, semantic_tokens, semantic_tokens_range, token_hash,
@@ -1598,13 +1599,19 @@ impl LanguageServer for Backend {
             (cfg.diagnostics.clone(), cfg.php_version.clone())
         };
 
+        // Build inheritance tables once for the entire workspace.
+        // The persistent codebase already has all file definitions collected
+        // incrementally via collect_into_codebase(). A single finalize() call
+        // here is O(N); the old approach called finalize() per file → O(N²).
+        self.codebase.finalize();
+
         let items: Vec<WorkspaceDocumentDiagnosticReport> = all_parse_diags
             .into_iter()
             .filter_map(|(uri, parse_diags, version)| {
                 let doc = self.docs.get_doc(&uri)?;
 
                 let source = doc.source().to_string();
-                let sem_diags = semantic_diagnostics(
+                let sem_diags = semantic_diagnostics_no_rebuild(
                     &uri,
                     &doc,
                     &self.codebase,

--- a/src/semantic_diagnostics.rs
+++ b/src/semantic_diagnostics.rs
@@ -69,6 +69,52 @@ pub fn semantic_diagnostics(
         .collect()
 }
 
+/// Run semantic body analysis on `doc` assuming the codebase is already
+/// finalized (all definitions collected, `finalize()` already called).
+///
+/// Unlike [`semantic_diagnostics`], this function does **not** mutate the
+/// codebase — it skips the `remove_file_definitions` / re-collect / `finalize`
+/// cycle. Intended for workspace diagnostic batch passes where the codebase is
+/// built once upfront and `finalize()` is called a single time before the loop.
+pub fn semantic_diagnostics_no_rebuild(
+    uri: &Url,
+    doc: &ParsedDoc,
+    codebase: &mir_codebase::Codebase,
+    cfg: &DiagnosticsConfig,
+    _php_version: Option<&str>,
+) -> Vec<Diagnostic> {
+    if !cfg.enabled {
+        return vec![];
+    }
+
+    let file: Arc<str> = Arc::from(uri.as_str());
+    let source_map = php_rs_parser::source_map::SourceMap::new(doc.source());
+
+    // Pass 2 only: analyse function/method bodies.
+    // The codebase is already finalized — skip remove/re-collect/finalize so
+    // that inheritance tables are not torn down and rebuilt for every file.
+    let mut issue_buffer = mir_issues::IssueBuffer::new();
+    let mut symbols = Vec::new();
+    let mut analyzer = mir_analyzer::stmt::StatementsAnalyzer::new(
+        codebase,
+        file,
+        doc.source(),
+        &source_map,
+        &mut issue_buffer,
+        &mut symbols,
+    );
+    let mut ctx = mir_analyzer::context::Context::new();
+    analyzer.analyze_stmts(&doc.program().stmts, &mut ctx);
+
+    issue_buffer
+        .into_issues()
+        .into_iter()
+        .filter(|i| !i.suppressed)
+        .filter(|i| issue_passes_filter(i, cfg))
+        .map(|i| to_lsp_diagnostic(i, uri))
+        .collect()
+}
+
 /// Returns `true` if the mir-analyzer issue is allowed through by the config.
 fn issue_passes_filter(issue: &mir_issues::Issue, cfg: &DiagnosticsConfig) -> bool {
     use mir_issues::IssueKind;


### PR DESCRIPTION
## Summary

- `workspace_diagnostic()` previously called `finalize()` once per indexed file, rebuilding the full inheritance graph each iteration — O(N²) on large workspaces
- Adds `semantic_diagnostics_no_rebuild()` that skips the codebase mutation cycle and runs body analysis only
- `workspace_diagnostic()` now calls `codebase.finalize()` once upfront and uses the new function per file, reducing the pass from O(N²) to O(N)

Closes #106