### PR TITLE
chore: update all dependencies to latest versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -104,9 +113,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-buffer"
@@ -134,6 +143,16 @@ name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "cc"
+version = "1.2.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -170,9 +189,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
 ]
@@ -210,25 +229,24 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.5.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
 dependencies = [
+ "alloca",
  "anes",
  "cast",
  "ciborium",
  "clap",
  "criterion-plot",
- "is-terminal",
  "itertools",
  "num-traits",
- "once_cell",
  "oorandom",
+ "page_size",
  "plotters",
  "rayon",
  "regex",
  "serde",
- "serde_derive",
  "serde_json",
  "tinytemplate",
  "walkdir",
@@ -236,9 +254,9 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.5.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
 dependencies = [
  "cast",
  "itertools",
@@ -376,6 +394,12 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "foldhash"
@@ -526,12 +550,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
-
-[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -668,17 +686,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-terminal"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys",
-]
-
-[[package]]
 name = "is_ci"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -686,9 +693,9 @@ checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
 
 [[package]]
 name = "itertools"
-version = "0.10.5"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -717,9 +724,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "linux-raw-sys"
@@ -819,9 +826,9 @@ dependencies = [
 
 [[package]]
 name = "mir-analyzer"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "848dc2442af9acb773af8564786b5a1b747b0f3203e80bdc4bb0c8afd5c95111"
+checksum = "d5b38cb1be1e3dc2ad8ac1d1d38d294824ffc8ad2b5e3fea167dd8b8dfa4b172"
 dependencies = [
  "bumpalo",
  "indexmap",
@@ -840,9 +847,9 @@ dependencies = [
 
 [[package]]
 name = "mir-codebase"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ca6a4591a4497ab7ad79f7996e2a61a74158b3cf168a307289d12e63edfdf27"
+checksum = "e6f79a3d1b15274b8b9cdf0d685d3e6c3562be0f7f5c332684897c6896479cea"
 dependencies = [
  "dashmap 6.1.0",
  "indexmap",
@@ -853,9 +860,9 @@ dependencies = [
 
 [[package]]
 name = "mir-issues"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f18361b9a4a1a99a7cdc7275b30028b06be5713326a6c1b991b4f0b63701ad6"
+checksum = "d7a0cb8da86cd15b82ac85515b1f9f17cbe404d344705b6ac54fad38f16690cd"
 dependencies = [
  "mir-types",
  "owo-colors",
@@ -865,9 +872,9 @@ dependencies = [
 
 [[package]]
 name = "mir-types"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5454172c589ff8797bebd0efb079061c51e1d03bca7e56ad987b264333b7dcf4"
+checksum = "b322d6eacd9221d17e7d806619bff9a28939896e838d4fe00bd0e9054cb90bed"
 dependencies = [
  "indexmap",
  "serde",
@@ -911,6 +918,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -941,9 +958,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "php-ast"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d6d6cac9004e6c4eb89eec5dde2984a66c67c9569d254dff940c83fb81799bc"
+checksum = "a2531f4c82854d4ba443feed007fc749cc88e7e04e35bdf7f1784f803b8537e0"
 dependencies = [
  "bumpalo",
  "serde",
@@ -951,9 +968,9 @@ dependencies = [
 
 [[package]]
 name = "php-lexer"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4c8a5d3c7011e478b96d540726000ec9fff680d5d00193aa59282f9ea2bd3a9"
+checksum = "8a759b83ad609f6c2cfb7d29de821668aefc75fc6ed2f479d5248eee1e3e5262"
 dependencies = [
  "memchr",
  "php-ast",
@@ -981,9 +998,9 @@ dependencies = [
 
 [[package]]
 name = "php-rs-parser"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201d9a924e9d17bbf74b070d272685d26234b3ab830ba4d7e612b039c65d6f51"
+checksum = "e6846740c75552a4b091434bc21451c4be5de94b61a1755bbd1aa1c24626a9dc"
 dependencies = [
  "bumpalo",
  "miette",
@@ -1100,9 +1117,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -1124,7 +1141,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -1168,7 +1185,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1266,6 +1283,12 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
@@ -1426,9 +1449,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.51.1"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",
@@ -1718,7 +1741,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -1735,6 +1758,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1742,6 +1781,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"
@@ -1816,7 +1861,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "indexmap",
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,12 +28,12 @@ name = "requests"
 harness = false
 
 [dependencies]
-mir-analyzer = "0.4.1"
-mir-issues = "0.4.1"
-mir-codebase = "0.4.1"
-mir-types = "0.4.1"
-php-rs-parser = "0.6.2"
-php-ast = "0.6.2"
+mir-analyzer = "0.5.0"
+mir-issues = "0.5.0"
+mir-codebase = "0.5.0"
+mir-types = "0.5.0"
+php-rs-parser = "0.7.0"
+php-ast = "0.7.0"
 bumpalo = { version = "3", features = ["collections"] }
 tower-lsp = "0.20"
 tokio = { version = "1", features = ["full"] }
@@ -43,4 +43,4 @@ dashmap = "6"
 [dev-dependencies]
 tempfile = "3"
 expect-test = "1"
-criterion = { version = "0.5", features = ["html_reports"] }
+criterion = { version = "0.8", features = ["html_reports"] }

--- a/src/phpstorm_meta.rs
+++ b/src/phpstorm_meta.rs
@@ -136,7 +136,7 @@ fn extract_static_call_target(expr: &php_ast::Expr<'_, '_>) -> Option<(String, S
         return None;
     };
     let class_name = extract_class_name(s.class)?;
-    let method_name = s.method.to_string();
+    let method_name = s.method.name_str()?.to_string();
     Some((class_name, method_name))
 }
 
@@ -195,7 +195,7 @@ fn extract_string_or_class(expr: &php_ast::Expr<'_, '_>) -> Option<String> {
         }
         ExprKind::ClassConstAccess(c) => {
             // `Foo::class` — extract `Foo`.
-            if c.member == "class" {
+            if c.member.name_str() == Some("class") {
                 extract_class_name(c.class)
             } else {
                 None

--- a/src/type_map.rs
+++ b/src/type_map.rs
@@ -521,7 +521,7 @@ fn collect_types_expr(
         ExprKind::StaticMethodCall(s) => {
             if let ExprKind::Identifier(class) = &s.class.kind
                 && class.as_str() == "Closure"
-                && s.method == "bind"
+                && s.method.name_str() == Some("bind")
                 && let Some(obj_arg) = s.args.get(1)
                 && let Some(cls) = resolve_var_type_str(&obj_arg.value, map)
             {
@@ -672,15 +672,17 @@ fn infer_from_meta_method_call(
     let arg = m.args.first()?;
     let arg_str = match &arg.value.kind {
         ExprKind::String(s) => s.trim_start_matches('\\').to_string(),
-        ExprKind::ClassConstAccess(c) if c.member == "class" => match &c.class.kind {
-            ExprKind::Identifier(n) => n
-                .trim_start_matches('\\')
-                .rsplit('\\')
-                .next()
-                .unwrap_or(n)
-                .to_string(),
-            _ => return None,
-        },
+        ExprKind::ClassConstAccess(c) if c.member.name_str() == Some("class") => {
+            match &c.class.kind {
+                ExprKind::Identifier(n) => n
+                    .trim_start_matches('\\')
+                    .rsplit('\\')
+                    .next()
+                    .unwrap_or(n)
+                    .to_string(),
+                _ => return None,
+            }
+        }
         _ => return None,
     };
     meta.resolve_return_type(&receiver_class, &method_name, &arg_str)

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -898,7 +898,7 @@ pub fn refs_in_expr(source: &str, expr: &Expr<'_, '_>, word: &str, out: &mut Vec
         }
         ExprKind::StaticMethodCall(s) => {
             refs_in_expr(source, s.class, word, out);
-            if s.method.as_ref() == word {
+            if s.method.name_str() == Some(word) {
                 out.push(expr.span);
             }
             args(source, &s.args, word, out);
@@ -955,7 +955,7 @@ pub fn refs_in_expr(source: &str, expr: &Expr<'_, '_>, word: &str, out: &mut Vec
         ExprKind::StaticPropertyAccess(s) => refs_in_expr(source, s.class, word, out),
         ExprKind::ClassConstAccess(c) => {
             refs_in_expr(source, c.class, word, out);
-            if c.member.as_ref() == word {
+            if c.member.name_str() == Some(word) {
                 out.push(expr.span);
             }
         }
@@ -1291,7 +1291,7 @@ fn method_refs_in_expr(expr: &Expr<'_, '_>, name: &str, out: &mut Vec<Span>) {
         }
         ExprKind::StaticMethodCall(s) => {
             method_refs_in_expr(s.class, name, out);
-            if s.method.as_ref() == name {
+            if s.method.name_str() == Some(name) {
                 // For static calls, the span covers the whole expression; we need the
                 // method-name portion. Use the existing refs_in_expr behaviour which
                 // pushed expr.span for static methods — replicate that here.


### PR DESCRIPTION
## Summary

- Bumps `mir-analyzer`, `mir-issues`, `mir-codebase`, `mir-types` from 0.4.1 → 0.5.0
- Bumps `php-ast` and `php-rs-parser` from 0.6.2 → 0.7.0
- Bumps `criterion` from 0.5 → 0.8
- Routine lockfile updates: `bitflags`, `clap`, `libc`, `rayon`, `tokio`

**Breaking API change in `php-ast` 0.7:** `method` and `member` fields on `MethodCallExpr`, `StaticMethodCallExpr`, and `StaticAccessExpr` are now `&Expr` instead of `&str`. Updated three call sites (`phpstorm_meta.rs`, `type_map.rs`, `walk.rs`) to use the new `Expr::name_str()` accessor.

## Test plan

- [x] `cargo build` passes with no errors
- [x] `cargo test` — all 783 tests pass