### PR TITLE
perf: eliminate redundant allocations in hover, completion, and rename

### DIFF
--- a/src/completion/mod.rs
+++ b/src/completion/mod.rs
@@ -224,7 +224,8 @@ pub fn filtered_completions_at(
         Some(">") => {
             // Arrow: $obj->  or  $this->
             if let (Some(src), Some(pos)) = (source, position) {
-                let type_map = TypeMap::from_docs_with_meta(doc, other_docs, meta);
+                let type_map =
+                    TypeMap::from_docs_with_meta(doc, other_docs.iter().map(|d| d.as_ref()), meta);
                 if let Some(class_names) = resolve_receiver_class(src, doc, pos, &type_map) {
                     // Feature 5: support union types (Foo|Bar)
                     let mut items = Vec::new();
@@ -558,7 +559,8 @@ fn match_arm_completions(
     for line_idx in (end_line..=start_line).rev() {
         let line = source.lines().nth(line_idx)?;
         if let Some(cap) = extract_match_subject(line) {
-            let type_map = TypeMap::from_docs_with_meta(doc, other_docs, meta);
+            let type_map =
+                TypeMap::from_docs_with_meta(doc, other_docs.iter().map(|d| d.as_ref()), meta);
             let class_name = if cap == "this" {
                 enclosing_class_at(source, doc, position)?
             } else {

--- a/src/hover.rs
+++ b/src/hover.rs
@@ -59,8 +59,8 @@ pub fn hover_at(
 
     // Feature 2: hover on $variable shows its type
     if word.starts_with('$') {
-        let arc_docs: Vec<Arc<ParsedDoc>> = other_docs.iter().map(|(_, d)| d.clone()).collect();
-        let type_map = TypeMap::from_docs_with_meta(doc, &arc_docs, None);
+        let type_map =
+            TypeMap::from_docs_with_meta(doc, other_docs.iter().map(|(_, d)| d.as_ref()), None);
         if let Some(class_name) = type_map.get(&word) {
             return Some(Hover {
                 contents: HoverContents::Markup(MarkupContent {
@@ -140,9 +140,11 @@ pub fn hover_at(
                 let before_arrow = &line_text[..apos];
                 let receiver_var = extract_receiver_var_from_end(before_arrow);
                 if let Some(var_name) = receiver_var {
-                    let arc_docs: Vec<Arc<ParsedDoc>> =
-                        other_docs.iter().map(|(_, d)| d.clone()).collect();
-                    let type_map = TypeMap::from_docs_with_meta(doc, &arc_docs, None);
+                    let type_map = TypeMap::from_docs_with_meta(
+                        doc,
+                        other_docs.iter().map(|(_, d)| d.as_ref()),
+                        None,
+                    );
                     let class_name = if var_name == "$this" {
                         crate::type_map::enclosing_class_at(source, doc, position)
                             .or_else(|| type_map.get("$this").map(|s| s.to_string()))
@@ -150,11 +152,9 @@ pub fn hover_at(
                         type_map.get(&var_name).map(|s| s.to_string())
                     };
                     if let Some(cls) = class_name {
-                        // Search current doc + other docs for the property type
-                        let all_docs_search: Vec<&ParsedDoc> = std::iter::once(doc)
-                            .chain(other_docs.iter().map(|(_, d)| d.as_ref()))
-                            .collect();
-                        for d in &all_docs_search {
+                        for d in
+                            std::iter::once(doc).chain(other_docs.iter().map(|(_, d)| d.as_ref()))
+                        {
                             if let Some((type_str, db)) = find_property_info(d, &cls, &word) {
                                 let sig = format!(
                                     "(property) {}::${}{}",

--- a/src/rename.rs
+++ b/src/rename.rs
@@ -87,20 +87,20 @@ pub fn rename_variable(
     let mut spans = Vec::new();
     collect_var_refs_in_scope(stmts, bare, byte_off, &mut spans);
 
+    let mut seen = std::collections::HashSet::new();
     let mut edits: Vec<TextEdit> = spans
         .into_iter()
-        .map(|span| {
+        .filter_map(|span| {
             let start = offset_to_position(source, span.start);
             let end = offset_to_position(source, span.end);
-            TextEdit {
-                range: Range { start, end },
-                new_text: new_text.clone(),
-            }
+            seen.insert((start.line, start.character))
+                .then_some(TextEdit {
+                    range: Range { start, end },
+                    new_text: new_text.clone(),
+                })
         })
         .collect();
-
     edits.sort_by_key(|e| (e.range.start.line, e.range.start.character));
-    edits.dedup_by_key(|e| (e.range.start.line, e.range.start.character));
 
     let mut changes = HashMap::new();
     if !edits.is_empty() {
@@ -131,19 +131,20 @@ pub fn rename_property(
         let mut spans = Vec::new();
         property_refs_in_stmts(source, &doc.program().stmts, prop_name, &mut spans);
         if !spans.is_empty() {
+            let mut seen = std::collections::HashSet::new();
             let mut edits: Vec<TextEdit> = spans
                 .into_iter()
-                .map(|span| {
+                .filter_map(|span| {
                     let start = offset_to_position(source, span.start);
                     let end = offset_to_position(source, span.end);
-                    TextEdit {
-                        range: Range { start, end },
-                        new_text: new_name.to_string(),
-                    }
+                    seen.insert((start.line, start.character))
+                        .then_some(TextEdit {
+                            range: Range { start, end },
+                            new_text: new_name.to_string(),
+                        })
                 })
                 .collect();
             edits.sort_by_key(|e| (e.range.start.line, e.range.start.character));
-            edits.dedup_by_key(|e| (e.range.start.line, e.range.start.character));
             changes.insert(uri.clone(), edits);
         }
     }

--- a/src/type_map.rs
+++ b/src/type_map.rs
@@ -40,10 +40,10 @@ impl TypeMap {
 
     /// Build from a parsed document plus cross-file docs, optionally enriched
     /// by PHPStorm metadata. Method-return-type inference spans all provided docs.
-    pub fn from_docs_with_meta(
+    pub fn from_docs_with_meta<'a>(
         doc: &ParsedDoc,
-        other_docs: &[std::sync::Arc<ParsedDoc>],
-        meta: Option<&PhpStormMeta>,
+        other_docs: impl IntoIterator<Item = &'a ParsedDoc>,
+        meta: Option<&'a PhpStormMeta>,
     ) -> Self {
         let mut method_returns = build_method_returns(doc);
         for other in other_docs {


### PR DESCRIPTION
## Summary

Structural performance fixes across hover, completion, and rename — no mir dependency, no caching required. All changes are pure algorithmic/allocation improvements.

## Changes

### 1. `type_map.rs` — generalize `from_docs_with_meta` signature

Changed the `other_docs` parameter from `&[Arc<ParsedDoc>]` to `impl IntoIterator<Item = &'a ParsedDoc>`. This allows callers to pass an iterator directly without materializing an intermediate `Vec`, and unlocks fixes 2 and 3 below.

### 2. `hover.rs` — remove intermediate `Vec<Arc<ParsedDoc>>` for TypeMap construction

Two call sites in `hover_at` were collecting a `Vec<Arc<ParsedDoc>>` by cloning every Arc before passing it to `TypeMap::from_docs_with_meta`. With the updated signature, both now pass `other_docs.iter().map(|(_, d)| d.as_ref())` directly — no Vec allocation, no atomic refcount increments.

```rust
// Before
let arc_docs: Vec<Arc<ParsedDoc>> = other_docs.iter().map(|(_, d)| d.clone()).collect();
let type_map = TypeMap::from_docs_with_meta(doc, &arc_docs, None);

// After
let type_map = TypeMap::from_docs_with_meta(doc, other_docs.iter().map(|(_, d)| d.as_ref()), None);
```

### 3. `hover.rs` — replace `Vec::collect` with direct iterator chain for property search

The property hover code was materializing a temporary `Vec<&ParsedDoc>` just to iterate over it immediately after. Replaced with a direct iterator chain.

```rust
// Before
let all_docs_search: Vec<&ParsedDoc> = std::iter::once(doc)
    .chain(other_docs.iter().map(|(_, d)| d.as_ref()))
    .collect();
for d in &all_docs_search { ... }

// After
for d in std::iter::once(doc).chain(other_docs.iter().map(|(_, d)| d.as_ref())) { ... }
```

### 4. `rename.rs` — replace sort+dedup with HashSet deduplication in `rename_variable` and `rename_property`

Both rename functions were collecting all spans, sorting, then deduplicating by position. Replaced with a `HashSet` that filters duplicates during the initial collection pass. The sort is kept for stable edit ordering; only the redundant second pass is eliminated.

```rust
// Before
let mut edits: Vec<TextEdit> = spans.into_iter().map(|span| { ... }).collect();
edits.sort_by_key(|e| (e.range.start.line, e.range.start.character));
edits.dedup_by_key(|e| (e.range.start.line, e.range.start.character));

// After
let mut seen = std::collections::HashSet::new();
let mut edits: Vec<TextEdit> = spans
    .into_iter()
    .filter_map(|span| {
        seen.insert((start.line, start.character)).then_some(TextEdit { ... })
    })
    .collect();
edits.sort_by_key(|e| (e.range.start.line, e.range.start.character));
```

## Test plan

- All 784 existing tests pass
- Hover variable, property (`$obj->prop`, `$this->prop`, nullsafe `?->`), and cross-file hover tests cover changes 2 and 3
- `rename_variable_within_function`, `rename_variable_does_not_cross_function_boundary`, `rename_property_renames_declaration_and_accesses`, `rename_property_works_across_files` cover change 4