### PR TITLE
perf(declaration): merge two-pass all_docs scan into one

### DIFF
--- a/src/declaration.rs
+++ b/src/declaration.rs
@@ -23,7 +23,9 @@ pub fn goto_declaration(
 ) -> Option<Location> {
     let word = word_at(source, position)?;
 
-    // First pass: look for an abstract or interface declaration
+    // Single pass: prefer abstract/interface declarations globally; save the
+    // first concrete declaration as a fallback in case none is found.
+    let mut fallback: Option<Location> = None;
     for (uri, doc) in all_docs {
         let doc_source = doc.source();
         if let Some(range) = find_abstract_declaration(doc_source, &doc.program().stmts, &word) {
@@ -32,20 +34,16 @@ pub fn goto_declaration(
                 range,
             });
         }
-    }
-
-    // Second pass: any declaration (same as goto_definition)
-    for (uri, doc) in all_docs {
-        let doc_source = doc.source();
-        if let Some(range) = find_any_declaration(doc_source, &doc.program().stmts, &word) {
-            return Some(Location {
+        if fallback.is_none()
+            && let Some(range) = find_any_declaration(doc_source, &doc.program().stmts, &word)
+        {
+            fallback = Some(Location {
                 uri: uri.clone(),
                 range,
             });
         }
     }
-
-    None
+    fallback
 }
 
 fn find_abstract_declaration(


### PR DESCRIPTION
## Summary

- `goto_declaration` previously iterated `all_docs` twice: once for abstract/interface declarations, then again for concrete ones if nothing was found
- Merged into a single pass: abstract declarations still return immediately; the first concrete declaration seen is saved as `fallback` and returned only if no abstract match is found across the whole list

## Test plan

- [x] All 767 existing tests pass (`cargo test`)