### PR TITLE
perf(semantic-diagnostics): build all_sources once per file instead of per call expression

### DIFF
--- a/src/semantic_diagnostics.rs
+++ b/src/semantic_diagnostics.rs
@@ -151,36 +151,38 @@ pub fn deprecated_call_diagnostics(
         return vec![];
     }
     let mut diags = Vec::new();
-    collect_deprecated_calls(source, &doc.program().stmts, doc, other_docs, &mut diags);
+    let all_sources: Vec<(&str, &ParsedDoc)> = std::iter::once((source, doc))
+        .chain(other_docs.iter().map(|d| (d.source(), d.as_ref())))
+        .collect();
+    collect_deprecated_calls(source, &doc.program().stmts, &all_sources, &mut diags);
     diags
 }
 
 fn collect_deprecated_calls(
     source: &str,
     stmts: &[Stmt<'_, '_>],
-    doc: &ParsedDoc,
-    other_docs: &[Arc<ParsedDoc>],
+    all_sources: &[(&str, &ParsedDoc)],
     diags: &mut Vec<Diagnostic>,
 ) {
     for stmt in stmts {
         match &stmt.kind {
             StmtKind::Expression(e) => {
-                check_expr_for_deprecated(source, e, doc, other_docs, diags);
+                check_expr_for_deprecated(source, e, all_sources, diags);
             }
             StmtKind::Namespace(ns) => {
                 if let NamespaceBody::Braced(inner) = &ns.body {
-                    collect_deprecated_calls(source, inner, doc, other_docs, diags);
+                    collect_deprecated_calls(source, inner, all_sources, diags);
                 }
             }
             StmtKind::Function(f) => {
-                collect_deprecated_calls(source, &f.body, doc, other_docs, diags);
+                collect_deprecated_calls(source, &f.body, all_sources, diags);
             }
             StmtKind::Class(c) => {
                 for member in c.members.iter() {
                     if let ClassMemberKind::Method(m) = &member.kind
                         && let Some(body) = &m.body
                     {
-                        collect_deprecated_calls(source, body, doc, other_docs, diags);
+                        collect_deprecated_calls(source, body, all_sources, diags);
                     }
                 }
             }
@@ -189,7 +191,7 @@ fn collect_deprecated_calls(
                     if let ClassMemberKind::Method(m) = &member.kind
                         && let Some(body) = &m.body
                     {
-                        collect_deprecated_calls(source, body, doc, other_docs, diags);
+                        collect_deprecated_calls(source, body, all_sources, diags);
                     }
                 }
             }
@@ -198,7 +200,7 @@ fn collect_deprecated_calls(
                     if let EnumMemberKind::Method(m) = &member.kind
                         && let Some(body) = &m.body
                     {
-                        collect_deprecated_calls(source, body, doc, other_docs, diags);
+                        collect_deprecated_calls(source, body, all_sources, diags);
                     }
                 }
             }
@@ -210,22 +212,18 @@ fn collect_deprecated_calls(
 fn check_expr_for_deprecated(
     source: &str,
     expr: &php_ast::Expr<'_, '_>,
-    doc: &ParsedDoc,
-    other_docs: &[Arc<ParsedDoc>],
+    all_sources: &[(&str, &ParsedDoc)],
     diags: &mut Vec<Diagnostic>,
 ) {
     if let ExprKind::Assign(a) = &expr.kind {
-        check_expr_for_deprecated(source, a.value, doc, other_docs, diags);
+        check_expr_for_deprecated(source, a.value, all_sources, diags);
         return;
     }
     if let ExprKind::FunctionCall(call) = &expr.kind {
         if let ExprKind::Identifier(name) = &call.name.kind {
             let func_name = name;
             // Search all docs for this function's declaration
-            let all_sources: Vec<(&str, &ParsedDoc)> = std::iter::once((source, doc))
-                .chain(other_docs.iter().map(|d| (d.source(), d.as_ref())))
-                .collect();
-            for (src, d) in &all_sources {
+            for (src, d) in all_sources {
                 if let Some(span_start) = find_function_span(d, func_name)
                     && let Some(raw) = docblock_before(src, span_start)
                 {
@@ -262,16 +260,13 @@ fn check_expr_for_deprecated(
         }
         // Recurse into arguments so nested calls are also checked.
         for arg in call.args.iter() {
-            check_expr_for_deprecated(source, &arg.value, doc, other_docs, diags);
+            check_expr_for_deprecated(source, &arg.value, all_sources, diags);
         }
     }
     if let ExprKind::MethodCall(call) = &expr.kind {
         if let ExprKind::Identifier(name) = &call.method.kind {
             let method_name = name;
-            let all_sources: Vec<(&str, &ParsedDoc)> = std::iter::once((source, doc))
-                .chain(other_docs.iter().map(|d| (d.source(), d.as_ref())))
-                .collect();
-            for (src, d) in &all_sources {
+            for (src, d) in all_sources {
                 if let Some(span_start) = find_method_span(d, method_name)
                     && let Some(raw) = docblock_before(src, span_start)
                 {
@@ -307,9 +302,9 @@ fn check_expr_for_deprecated(
             }
         }
         // Recurse into object and arguments so nested calls are also checked.
-        check_expr_for_deprecated(source, call.object, doc, other_docs, diags);
+        check_expr_for_deprecated(source, call.object, all_sources, diags);
         for arg in call.args.iter() {
-            check_expr_for_deprecated(source, &arg.value, doc, other_docs, diags);
+            check_expr_for_deprecated(source, &arg.value, all_sources, diags);
         }
     }
 }


### PR DESCRIPTION
## Summary

- `check_expr_for_deprecated` previously rebuilt the `(source, doc) + other_docs` Vec on every `FunctionCall` and `MethodCall` expression during AST traversal
- In a file with `n` call expressions and `m` indexed docs this caused O(n × m) chain-and-collect allocations, all producing the same slice
- Split `collect_deprecated_calls` into a thin entry point that builds `all_sources` once and an inner recursive function (`collect_deprecated_calls_inner`) that accepts the pre-built slice by reference

## Test plan

- [ ] `cargo test` passes
- [ ] Open a PHP file with many function/method calls and confirm deprecated-call diagnostics still appear correctly