### PR TITLE
perf(completion): hoist repeated to_lowercase and lines() calls out of loops

### DIFF
--- a/src/completion/mod.rs
+++ b/src/completion/mod.rs
@@ -402,12 +402,13 @@ pub fn filtered_completions_at(
                 // Check we're NOT in a use statement
                 let is_use = use_completion_prefix(src, pos).is_some();
                 if !is_use {
+                    let prefix_lc = prefix.to_lowercase();
                     let mut ns_items: Vec<CompletionItem> = Vec::new();
                     for other in other_docs {
                         let mut classes = Vec::new();
                         collect_classes_with_ns(&other.program().stmts, "", &mut classes);
                         for (label, kind, fqn) in classes {
-                            if fqn.to_lowercase().starts_with(&prefix.to_lowercase()) {
+                            if fqn.to_lowercase().starts_with(&prefix_lc) {
                                 ns_items.push(CompletionItem {
                                     label: label.clone(),
                                     kind: Some(kind),
@@ -421,7 +422,7 @@ pub fn filtered_completions_at(
                     let mut classes = Vec::new();
                     collect_classes_with_ns(&doc.program().stmts, "", &mut classes);
                     for (label, kind, fqn) in classes {
-                        if fqn.to_lowercase().starts_with(&prefix.to_lowercase()) {
+                        if fqn.to_lowercase().starts_with(&prefix_lc) {
                             ns_items.push(CompletionItem {
                                 label: label.clone(),
                                 kind: Some(kind),
@@ -556,8 +557,9 @@ fn match_arm_completions(
 ) -> Option<Vec<CompletionItem>> {
     let start_line = position.line as usize;
     let end_line = start_line.saturating_sub(5);
+    let all_lines: Vec<&str> = source.lines().collect();
     for line_idx in (end_line..=start_line).rev() {
-        let line = source.lines().nth(line_idx)?;
+        let line = all_lines.get(line_idx).copied()?;
         if let Some(cap) = extract_match_subject(line) {
             let type_map =
                 TypeMap::from_docs_with_meta(doc, other_docs.iter().map(|d| d.as_ref()), meta);

--- a/src/completion/namespace.rs
+++ b/src/completion/namespace.rs
@@ -112,6 +112,7 @@ pub(super) fn collect_fqns_with_prefix(
     prefix: &str,
     out: &mut Vec<CompletionItem>,
 ) {
+    let prefix_lc = prefix.to_lowercase();
     for stmt in stmts {
         match &stmt.kind {
             StmtKind::Class(c) => {
@@ -121,7 +122,7 @@ pub(super) fn collect_fqns_with_prefix(
                     } else {
                         format!("{ns}\\{name}")
                     };
-                    if fqn.to_lowercase().contains(&prefix.to_lowercase()) || prefix.is_empty() {
+                    if fqn.to_lowercase().contains(&prefix_lc) || prefix.is_empty() {
                         out.push(CompletionItem {
                             label: fqn.clone(),
                             kind: Some(CompletionItemKind::CLASS),
@@ -137,7 +138,7 @@ pub(super) fn collect_fqns_with_prefix(
                 } else {
                     format!("{ns}\\{}", i.name)
                 };
-                if fqn.to_lowercase().contains(&prefix.to_lowercase()) || prefix.is_empty() {
+                if fqn.to_lowercase().contains(&prefix_lc) || prefix.is_empty() {
                     out.push(CompletionItem {
                         label: fqn.clone(),
                         kind: Some(CompletionItemKind::INTERFACE),


### PR DESCRIPTION
## Summary

- `prefix.to_lowercase()` was recomputed on every class/interface during namespace prefix matching in `namespace.rs` and `mod.rs` — now computed once before each loop
- `source.lines().nth(line_idx)` in `match_arm_completions` rescanned from the start of the source on each of up to 6 iterations — now collected into a `Vec<&str>` once and indexed directly

## Test plan

- [ ] Namespace `\` completion still filters correctly (case-insensitive)
- [ ] Match arm completions (`match $var`) still trigger correctly