### PR TITLE
fix(document_store): evict token cache on close

### DIFF
--- a/src/document_store.rs
+++ b/src/document_store.rs
@@ -88,6 +88,7 @@ impl DocumentStore {
                 q.push_back(uri.clone());
             }
         }
+        self.token_cache.remove(uri);
     }
 
     pub fn index(&self, uri: Url, text: &str) {
@@ -377,6 +378,17 @@ mod tests {
             store.get_doc(&uri("/1.php")).is_none(),
             "/1.php must have been evicted as the oldest indexed-only file"
         );
+    }
+
+    #[test]
+    fn close_evicts_token_cache() {
+        let store = DocumentStore::new();
+        let u = uri("/a.php");
+        open(&store, u.clone(), "<?php".to_string());
+        store.store_token_cache(&u, "id1".to_string(), vec![]);
+        assert!(store.get_token_cache(&u, "id1").is_some());
+        store.close(&u);
+        assert!(store.get_token_cache(&u, "id1").is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `close()` now removes the semantic token cache entry for the closed file

## Problem

`token_cache` stores `(result_id, Vec<SemanticToken>)` per file to serve incremental delta responses. Entries were only removed in `remove()` (file deleted), never in `close()` (file closed by the editor). Tokens for closed files accumulated for the entire session.

## Fix

One line added to `close()`:

```rust
self.token_cache.remove(uri);
```

## Test plan

- [ ] `cargo test` passes
- [ ] New test `close_evicts_token_cache` verifies the entry is gone after close