### PR TITLE
docs(readme): link dedicated PHPStorm plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ For full installation options see **[docs/getting-started.md](docs/getting-start
 | Neovim 0.10 | `vim.lsp.start` in a `FileType` autocmd |
 | Zed | `lsp` block in `~/.config/zed/settings.json` |
 | Cursor | Settings → Features → Language Servers |
-| PHPStorm | [LSP4IJ](https://plugins.jetbrains.com/plugin/23257-lsp4ij) plugin |
+| PHPStorm | [php-lsp-phpstorm-plugin](https://github.com/jorgsowa/php-lsp-phpstorm-plugin) |
 | Claude Code | `claude plugin add https://github.com/jorgsowa/claude-php-lsp-plugin` |
 
 Config snippets for every editor: **[docs/editors.md](docs/editors.md)**

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ For full installation options see **[docs/getting-started.md](docs/getting-start
 | Neovim 0.10 | `vim.lsp.start` in a `FileType` autocmd |
 | Zed | `lsp` block in `~/.config/zed/settings.json` |
 | Cursor | Settings → Features → Language Servers |
-| PHPStorm | [php-lsp-phpstorm-plugin](https://github.com/jorgsowa/php-lsp-phpstorm-plugin) |
+| PHPStorm | [php-lsp](https://plugins.jetbrains.com/plugin/31223-php-lsp) plugin ([source](https://github.com/jorgsowa/php-lsp-phpstorm-plugin)) |
 | Claude Code | `claude plugin add https://github.com/jorgsowa/claude-php-lsp-plugin` |
 
 Config snippets for every editor: **[docs/editors.md](docs/editors.md)**

--- a/docs/editors.md
+++ b/docs/editors.md
@@ -183,29 +183,11 @@ vim.api.nvim_create_autocmd('FileType', {
 
 ### PHPStorm
 
-> **Native plugin:** A dedicated php-lsp plugin for PhpStorm is currently [under review on the JetBrains Marketplace](https://plugins.jetbrains.com/plugin/31223-php-lsp). Once approved, it will offer a simpler setup than the LSP4IJ approach below.
+Install the [php-lsp](https://plugins.jetbrains.com/plugin/31223-php-lsp) plugin from the JetBrains Marketplace (**Settings → Plugins → Marketplace → "php-lsp"**).
 
-1. Install the [LSP4IJ](https://plugins.jetbrains.com/plugin/23257-lsp4ij) plugin (**Settings → Plugins → Marketplace → "LSP4IJ"**).
-2. Go to **Settings → Languages & Frameworks → LSP → Language Servers → +**, choose **Custom server**, and fill in the **Server** tab:
-
-   | Field | Value |
-   |---|---|
-   | Name | `php-lsp` |
-   | Command | `<path-to-php-lsp>` |
-
-3. In the **Mappings** tab add file name pattern `*.php`.
-4. In the **Configuration** tab paste your options into the **Initialization options** JSON field:
-
-```json
-{
-  "phpVersion": "8.5",
-  "excludePaths": ["cache/*", "storage/*"]
-}
-```
+The plugin handles everything automatically — no manual server configuration required. Source is available at [jorgsowa/php-lsp-phpstorm-plugin](https://github.com/jorgsowa/php-lsp-phpstorm-plugin).
 
 See [configuration.md](configuration.md) for all available options.
-
-> **Known issue:** LSP4IJ throws an `UnsupportedOperationException` on `workspace/inlineValue/refresh` (tracked in [redhat-developer/lsp4ij#1470](https://github.com/redhat-developer/lsp4ij/issues/1470)). Update LSP4IJ to the latest version once a fix is released.
 
 ---
 


### PR DESCRIPTION
## Summary
- Replaces the generic [LSP4IJ](https://plugins.jetbrains.com/plugin/23257-lsp4ij) plugin link in the Editor Setup table with the dedicated [php-lsp-phpstorm-plugin](https://github.com/jorgsowa/php-lsp-phpstorm-plugin)