### PR TITLE
perf(references): use mir codebase index for O(1) function/class lookups

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1,4 +1,5 @@
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
 
 use tower_lsp::jsonrpc::Result;
@@ -42,12 +43,12 @@ use crate::organize_imports::organize_imports_action;
 use crate::phpdoc_action::phpdoc_actions;
 use crate::phpstorm_meta::PhpStormMeta;
 use crate::promote_action::promote_constructor_actions;
-use crate::references::{SymbolKind, find_references};
+use crate::references::{SymbolKind, find_references, find_references_codebase};
 use crate::rename::{prepare_rename, rename, rename_property, rename_variable};
 use crate::selection_range::selection_ranges;
 use crate::semantic_diagnostics::{
-    deprecated_call_diagnostics, duplicate_declaration_diagnostics, semantic_diagnostics,
-    semantic_diagnostics_no_rebuild,
+    deprecated_call_diagnostics, duplicate_declaration_diagnostics, index_file_references,
+    semantic_diagnostics, semantic_diagnostics_no_rebuild,
 };
 use crate::semantic_tokens::{
     compute_token_delta, legend, semantic_tokens, semantic_tokens_range, token_hash,
@@ -155,6 +156,9 @@ pub struct Backend {
     meta: Arc<RwLock<PhpStormMeta>>,
     config: Arc<RwLock<LspConfig>>,
     codebase: Arc<mir_codebase::Codebase>,
+    /// Set to `true` once the post-scan reference-indexing pass completes.
+    /// `find_references_codebase` is only used when this is `true`.
+    ref_index_ready: Arc<AtomicBool>,
 }
 
 impl Backend {
@@ -169,6 +173,7 @@ impl Backend {
             meta: Arc::new(RwLock::new(PhpStormMeta::default())),
             config: Arc::new(RwLock::new(LspConfig::default())),
             codebase: Arc::new(codebase),
+            ref_index_ready: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -444,6 +449,7 @@ impl LanguageServer for Backend {
             let docs = Arc::clone(&self.docs);
             let client = self.client.clone();
             let codebase = Arc::clone(&self.codebase);
+            let ref_index_ready = Arc::clone(&self.ref_index_ready);
             let exclude_paths = self.config.read().unwrap().exclude_paths.clone();
             tokio::spawn(async move {
                 client
@@ -493,6 +499,12 @@ impl LanguageServer for Backend {
                 // that the index is populated. Without this, editors that opened
                 // files before indexing finished would show stale information.
                 send_refresh_requests(&client).await;
+
+                // Phase 3: build the reference index in the background so that
+                // find_references_codebase can serve O(1) lookups instead of
+                // scanning every file's AST. Runs after the progress notification
+                // so the editor considers indexing "done" while this completes.
+                build_reference_index(docs, codebase, ref_index_ready).await;
             });
         }
 
@@ -836,7 +848,17 @@ impl LanguageServer for Backend {
         };
         let all_docs = self.docs.all_docs();
         let include_declaration = params.context.include_declaration;
-        let locations = find_references(&word, &all_docs, include_declaration, kind);
+
+        // Fast path: use the pre-computed reference index once it is ready.
+        // Falls back to the full AST scan for Method / None kinds, and whenever
+        // the symbol is not found in the codebase (returns None).
+        let locations = if self.ref_index_ready.load(Ordering::SeqCst) {
+            find_references_codebase(&word, &all_docs, include_declaration, kind, &self.codebase)
+                .unwrap_or_else(|| find_references(&word, &all_docs, include_declaration, kind))
+        } else {
+            find_references(&word, &all_docs, include_declaration, kind)
+        };
+
         Ok(if locations.is_empty() {
             None
         } else {
@@ -2323,6 +2345,45 @@ async fn scan_workspace(
     while set.join_next().await.is_some() {}
 
     count.load(std::sync::atomic::Ordering::Relaxed)
+}
+
+/// Phase 3 of workspace initialisation: run `StatementsAnalyzer` on every
+/// indexed file to populate `codebase.symbol_reference_locations`.
+///
+/// This is deliberately run *after* the progress notification is sent so the
+/// editor considers indexing finished while this background work completes.
+/// Once done, `ref_index_ready` is set to `true` so the `references` handler
+/// can switch to O(1) codebase lookups instead of scanning every AST.
+async fn build_reference_index(
+    docs: Arc<DocumentStore>,
+    codebase: Arc<mir_codebase::Codebase>,
+    ready: Arc<AtomicBool>,
+) {
+    // Finalize inheritance tables once before analysing any file body.
+    codebase.finalize();
+
+    let all_docs = docs.all_docs();
+    let parallelism = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(4);
+    let sem = Arc::new(tokio::sync::Semaphore::new(parallelism));
+    let mut set: tokio::task::JoinSet<()> = tokio::task::JoinSet::new();
+
+    for (uri, doc) in all_docs {
+        let permit = Arc::clone(&sem).acquire_owned().await.unwrap();
+        let codebase = Arc::clone(&codebase);
+        set.spawn(async move {
+            let _permit = permit;
+            tokio::task::spawn_blocking(move || {
+                index_file_references(&uri, &doc, &codebase);
+            })
+            .await
+            .ok();
+        });
+    }
+
+    while set.join_next().await.is_some() {}
+    ready.store(true, Ordering::SeqCst);
 }
 
 #[cfg(test)]

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -660,7 +660,12 @@ impl LanguageServer for Backend {
                 let source = docs.get(&uri).unwrap_or_default();
                 let mut all_diags = diagnostics;
                 if let Some(d) = docs.get_doc(&uri) {
+                    // Full incremental update: evict stale definitions and
+                    // reference locations, re-collect, and rebuild inheritance
+                    // so the reference index is always consistent after an edit.
+                    codebase.remove_file_definitions(uri.as_str());
                     collect_into_codebase(&codebase, &uri, &d);
+                    codebase.finalize();
                     if ref_index_ready.load(Ordering::Acquire) {
                         index_file_references(&uri, &d, &codebase);
                     }
@@ -726,7 +731,9 @@ impl LanguageServer for Backend {
                     {
                         self.docs.index(change.uri.clone(), &text);
                         if let Some(d) = self.docs.get_doc(&change.uri) {
+                            self.codebase.remove_file_definitions(change.uri.as_str());
                             self.collect_definitions_for(&change.uri, &d);
+                            self.codebase.finalize();
                             if self.ref_index_ready.load(Ordering::Acquire) {
                                 index_file_references(&change.uri, &d, &self.codebase);
                             }

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -644,6 +644,7 @@ impl LanguageServer for Backend {
         let docs = Arc::clone(&self.docs);
         let client = self.client.clone();
         let codebase = Arc::clone(&self.codebase);
+        let ref_index_ready = Arc::clone(&self.ref_index_ready);
         let diag_cfg = self.config.read().unwrap().diagnostics.clone();
         tokio::spawn(async move {
             // 100 ms debounce: if another edit arrives before we parse, the
@@ -660,6 +661,9 @@ impl LanguageServer for Backend {
                 let mut all_diags = diagnostics;
                 if let Some(d) = docs.get_doc(&uri) {
                     collect_into_codebase(&codebase, &uri, &d);
+                    if ref_index_ready.load(Ordering::Acquire) {
+                        index_file_references(&uri, &d, &codebase);
+                    }
                     all_diags.extend(duplicate_declaration_diagnostics(&source, &d, &diag_cfg));
                     let other_raw = docs.other_docs(&uri);
                     let other_docs: Vec<Arc<ParsedDoc>> =
@@ -723,6 +727,9 @@ impl LanguageServer for Backend {
                         self.docs.index(change.uri.clone(), &text);
                         if let Some(d) = self.docs.get_doc(&change.uri) {
                             self.collect_definitions_for(&change.uri, &d);
+                            if self.ref_index_ready.load(Ordering::Acquire) {
+                                index_file_references(&change.uri, &d, &self.codebase);
+                            }
                         }
                     }
                 }
@@ -852,7 +859,7 @@ impl LanguageServer for Backend {
         // Fast path: use the pre-computed reference index once it is ready.
         // Falls back to the full AST scan for Method / None kinds, and whenever
         // the symbol is not found in the codebase (returns None).
-        let locations = if self.ref_index_ready.load(Ordering::SeqCst) {
+        let locations = if self.ref_index_ready.load(Ordering::Acquire) {
             find_references_codebase(&word, &all_docs, include_declaration, kind, &self.codebase)
                 .unwrap_or_else(|| find_references(&word, &all_docs, include_declaration, kind))
         } else {
@@ -2385,7 +2392,7 @@ async fn build_reference_index(
     }
 
     while set.join_next().await.is_some() {}
-    ready.store(true, Ordering::SeqCst);
+    ready.store(true, Ordering::Release);
 }
 
 #[cfg(test)]

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -501,7 +501,7 @@ impl LanguageServer for Backend {
                 send_refresh_requests(&client).await;
 
                 // Phase 3: build the reference index in the background so that
-                // find_references_codebase can serve O(1) lookups instead of
+                // find_references_codebase can serve O(k) lookups instead of
                 // scanning every file's AST. Runs after the progress notification
                 // so the editor considers indexing "done" while this completes.
                 build_reference_index(docs, codebase, ref_index_ready).await;
@@ -2353,15 +2353,17 @@ async fn scan_workspace(
 /// This is deliberately run *after* the progress notification is sent so the
 /// editor considers indexing finished while this background work completes.
 /// Once done, `ref_index_ready` is set to `true` so the `references` handler
-/// can switch to O(1) codebase lookups instead of scanning every AST.
+/// can switch to O(k) codebase lookups instead of scanning every AST.
 async fn build_reference_index(
     docs: Arc<DocumentStore>,
     codebase: Arc<mir_codebase::Codebase>,
     ready: Arc<AtomicBool>,
 ) {
-    // Finalize inheritance tables once before analysing any file body.
-    codebase.finalize();
-
+    // The codebase was already finalized at the end of the workspace scan
+    // (Phase 2). Calling finalize() again here would race with concurrent
+    // semantic_diagnostics calls that reset the finalized flag via
+    // remove_file_definitions(), causing method-inheritance lookups to
+    // transiently return None and silently drop those references from the index.
     let all_docs = docs.all_docs();
     let parallelism = std::thread::available_parallelism()
         .map(|n| n.get())

--- a/src/references.rs
+++ b/src/references.rs
@@ -92,7 +92,7 @@ pub fn find_references_codebase(
                 .iter()
                 .filter_map(|e| {
                     let fqn = e.key();
-                    let short = fqn.rsplit('\\').next().unwrap_or(fqn);
+                    let short = fqn.rsplit('\\').next().unwrap_or(fqn.as_ref());
                     if short == word {
                         Some(fqn.clone())
                     } else {
@@ -120,13 +120,18 @@ pub fn find_references_codebase(
                     locations.push(loc);
                 }
             }
-            Some(locations)
+            if locations.is_empty() {
+                None
+            } else {
+                Some(locations)
+            }
         }
 
         Some(SymbolKind::Class) => {
             // Collect all FQCNs whose short name matches `word` across all type maps.
             let mut fqcns: Vec<Arc<str>> = Vec::new();
-            let short_matches = |fqcn: &Arc<str>| fqcn.rsplit('\\').next().unwrap_or(fqcn) == word;
+            let short_matches =
+                |fqcn: &Arc<str>| fqcn.rsplit('\\').next().unwrap_or(fqcn.as_ref()) == word;
             for e in codebase.classes.iter() {
                 if short_matches(e.key()) {
                     fqcns.push(e.key().clone());
@@ -166,7 +171,11 @@ pub fn find_references_codebase(
                     locations.push(loc);
                 }
             }
-            Some(locations)
+            if locations.is_empty() {
+                None
+            } else {
+                Some(locations)
+            }
         }
 
         // Method references: mir only tracks calls on known types; fall back to

--- a/src/references.rs
+++ b/src/references.rs
@@ -48,6 +48,133 @@ pub fn find_references_with_use(
     find_references_inner(word, all_docs, include_declaration, true, None)
 }
 
+/// Fast path: look up pre-computed reference locations from the mir codebase index.
+///
+/// Only handles `Function` and `Class` kinds — for those the mir analyzer records every
+/// call-site / instantiation with a precise name-only span via `mark_*_referenced_at`.
+/// Returns `None` for `Method` (type-unaware callers would be missed) and for `None`
+/// kind (caller should use the general AST walker instead).
+///
+/// Returns `None` also when the symbol is not found in the codebase, signalling the
+/// caller to fall back to the AST scan.
+pub fn find_references_codebase(
+    word: &str,
+    all_docs: &[(Url, Arc<ParsedDoc>)],
+    include_declaration: bool,
+    kind: Option<SymbolKind>,
+    codebase: &mir_codebase::Codebase,
+) -> Option<Vec<Location>> {
+    // Build a URI-string → (Url, ParsedDoc) map for O(1) lookup.
+    let doc_map: std::collections::HashMap<&str, (&Url, &Arc<ParsedDoc>)> = all_docs
+        .iter()
+        .map(|(url, doc)| (url.as_str(), (url, doc)))
+        .collect();
+
+    let spans_to_location = |file: &str, start: u32, end: u32| -> Option<Location> {
+        let (url, doc) = doc_map.get(file)?;
+        let source = doc.source();
+        let start_pos = offset_to_position(source, start);
+        let end_pos = offset_to_position(source, end);
+        Some(Location {
+            uri: (*url).clone(),
+            range: Range {
+                start: start_pos,
+                end: end_pos,
+            },
+        })
+    };
+
+    match kind {
+        Some(SymbolKind::Function) => {
+            // Collect all FQNs whose short name (last `\`-segment) matches `word`.
+            let fqns: Vec<Arc<str>> = codebase
+                .functions
+                .iter()
+                .filter_map(|e| {
+                    let fqn = e.key();
+                    let short = fqn.rsplit('\\').next().unwrap_or(fqn);
+                    if short == word {
+                        Some(fqn.clone())
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+
+            if fqns.is_empty() {
+                return None;
+            }
+
+            let mut locations: Vec<Location> = Vec::new();
+            for fqn in &fqns {
+                for (file, start, end) in codebase.get_reference_locations(fqn) {
+                    if let Some(loc) = spans_to_location(&file, start, end) {
+                        locations.push(loc);
+                    }
+                }
+                if include_declaration
+                    && let Some(func) = codebase.functions.get(fqn.as_ref())
+                    && let Some(decl) = &func.location
+                    && let Some(loc) = spans_to_location(&decl.file, decl.start, decl.end)
+                {
+                    locations.push(loc);
+                }
+            }
+            Some(locations)
+        }
+
+        Some(SymbolKind::Class) => {
+            // Collect all FQCNs whose short name matches `word` across all type maps.
+            let mut fqcns: Vec<Arc<str>> = Vec::new();
+            let short_matches = |fqcn: &Arc<str>| fqcn.rsplit('\\').next().unwrap_or(fqcn) == word;
+            for e in codebase.classes.iter() {
+                if short_matches(e.key()) {
+                    fqcns.push(e.key().clone());
+                }
+            }
+            for e in codebase.interfaces.iter() {
+                if short_matches(e.key()) {
+                    fqcns.push(e.key().clone());
+                }
+            }
+            for e in codebase.traits.iter() {
+                if short_matches(e.key()) {
+                    fqcns.push(e.key().clone());
+                }
+            }
+            for e in codebase.enums.iter() {
+                if short_matches(e.key()) {
+                    fqcns.push(e.key().clone());
+                }
+            }
+
+            if fqcns.is_empty() {
+                return None;
+            }
+
+            let mut locations: Vec<Location> = Vec::new();
+            for fqcn in &fqcns {
+                for (file, start, end) in codebase.get_reference_locations(fqcn) {
+                    if let Some(loc) = spans_to_location(&file, start, end) {
+                        locations.push(loc);
+                    }
+                }
+                if include_declaration
+                    && let Some(decl) = codebase.get_symbol_location(fqcn)
+                    && let Some(loc) = spans_to_location(&decl.file, decl.start, decl.end)
+                {
+                    locations.push(loc);
+                }
+            }
+            Some(locations)
+        }
+
+        // Method references: mir only tracks calls on known types; fall back to
+        // the AST walker so dynamic / unknown-type call sites are included.
+        Some(SymbolKind::Method) | None => None,
+    }
+}
+
 fn find_references_inner(
     word: &str,
     all_docs: &[(Url, Arc<ParsedDoc>)],

--- a/src/semantic_diagnostics.rs
+++ b/src/semantic_diagnostics.rs
@@ -140,6 +140,32 @@ fn issue_passes_filter(issue: &mir_issues::Issue, cfg: &DiagnosticsConfig) -> bo
     }
 }
 
+/// Run Pass 2 analysis on `doc` to populate `codebase.symbol_reference_locations`.
+///
+/// Unlike [`semantic_diagnostics`] and [`semantic_diagnostics_no_rebuild`], this
+/// function discards all emitted issues — its only purpose is the side-effect of
+/// calling `mark_*_referenced_at` on the codebase so that `get_reference_locations`
+/// returns complete results for `find_references`.
+///
+/// The codebase must already be finalized (all definitions collected, `finalize()`
+/// called) before this is invoked.
+pub fn index_file_references(uri: &Url, doc: &ParsedDoc, codebase: &mir_codebase::Codebase) {
+    let file: Arc<str> = Arc::from(uri.as_str());
+    let source_map = php_rs_parser::source_map::SourceMap::new(doc.source());
+    let mut issue_buffer = mir_issues::IssueBuffer::new();
+    let mut symbols = Vec::new();
+    let mut analyzer = mir_analyzer::stmt::StatementsAnalyzer::new(
+        codebase,
+        file,
+        doc.source(),
+        &source_map,
+        &mut issue_buffer,
+        &mut symbols,
+    );
+    let mut ctx = mir_analyzer::context::Context::new();
+    analyzer.analyze_stmts(&doc.program().stmts, &mut ctx);
+}
+
 /// Check for deprecated function/method calls and emit Warning diagnostics.
 pub fn deprecated_call_diagnostics(
     source: &str,

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -899,7 +899,7 @@ pub fn refs_in_expr(source: &str, expr: &Expr<'_, '_>, word: &str, out: &mut Vec
         ExprKind::StaticMethodCall(s) => {
             refs_in_expr(source, s.class, word, out);
             if s.method.name_str() == Some(word) {
-                out.push(expr.span);
+                out.push(s.method.span);
             }
             args(source, &s.args, word, out);
         }
@@ -1292,10 +1292,7 @@ fn method_refs_in_expr(expr: &Expr<'_, '_>, name: &str, out: &mut Vec<Span>) {
         ExprKind::StaticMethodCall(s) => {
             method_refs_in_expr(s.class, name, out);
             if s.method.name_str() == Some(name) {
-                // For static calls, the span covers the whole expression; we need the
-                // method-name portion. Use the existing refs_in_expr behaviour which
-                // pushed expr.span for static methods — replicate that here.
-                out.push(expr.span);
+                out.push(s.method.span);
             }
             for a in s.args.iter() {
                 method_refs_in_expr(&a.value, name, out);


### PR DESCRIPTION
## Summary

### Performance: mir codebase index for references

Adds a background post-scan pass (`build_reference_index`) that runs `StatementsAnalyzer` on every indexed file to populate `codebase.symbol_reference_locations` via the `mark_*_referenced_at` side-effects already present in mir 0.5. Once complete it sets a `ref_index_ready` flag.

Adds `find_references_codebase` — a fast path for `Function` and `Class` kinds that calls `get_reference_locations` (O(k) where k = number of occurrences, vs the previous O(n_files × file_size) AST scan). Returns `None` in three cases, falling back to the full AST scan:

- `Method` kind — mir only records calls on statically-known receiver types; dynamic dispatch would be missed
- `None` kind — general walker needed
- Symbol not found in the codebase — covers external/vendor code and the window before the index is ready

### Bug fix: static method call span precision (closes #155)

`refs_in_expr` and `method_refs_in_expr` both pushed `expr.span` for `StaticMethodCall`, which covers the entire `Foo::bar()` expression. Changed to `s.method.span` so find-references, document highlight, and rename ranges point to just the method-name token (`bar`). A dedicated test for this case is still missing and tracked in #155.

## Test plan

- [x] `cargo test` — all 783 tests pass
- [x] Fast path returns `None` for Method/None kinds → AST fallback always runs for those
- [x] Fast path returns `None` when symbol not found in codebase → correct fallback before index is ready
- [ ] No targeted test for static-method-call span precision — tracked in #155