### PR TITLE
perf: eliminate per-item to_lowercase allocations in completion and organize_imports

### DIFF
--- a/src/completion/mod.rs
+++ b/src/completion/mod.rs
@@ -408,7 +408,10 @@ pub fn filtered_completions_at(
                         let mut classes = Vec::new();
                         collect_classes_with_ns(&other.program().stmts, "", &mut classes);
                         for (label, kind, fqn) in classes {
-                            if fqn.to_lowercase().starts_with(&prefix_lc) {
+                            if fqn
+                                .get(..prefix_lc.len())
+                                .is_some_and(|s| s.eq_ignore_ascii_case(&prefix_lc))
+                            {
                                 ns_items.push(CompletionItem {
                                     label: label.clone(),
                                     kind: Some(kind),
@@ -422,7 +425,10 @@ pub fn filtered_completions_at(
                     let mut classes = Vec::new();
                     collect_classes_with_ns(&doc.program().stmts, "", &mut classes);
                     for (label, kind, fqn) in classes {
-                        if fqn.to_lowercase().starts_with(&prefix_lc) {
+                        if fqn
+                            .get(..prefix_lc.len())
+                            .is_some_and(|s| s.eq_ignore_ascii_case(&prefix_lc))
+                        {
                             ns_items.push(CompletionItem {
                                 label: label.clone(),
                                 kind: Some(kind),
@@ -534,7 +540,8 @@ pub fn filtered_completions_at(
                 let ns_prefix = prefix.trim_start_matches('\\').to_lowercase();
                 items.retain(|i| {
                     let fqn = i.detail.as_deref().unwrap_or(&i.label);
-                    fqn.to_lowercase().starts_with(&ns_prefix)
+                    fqn.get(..ns_prefix.len())
+                        .is_some_and(|s| s.eq_ignore_ascii_case(&ns_prefix))
                 });
             } else if !prefix.is_empty() {
                 items.retain(|i| fuzzy_camel_match(&prefix, &i.label));

--- a/src/completion/namespace.rs
+++ b/src/completion/namespace.rs
@@ -122,7 +122,7 @@ pub(super) fn collect_fqns_with_prefix(
                     } else {
                         format!("{ns}\\{name}")
                     };
-                    if fqn.to_lowercase().contains(&prefix_lc) || prefix.is_empty() {
+                    if prefix.is_empty() || fqn.to_lowercase().contains(&prefix_lc) {
                         out.push(CompletionItem {
                             label: fqn.clone(),
                             kind: Some(CompletionItemKind::CLASS),
@@ -138,7 +138,7 @@ pub(super) fn collect_fqns_with_prefix(
                 } else {
                     format!("{ns}\\{}", i.name)
                 };
-                if fqn.to_lowercase().contains(&prefix_lc) || prefix.is_empty() {
+                if prefix.is_empty() || fqn.to_lowercase().contains(&prefix_lc) {
                     out.push(CompletionItem {
                         label: fqn.clone(),
                         kind: Some(CompletionItemKind::INTERFACE),

--- a/src/organize_imports.rs
+++ b/src/organize_imports.rs
@@ -102,8 +102,8 @@ fn render_group(stmts: &[UseStatement], indent: &str, keyword: Option<&str>) -> 
 
 /// Sort a group alphabetically (case-insensitive) and deduplicate by FQN.
 fn sort_and_dedup(group: &mut Vec<UseStatement>) {
-    group.sort_by(|a, b| a.fqn.to_lowercase().cmp(&b.fqn.to_lowercase()));
-    group.dedup_by(|a, b| a.fqn.to_lowercase() == b.fqn.to_lowercase());
+    group.sort_by_cached_key(|u| u.fqn.to_lowercase());
+    group.dedup_by(|a, b| a.fqn.eq_ignore_ascii_case(&b.fqn));
 }
 
 fn make_action(uri: &Url, edit: TextEdit) -> CodeActionOrCommand {


### PR DESCRIPTION
## Summary

- Replace `fqn.to_lowercase().starts_with()` inside completion loops with zero-allocation `eq_ignore_ascii_case` slice comparisons — PHP FQNs are ASCII, so no Unicode handling is needed
- Use `sort_by_cached_key` in `sort_and_dedup` so each FQN is lowercased once instead of O(n log n) times during sort, and `eq_ignore_ascii_case` for dedup
- Short-circuit `prefix.is_empty()` before the `to_lowercase()` call in `collect_fqns_with_prefix` to skip the allocation entirely for the common empty-prefix case

## Test plan

- [ ] All existing tests pass (`cargo test`)
- [ ] Namespace-qualified completion (e.g. `App\Http\`) still filters correctly
- [ ] Organize imports still sorts and deduplicates case-insensitively