### PR TITLE
perf: O(log n) line lookup via precomputed line index in ParsedDoc

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -21,6 +21,7 @@ pub struct ParsedDoc {
     _arena: Box<bumpalo::Bump>,
     #[allow(clippy::box_collection)]
     _source: Box<String>,
+    line_starts: Vec<u32>,
 }
 
 // SAFETY: Program nodes contain only data; no thread-local state.
@@ -43,11 +44,14 @@ impl ParsedDoc {
 
         let result = php_rs_parser::parse(arena_ref, src_ref);
 
+        let line_starts = build_line_starts(src_ref);
+
         ParsedDoc {
             program: Box::new(result.program),
             errors: result.errors,
             _arena: arena_box,
             _source: source_box,
+            line_starts,
         }
     }
 
@@ -65,6 +69,12 @@ impl ParsedDoc {
     pub fn source(&self) -> &str {
         &self._source
     }
+
+    /// Borrow the precomputed line-start byte offsets.
+    /// `line_starts[i]` is the byte offset of the first character on line `i`.
+    pub fn line_starts(&self) -> &[u32] {
+        &self.line_starts
+    }
 }
 
 impl Default for ParsedDoc {
@@ -75,32 +85,44 @@ impl Default for ParsedDoc {
 
 // ── Span / position utilities ─────────────────────────────────────────────────
 
+/// Build a table of byte offsets for the start of each line.
+/// `result[i]` is the byte offset of the first character on line `i`.
+fn build_line_starts(source: &str) -> Vec<u32> {
+    let mut starts = vec![0u32];
+    for (i, b) in source.bytes().enumerate() {
+        if b == b'\n' {
+            starts.push(i as u32 + 1);
+        }
+    }
+    starts
+}
+
 /// Convert a byte offset into `source` to an LSP `Position` (0-based line/char).
 ///
-/// Handles both LF-only and CRLF line endings. When the offset lands on or
-/// after a `\r` that immediately precedes `\n`, the `\r` is not counted as a
-/// column so that positions are consistent regardless of line-ending style.
-pub fn offset_to_position(source: &str, offset: u32) -> Position {
-    let offset = (offset as usize).min(source.len());
-    let prefix = &source[..offset];
-    let line = prefix.bytes().filter(|&b| b == b'\n').count() as u32;
-    let last_nl = prefix.rfind('\n').map(|i| i + 1).unwrap_or(0);
-    // Strip a trailing \r so CRLF line endings don't inflate the column count.
-    let line_segment = prefix[last_nl..]
-        .strip_suffix('\r')
-        .unwrap_or(&prefix[last_nl..]);
-    let character = line_segment
-        .chars()
-        .map(|c| c.len_utf16() as u32)
-        .sum::<u32>();
+/// Uses a precomputed `line_starts` table for O(log n) binary search.
+/// Handles both LF-only and CRLF line endings: a trailing `\r` before `\n` is
+/// not counted as a column so that positions are consistent regardless of
+/// line-ending style.
+pub fn offset_to_position(source: &str, line_starts: &[u32], offset: u32) -> Position {
+    let offset_usize = (offset as usize).min(source.len());
+    // Binary search: find the last line_start ≤ offset.
+    let line = match line_starts.partition_point(|&s| s <= offset) {
+        0 => 0u32,
+        i => (i - 1) as u32,
+    };
+    let line_start = line_starts.get(line as usize).copied().unwrap_or(0) as usize;
+    let segment = &source[line_start..offset_usize];
+    // Strip trailing \r to handle CRLF: don't count \r as a column.
+    let segment = segment.strip_suffix('\r').unwrap_or(segment);
+    let character = segment.chars().map(|c| c.len_utf16() as u32).sum::<u32>();
     Position { line, character }
 }
 
 /// Convert a `Span` (byte-offset pair) to an LSP `Range`.
-pub fn span_to_range(source: &str, span: Span) -> Range {
+pub fn span_to_range(source: &str, line_starts: &[u32], span: Span) -> Range {
     Range {
-        start: offset_to_position(source, span.start),
-        end: offset_to_position(source, span.end),
+        start: offset_to_position(source, line_starts, span.start),
+        end: offset_to_position(source, line_starts, span.end),
     }
 }
 
@@ -121,11 +143,11 @@ pub fn str_offset(source: &str, substr: &str) -> u32 {
 }
 
 /// Build an LSP `Range` for a name that is a sub-slice of `source`.
-pub fn name_range(source: &str, name: &str) -> Range {
+pub fn name_range(source: &str, line_starts: &[u32], name: &str) -> Range {
     let start = str_offset(source, name);
     Range {
-        start: offset_to_position(source, start),
-        end: offset_to_position(source, start + name.len() as u32),
+        start: offset_to_position(source, line_starts, start),
+        end: offset_to_position(source, line_starts, start + name.len() as u32),
     }
 }
 
@@ -173,8 +195,10 @@ mod tests {
 
     #[test]
     fn offset_to_position_first_line() {
+        let src = "<?php\nfoo";
+        let doc = ParsedDoc::parse(src.to_string());
         assert_eq!(
-            offset_to_position("<?php\nfoo", 0),
+            offset_to_position(src, doc.line_starts(), 0),
             Position {
                 line: 0,
                 character: 0
@@ -185,8 +209,10 @@ mod tests {
     #[test]
     fn offset_to_position_second_line() {
         // "<?php\n" — offset 6 is start of line 1
+        let src = "<?php\nfoo";
+        let doc = ParsedDoc::parse(src.to_string());
         assert_eq!(
-            offset_to_position("<?php\nfoo", 6),
+            offset_to_position(src, doc.line_starts(), 6),
             Position {
                 line: 1,
                 character: 0
@@ -201,8 +227,9 @@ mod tests {
         // source: "a😀b" — byte offsets: a=0, 😀=1..5, b=5
         // UTF-16:            a=col 0, 😀=col 1..3, b=col 3
         let src = "a\u{1F600}b";
+        let doc = ParsedDoc::parse(src.to_string());
         assert_eq!(
-            offset_to_position(src, 5), // byte offset of 'b'
+            offset_to_position(src, doc.line_starts(), 5), // byte offset of 'b'
             Position {
                 line: 0,
                 character: 3
@@ -215,8 +242,9 @@ mod tests {
         // CRLF: offset pointing to first char of line 1 must give character=0.
         // "foo\r\nbar": f=0 o=1 o=2 \r=3 \n=4 b=5 a=6 r=7
         let src = "foo\r\nbar";
+        let doc = ParsedDoc::parse(src.to_string());
         assert_eq!(
-            offset_to_position(src, 5), // 'b'
+            offset_to_position(src, doc.line_starts(), 5), // 'b'
             Position {
                 line: 1,
                 character: 0
@@ -229,8 +257,9 @@ mod tests {
         // Offset pointing to the \r itself must not count it as a column.
         // "foo\r\nbar": the \r is at offset 3, column must be 3 (length of "foo").
         let src = "foo\r\nbar";
+        let doc = ParsedDoc::parse(src.to_string());
         assert_eq!(
-            offset_to_position(src, 3), // '\r'
+            offset_to_position(src, doc.line_starts(), 3), // '\r'
             Position {
                 line: 0,
                 character: 3
@@ -243,15 +272,16 @@ mod tests {
         // Multiple CRLF lines: columns must not accumulate stray \r counts.
         // "a\r\nb\r\nc": a=0 \r=1 \n=2 b=3 \r=4 \n=5 c=6
         let src = "a\r\nb\r\nc";
+        let doc = ParsedDoc::parse(src.to_string());
         assert_eq!(
-            offset_to_position(src, 6), // 'c'
+            offset_to_position(src, doc.line_starts(), 6), // 'c'
             Position {
                 line: 2,
                 character: 0
             }
         );
         assert_eq!(
-            offset_to_position(src, 3), // 'b'
+            offset_to_position(src, doc.line_starts(), 3), // 'b'
             Position {
                 line: 1,
                 character: 0

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -75,6 +75,14 @@ impl ParsedDoc {
     pub fn line_starts(&self) -> &[u32] {
         &self.line_starts
     }
+
+    /// Bundle source and line index for position lookups.
+    pub fn view(&self) -> SourceView<'_> {
+        SourceView {
+            source: self.source(),
+            line_starts: self.line_starts(),
+        }
+    }
 }
 
 impl Default for ParsedDoc {
@@ -95,6 +103,40 @@ fn build_line_starts(source: &str) -> Vec<u32> {
         }
     }
     starts
+}
+
+/// Bundles source text with its precomputed line-start table.
+/// `Copy` so inner functions can pass it by value without lifetime annotation churn.
+#[derive(Copy, Clone)]
+pub struct SourceView<'a> {
+    source: &'a str,
+    line_starts: &'a [u32],
+}
+
+impl<'a> SourceView<'a> {
+    #[inline]
+    pub fn source(self) -> &'a str {
+        self.source
+    }
+
+    pub fn position_of(self, offset: u32) -> Position {
+        offset_to_position(self.source, self.line_starts, offset)
+    }
+
+    pub fn range_of(self, span: Span) -> Range {
+        Range {
+            start: self.position_of(span.start),
+            end: self.position_of(span.end),
+        }
+    }
+
+    pub fn name_range(self, name: &str) -> Range {
+        let start = str_offset(self.source, name);
+        Range {
+            start: self.position_of(start),
+            end: self.position_of(start + name.len() as u32),
+        }
+    }
 }
 
 /// Convert a byte offset into `source` to an LSP `Position` (0-based line/char).

--- a/src/call_hierarchy.rs
+++ b/src/call_hierarchy.rs
@@ -7,7 +7,7 @@ use tower_lsp::lsp_types::{
     SymbolKind, Url,
 };
 
-use crate::ast::{ParsedDoc, name_range, span_to_range};
+use crate::ast::{ParsedDoc, SourceView, span_to_range};
 use crate::references::find_references;
 
 /// Find the declaration matching `name` and return a `CallHierarchyItem`.
@@ -16,11 +16,8 @@ pub fn prepare_call_hierarchy(
     all_docs: &[(Url, Arc<ParsedDoc>)],
 ) -> Option<CallHierarchyItem> {
     for (uri, doc) in all_docs {
-        let source = doc.source();
-        let line_starts = doc.line_starts();
-        if let Some(item) =
-            find_declaration_item(name, &doc.program().stmts, source, line_starts, uri)
-        {
+        let sv = doc.view();
+        if let Some(item) = find_declaration_item(name, &doc.program().stmts, sv, uri) {
             return Some(item);
         }
     }
@@ -41,13 +38,7 @@ pub fn incoming_calls(
 
     for loc in call_sites {
         let caller = doc_map.get(&loc.uri).and_then(|doc| {
-            enclosing_function(
-                doc.source(),
-                doc.line_starts(),
-                &doc.program().stmts,
-                loc.range.start,
-                &loc.uri,
-            )
+            enclosing_function(doc.view(), &doc.program().stmts, loc.range.start, &loc.uri)
         });
 
         let key = if let Some(ref ci) = caller {
@@ -89,7 +80,7 @@ pub fn outgoing_calls(
     let Some((_, doc)) = all_docs.iter().find(|(uri, _)| *uri == item.uri) else {
         return Vec::new();
     };
-    // Borrow source directly from the Arc to avoid cloning the whole file.
+    // Borrow sv.source() directly from the Arc to avoid cloning the whole file.
     let item_source = doc.source();
     let mut calls: Vec<(String, Span)> = Vec::new();
     collect_calls_for(&item.name, &doc.program().stmts, &mut calls);
@@ -120,15 +111,14 @@ pub fn outgoing_calls(
 fn find_declaration_item(
     name: &str,
     stmts: &[Stmt<'_, '_>],
-    source: &str,
-    line_starts: &[u32],
+    sv: SourceView<'_>,
     uri: &Url,
 ) -> Option<CallHierarchyItem> {
     for stmt in stmts {
         match &stmt.kind {
             StmtKind::Function(f) if f.name == name => {
-                let range = span_to_range(source, line_starts, stmt.span);
-                let sel = name_range(source, line_starts, f.name);
+                let range = sv.range_of(stmt.span);
+                let sel = sv.name_range(f.name);
                 return Some(CallHierarchyItem {
                     name: name.to_string(),
                     kind: SymbolKind::FUNCTION,
@@ -145,8 +135,8 @@ fn find_declaration_item(
                     if let ClassMemberKind::Method(m) = &member.kind
                         && m.name == name
                     {
-                        let range = span_to_range(source, line_starts, member.span);
-                        let sel = name_range(source, line_starts, m.name);
+                        let range = sv.range_of(member.span);
+                        let sel = sv.name_range(m.name);
                         return Some(CallHierarchyItem {
                             name: name.to_string(),
                             kind: SymbolKind::METHOD,
@@ -165,8 +155,8 @@ fn find_declaration_item(
                     if let ClassMemberKind::Method(m) = &member.kind
                         && m.name == name
                     {
-                        let range = span_to_range(source, line_starts, member.span);
-                        let sel = name_range(source, line_starts, m.name);
+                        let range = sv.range_of(member.span);
+                        let sel = sv.name_range(m.name);
                         return Some(CallHierarchyItem {
                             name: name.to_string(),
                             kind: SymbolKind::METHOD,
@@ -185,8 +175,8 @@ fn find_declaration_item(
                     if let EnumMemberKind::Method(m) = &member.kind
                         && m.name == name
                     {
-                        let range = span_to_range(source, line_starts, member.span);
-                        let sel = name_range(source, line_starts, m.name);
+                        let range = sv.range_of(member.span);
+                        let sel = sv.name_range(m.name);
                         return Some(CallHierarchyItem {
                             name: name.to_string(),
                             kind: SymbolKind::METHOD,
@@ -202,7 +192,7 @@ fn find_declaration_item(
             }
             StmtKind::Namespace(ns) => {
                 if let NamespaceBody::Braced(inner) = &ns.body
-                    && let Some(item) = find_declaration_item(name, inner, source, line_starts, uri)
+                    && let Some(item) = find_declaration_item(name, inner, sv, uri)
                 {
                     return Some(item);
                 }
@@ -214,14 +204,13 @@ fn find_declaration_item(
 }
 
 fn enclosing_function(
-    source: &str,
-    line_starts: &[u32],
+    sv: SourceView<'_>,
     stmts: &[Stmt<'_, '_>],
     pos: Position,
     uri: &Url,
 ) -> Option<CallHierarchyItem> {
     for stmt in stmts {
-        if let Some(item) = enclosing_in_stmt(source, line_starts, stmt, pos, uri) {
+        if let Some(item) = enclosing_in_stmt(sv, stmt, pos, uri) {
             return Some(item);
         }
     }
@@ -229,19 +218,18 @@ fn enclosing_function(
 }
 
 fn enclosing_in_stmt(
-    source: &str,
-    line_starts: &[u32],
+    sv: SourceView<'_>,
     stmt: &Stmt<'_, '_>,
     pos: Position,
     uri: &Url,
 ) -> Option<CallHierarchyItem> {
-    let range = span_to_range(source, line_starts, stmt.span);
+    let range = sv.range_of(stmt.span);
     if !range_contains(range, pos) {
         return None;
     }
     match &stmt.kind {
         StmtKind::Function(f) => {
-            let sel = name_range(source, line_starts, f.name);
+            let sel = sv.name_range(f.name);
             Some(CallHierarchyItem {
                 name: f.name.to_string(),
                 kind: SymbolKind::FUNCTION,
@@ -255,11 +243,11 @@ fn enclosing_in_stmt(
         }
         StmtKind::Class(c) => {
             for member in c.members.iter() {
-                let m_range = span_to_range(source, line_starts, member.span);
+                let m_range = sv.range_of(member.span);
                 if range_contains(m_range, pos)
                     && let ClassMemberKind::Method(m) = &member.kind
                 {
-                    let sel = name_range(source, line_starts, m.name);
+                    let sel = sv.name_range(m.name);
                     return Some(CallHierarchyItem {
                         name: m.name.to_string(),
                         kind: SymbolKind::METHOD,
@@ -276,11 +264,11 @@ fn enclosing_in_stmt(
         }
         StmtKind::Trait(t) => {
             for member in t.members.iter() {
-                let m_range = span_to_range(source, line_starts, member.span);
+                let m_range = sv.range_of(member.span);
                 if range_contains(m_range, pos)
                     && let ClassMemberKind::Method(m) = &member.kind
                 {
-                    let sel = name_range(source, line_starts, m.name);
+                    let sel = sv.name_range(m.name);
                     return Some(CallHierarchyItem {
                         name: m.name.to_string(),
                         kind: SymbolKind::METHOD,
@@ -297,11 +285,11 @@ fn enclosing_in_stmt(
         }
         StmtKind::Enum(e) => {
             for member in e.members.iter() {
-                let m_range = span_to_range(source, line_starts, member.span);
+                let m_range = sv.range_of(member.span);
                 if range_contains(m_range, pos)
                     && let EnumMemberKind::Method(m) = &member.kind
                 {
-                    let sel = name_range(source, line_starts, m.name);
+                    let sel = sv.name_range(m.name);
                     return Some(CallHierarchyItem {
                         name: m.name.to_string(),
                         kind: SymbolKind::METHOD,
@@ -318,7 +306,7 @@ fn enclosing_in_stmt(
         }
         StmtKind::Namespace(ns) => {
             if let NamespaceBody::Braced(inner) = &ns.body {
-                return enclosing_function(source, line_starts, inner, pos, uri);
+                return enclosing_function(sv, inner, pos, uri);
             }
             None
         }

--- a/src/call_hierarchy.rs
+++ b/src/call_hierarchy.rs
@@ -17,7 +17,10 @@ pub fn prepare_call_hierarchy(
 ) -> Option<CallHierarchyItem> {
     for (uri, doc) in all_docs {
         let source = doc.source();
-        if let Some(item) = find_declaration_item(name, &doc.program().stmts, source, uri) {
+        let line_starts = doc.line_starts();
+        if let Some(item) =
+            find_declaration_item(name, &doc.program().stmts, source, line_starts, uri)
+        {
             return Some(item);
         }
     }
@@ -40,6 +43,7 @@ pub fn incoming_calls(
         let caller = doc_map.get(&loc.uri).and_then(|doc| {
             enclosing_function(
                 doc.source(),
+                doc.line_starts(),
                 &doc.program().stmts,
                 loc.range.start,
                 &loc.uri,
@@ -93,8 +97,9 @@ pub fn outgoing_calls(
     let mut result: Vec<CallHierarchyOutgoingCall> = Vec::new();
     // Track callee_name → index in `result` for O(1) dedup.
     let mut index: HashMap<String, usize> = HashMap::new();
+    let item_line_starts = doc.line_starts();
     for (callee_name, span) in calls {
-        let call_range = span_to_range(item_source, span);
+        let call_range = span_to_range(item_source, item_line_starts, span);
         if let Some(&idx) = index.get(&callee_name) {
             result[idx].from_ranges.push(call_range);
         } else if let Some(callee_item) = prepare_call_hierarchy(&callee_name, all_docs) {
@@ -116,13 +121,14 @@ fn find_declaration_item(
     name: &str,
     stmts: &[Stmt<'_, '_>],
     source: &str,
+    line_starts: &[u32],
     uri: &Url,
 ) -> Option<CallHierarchyItem> {
     for stmt in stmts {
         match &stmt.kind {
             StmtKind::Function(f) if f.name == name => {
-                let range = span_to_range(source, stmt.span);
-                let sel = name_range(source, f.name);
+                let range = span_to_range(source, line_starts, stmt.span);
+                let sel = name_range(source, line_starts, f.name);
                 return Some(CallHierarchyItem {
                     name: name.to_string(),
                     kind: SymbolKind::FUNCTION,
@@ -139,8 +145,8 @@ fn find_declaration_item(
                     if let ClassMemberKind::Method(m) = &member.kind
                         && m.name == name
                     {
-                        let range = span_to_range(source, member.span);
-                        let sel = name_range(source, m.name);
+                        let range = span_to_range(source, line_starts, member.span);
+                        let sel = name_range(source, line_starts, m.name);
                         return Some(CallHierarchyItem {
                             name: name.to_string(),
                             kind: SymbolKind::METHOD,
@@ -159,8 +165,8 @@ fn find_declaration_item(
                     if let ClassMemberKind::Method(m) = &member.kind
                         && m.name == name
                     {
-                        let range = span_to_range(source, member.span);
-                        let sel = name_range(source, m.name);
+                        let range = span_to_range(source, line_starts, member.span);
+                        let sel = name_range(source, line_starts, m.name);
                         return Some(CallHierarchyItem {
                             name: name.to_string(),
                             kind: SymbolKind::METHOD,
@@ -179,8 +185,8 @@ fn find_declaration_item(
                     if let EnumMemberKind::Method(m) = &member.kind
                         && m.name == name
                     {
-                        let range = span_to_range(source, member.span);
-                        let sel = name_range(source, m.name);
+                        let range = span_to_range(source, line_starts, member.span);
+                        let sel = name_range(source, line_starts, m.name);
                         return Some(CallHierarchyItem {
                             name: name.to_string(),
                             kind: SymbolKind::METHOD,
@@ -196,7 +202,7 @@ fn find_declaration_item(
             }
             StmtKind::Namespace(ns) => {
                 if let NamespaceBody::Braced(inner) = &ns.body
-                    && let Some(item) = find_declaration_item(name, inner, source, uri)
+                    && let Some(item) = find_declaration_item(name, inner, source, line_starts, uri)
                 {
                     return Some(item);
                 }
@@ -209,12 +215,13 @@ fn find_declaration_item(
 
 fn enclosing_function(
     source: &str,
+    line_starts: &[u32],
     stmts: &[Stmt<'_, '_>],
     pos: Position,
     uri: &Url,
 ) -> Option<CallHierarchyItem> {
     for stmt in stmts {
-        if let Some(item) = enclosing_in_stmt(source, stmt, pos, uri) {
+        if let Some(item) = enclosing_in_stmt(source, line_starts, stmt, pos, uri) {
             return Some(item);
         }
     }
@@ -223,17 +230,18 @@ fn enclosing_function(
 
 fn enclosing_in_stmt(
     source: &str,
+    line_starts: &[u32],
     stmt: &Stmt<'_, '_>,
     pos: Position,
     uri: &Url,
 ) -> Option<CallHierarchyItem> {
-    let range = span_to_range(source, stmt.span);
+    let range = span_to_range(source, line_starts, stmt.span);
     if !range_contains(range, pos) {
         return None;
     }
     match &stmt.kind {
         StmtKind::Function(f) => {
-            let sel = name_range(source, f.name);
+            let sel = name_range(source, line_starts, f.name);
             Some(CallHierarchyItem {
                 name: f.name.to_string(),
                 kind: SymbolKind::FUNCTION,
@@ -247,11 +255,11 @@ fn enclosing_in_stmt(
         }
         StmtKind::Class(c) => {
             for member in c.members.iter() {
-                let m_range = span_to_range(source, member.span);
+                let m_range = span_to_range(source, line_starts, member.span);
                 if range_contains(m_range, pos)
                     && let ClassMemberKind::Method(m) = &member.kind
                 {
-                    let sel = name_range(source, m.name);
+                    let sel = name_range(source, line_starts, m.name);
                     return Some(CallHierarchyItem {
                         name: m.name.to_string(),
                         kind: SymbolKind::METHOD,
@@ -268,11 +276,11 @@ fn enclosing_in_stmt(
         }
         StmtKind::Trait(t) => {
             for member in t.members.iter() {
-                let m_range = span_to_range(source, member.span);
+                let m_range = span_to_range(source, line_starts, member.span);
                 if range_contains(m_range, pos)
                     && let ClassMemberKind::Method(m) = &member.kind
                 {
-                    let sel = name_range(source, m.name);
+                    let sel = name_range(source, line_starts, m.name);
                     return Some(CallHierarchyItem {
                         name: m.name.to_string(),
                         kind: SymbolKind::METHOD,
@@ -289,11 +297,11 @@ fn enclosing_in_stmt(
         }
         StmtKind::Enum(e) => {
             for member in e.members.iter() {
-                let m_range = span_to_range(source, member.span);
+                let m_range = span_to_range(source, line_starts, member.span);
                 if range_contains(m_range, pos)
                     && let EnumMemberKind::Method(m) = &member.kind
                 {
-                    let sel = name_range(source, m.name);
+                    let sel = name_range(source, line_starts, m.name);
                     return Some(CallHierarchyItem {
                         name: m.name.to_string(),
                         kind: SymbolKind::METHOD,
@@ -310,7 +318,7 @@ fn enclosing_in_stmt(
         }
         StmtKind::Namespace(ns) => {
             if let NamespaceBody::Braced(inner) = &ns.body {
-                return enclosing_function(source, inner, pos, uri);
+                return enclosing_function(source, line_starts, inner, pos, uri);
             }
             None
         }

--- a/src/code_lens.rs
+++ b/src/code_lens.rs
@@ -26,14 +26,23 @@ pub fn code_lenses(
     all_docs: &[(Url, Arc<ParsedDoc>)],
 ) -> Vec<CodeLens> {
     let source = doc.source();
+    let line_starts = doc.line_starts();
     let mut lenses = Vec::new();
-    collect_lenses(&doc.program().stmts, source, uri, all_docs, &mut lenses);
+    collect_lenses(
+        &doc.program().stmts,
+        source,
+        line_starts,
+        uri,
+        all_docs,
+        &mut lenses,
+    );
     lenses
 }
 
 fn collect_lenses(
     stmts: &[Stmt<'_, '_>],
     source: &str,
+    line_starts: &[u32],
     uri: &Url,
     all_docs: &[(Url, Arc<ParsedDoc>)],
     out: &mut Vec<CodeLens>,
@@ -41,12 +50,12 @@ fn collect_lenses(
     for stmt in stmts {
         match &stmt.kind {
             StmtKind::Function(f) => {
-                let range = name_range(source, f.name);
+                let range = name_range(source, line_starts, f.name);
                 out.push(ref_count_lens(range, f.name, all_docs));
             }
             StmtKind::Class(c) => {
                 if let Some(class_name) = c.name {
-                    let class_range = name_range(source, class_name);
+                    let class_range = name_range(source, line_starts, class_name);
                     out.push(ref_count_lens(class_range, class_name, all_docs));
 
                     // Implementations count for abstract classes (classes extending this).
@@ -60,7 +69,7 @@ fn collect_lenses(
 
                     for member in c.members.iter() {
                         if let ClassMemberKind::Method(m) = &member.kind {
-                            let method_range = name_range(source, m.name);
+                            let method_range = name_range(source, line_starts, m.name);
                             out.push(ref_count_lens(method_range, m.name, all_docs));
 
                             if is_test_method(source, m, member.span.start) {
@@ -78,38 +87,38 @@ fn collect_lenses(
                 }
             }
             StmtKind::Interface(i) => {
-                let range = name_range(source, i.name);
+                let range = name_range(source, line_starts, i.name);
                 out.push(ref_count_lens(range, i.name, all_docs));
                 // Implementations count lens.
                 let impl_count = find_implementations(i.name, None, all_docs).len();
                 out.push(impl_count_lens(range, impl_count));
             }
             StmtKind::Trait(t) => {
-                let range = name_range(source, t.name);
+                let range = name_range(source, line_starts, t.name);
                 out.push(ref_count_lens(range, t.name, all_docs));
                 // Usages count: how many classes use this trait.
                 let usage_count = count_trait_usages(t.name, all_docs);
                 out.push(impl_count_lens(range, usage_count));
                 for member in t.members.iter() {
                     if let ClassMemberKind::Method(m) = &member.kind {
-                        let method_range = name_range(source, m.name);
+                        let method_range = name_range(source, line_starts, m.name);
                         out.push(ref_count_lens(method_range, m.name, all_docs));
                     }
                 }
             }
             StmtKind::Enum(e) => {
-                let range = name_range(source, e.name);
+                let range = name_range(source, line_starts, e.name);
                 out.push(ref_count_lens(range, e.name, all_docs));
                 for member in e.members.iter() {
                     if let EnumMemberKind::Method(m) = &member.kind {
-                        let method_range = name_range(source, m.name);
+                        let method_range = name_range(source, line_starts, m.name);
                         out.push(ref_count_lens(method_range, m.name, all_docs));
                     }
                 }
             }
             StmtKind::Namespace(ns) => {
                 if let NamespaceBody::Braced(inner) = &ns.body {
-                    collect_lenses(inner, source, uri, all_docs, out);
+                    collect_lenses(inner, source, line_starts, uri, all_docs, out);
                 }
             }
             _ => {}

--- a/src/code_lens.rs
+++ b/src/code_lens.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 use php_ast::{ClassMemberKind, EnumMemberKind, NamespaceBody, Stmt, StmtKind};
 use tower_lsp::lsp_types::{CodeLens, Command, Url};
 
-use crate::ast::{ParsedDoc, name_range};
+use crate::ast::{ParsedDoc, SourceView};
 use crate::docblock::docblock_before;
 use crate::implementation::find_implementations;
 use crate::references::find_references;
@@ -25,24 +25,15 @@ pub fn code_lenses(
     doc: &ParsedDoc,
     all_docs: &[(Url, Arc<ParsedDoc>)],
 ) -> Vec<CodeLens> {
-    let source = doc.source();
-    let line_starts = doc.line_starts();
+    let sv = doc.view();
     let mut lenses = Vec::new();
-    collect_lenses(
-        &doc.program().stmts,
-        source,
-        line_starts,
-        uri,
-        all_docs,
-        &mut lenses,
-    );
+    collect_lenses(&doc.program().stmts, sv, uri, all_docs, &mut lenses);
     lenses
 }
 
 fn collect_lenses(
     stmts: &[Stmt<'_, '_>],
-    source: &str,
-    line_starts: &[u32],
+    sv: SourceView<'_>,
     uri: &Url,
     all_docs: &[(Url, Arc<ParsedDoc>)],
     out: &mut Vec<CodeLens>,
@@ -50,12 +41,12 @@ fn collect_lenses(
     for stmt in stmts {
         match &stmt.kind {
             StmtKind::Function(f) => {
-                let range = name_range(source, line_starts, f.name);
+                let range = sv.name_range(f.name);
                 out.push(ref_count_lens(range, f.name, all_docs));
             }
             StmtKind::Class(c) => {
                 if let Some(class_name) = c.name {
-                    let class_range = name_range(source, line_starts, class_name);
+                    let class_range = sv.name_range(class_name);
                     out.push(ref_count_lens(class_range, class_name, all_docs));
 
                     // Implementations count for abstract classes (classes extending this).
@@ -69,10 +60,10 @@ fn collect_lenses(
 
                     for member in c.members.iter() {
                         if let ClassMemberKind::Method(m) = &member.kind {
-                            let method_range = name_range(source, line_starts, m.name);
+                            let method_range = sv.name_range(m.name);
                             out.push(ref_count_lens(method_range, m.name, all_docs));
 
-                            if is_test_method(source, m, member.span.start) {
+                            if is_test_method(sv.source(), m, member.span.start) {
                                 out.push(run_test_lens(method_range, uri, class_name, m.name));
                             }
 
@@ -87,38 +78,38 @@ fn collect_lenses(
                 }
             }
             StmtKind::Interface(i) => {
-                let range = name_range(source, line_starts, i.name);
+                let range = sv.name_range(i.name);
                 out.push(ref_count_lens(range, i.name, all_docs));
                 // Implementations count lens.
                 let impl_count = find_implementations(i.name, None, all_docs).len();
                 out.push(impl_count_lens(range, impl_count));
             }
             StmtKind::Trait(t) => {
-                let range = name_range(source, line_starts, t.name);
+                let range = sv.name_range(t.name);
                 out.push(ref_count_lens(range, t.name, all_docs));
                 // Usages count: how many classes use this trait.
                 let usage_count = count_trait_usages(t.name, all_docs);
                 out.push(impl_count_lens(range, usage_count));
                 for member in t.members.iter() {
                     if let ClassMemberKind::Method(m) = &member.kind {
-                        let method_range = name_range(source, line_starts, m.name);
+                        let method_range = sv.name_range(m.name);
                         out.push(ref_count_lens(method_range, m.name, all_docs));
                     }
                 }
             }
             StmtKind::Enum(e) => {
-                let range = name_range(source, line_starts, e.name);
+                let range = sv.name_range(e.name);
                 out.push(ref_count_lens(range, e.name, all_docs));
                 for member in e.members.iter() {
                     if let EnumMemberKind::Method(m) = &member.kind {
-                        let method_range = name_range(source, line_starts, m.name);
+                        let method_range = sv.name_range(m.name);
                         out.push(ref_count_lens(method_range, m.name, all_docs));
                     }
                 }
             }
             StmtKind::Namespace(ns) => {
                 if let NamespaceBody::Braced(inner) = &ns.body {
-                    collect_lenses(inner, source, line_starts, uri, all_docs, out);
+                    collect_lenses(inner, sv, uri, all_docs, out);
                 }
             }
             _ => {}

--- a/src/completion/mod.rs
+++ b/src/completion/mod.rs
@@ -408,7 +408,10 @@ pub fn filtered_completions_at(
                         let mut classes = Vec::new();
                         collect_classes_with_ns(&other.program().stmts, "", &mut classes);
                         for (label, kind, fqn) in classes {
-                            if fqn.to_lowercase().starts_with(&prefix_lc) {
+                            if fqn
+                                .get(..prefix_lc.len())
+                                .is_some_and(|s| s.eq_ignore_ascii_case(&prefix_lc))
+                            {
                                 ns_items.push(CompletionItem {
                                     label: label.clone(),
                                     kind: Some(kind),
@@ -422,7 +425,10 @@ pub fn filtered_completions_at(
                     let mut classes = Vec::new();
                     collect_classes_with_ns(&doc.program().stmts, "", &mut classes);
                     for (label, kind, fqn) in classes {
-                        if fqn.to_lowercase().starts_with(&prefix_lc) {
+                        if fqn
+                            .get(..prefix_lc.len())
+                            .is_some_and(|s| s.eq_ignore_ascii_case(&prefix_lc))
+                        {
                             ns_items.push(CompletionItem {
                                 label: label.clone(),
                                 kind: Some(kind),
@@ -534,7 +540,8 @@ pub fn filtered_completions_at(
                 let ns_prefix = prefix.trim_start_matches('\\').to_lowercase();
                 items.retain(|i| {
                     let fqn = i.detail.as_deref().unwrap_or(&i.label);
-                    fqn.to_lowercase().starts_with(&ns_prefix)
+                    fqn.get(..ns_prefix.len())
+                        .is_some_and(|s| s.eq_ignore_ascii_case(&ns_prefix))
                 });
             } else if !prefix.is_empty() {
                 items.retain(|i| fuzzy_camel_match(&prefix, &i.label));

--- a/src/completion/namespace.rs
+++ b/src/completion/namespace.rs
@@ -122,7 +122,7 @@ pub(super) fn collect_fqns_with_prefix(
                     } else {
                         format!("{ns}\\{name}")
                     };
-                    if fqn.to_lowercase().contains(&prefix_lc) || prefix.is_empty() {
+                    if prefix.is_empty() || fqn.to_lowercase().contains(&prefix_lc) {
                         out.push(CompletionItem {
                             label: fqn.clone(),
                             kind: Some(CompletionItemKind::CLASS),
@@ -138,7 +138,7 @@ pub(super) fn collect_fqns_with_prefix(
                 } else {
                     format!("{ns}\\{}", i.name)
                 };
-                if fqn.to_lowercase().contains(&prefix_lc) || prefix.is_empty() {
+                if prefix.is_empty() || fqn.to_lowercase().contains(&prefix_lc) {
                     out.push(CompletionItem {
                         label: fqn.clone(),
                         kind: Some(CompletionItemKind::INTERFACE),

--- a/src/completion/symbols.rs
+++ b/src/completion/symbols.rs
@@ -1,7 +1,7 @@
 use php_ast::{ClassMemberKind, EnumMemberKind, ExprKind, NamespaceBody, Stmt, StmtKind};
 use tower_lsp::lsp_types::{CompletionItem, CompletionItemKind};
 
-use crate::ast::{ParsedDoc, offset_to_position};
+use crate::ast::{ParsedDoc, SourceView};
 
 use super::{build_function_sig, callable_item, docblock_docs, named_arg_item};
 
@@ -14,16 +14,9 @@ pub fn symbol_completions(doc: &ParsedDoc) -> Vec<CompletionItem> {
 /// Like `symbol_completions` but only includes variables declared at or before `line`.
 /// Non-variable items (functions, classes, etc.) are always included.
 pub fn symbol_completions_before(doc: &ParsedDoc, line: u32) -> Vec<CompletionItem> {
-    let line_starts = doc.line_starts();
+    let sv = doc.view();
     let mut items = Vec::new();
-    collect_from_statements_before(
-        &doc.program().stmts,
-        &mut items,
-        line,
-        doc.source(),
-        line_starts,
-        Some(doc),
-    );
+    collect_from_statements_before(&doc.program().stmts, &mut items, line, sv, Some(doc));
     items
 }
 
@@ -31,22 +24,21 @@ fn collect_from_statements_before(
     stmts: &[Stmt<'_, '_>],
     items: &mut Vec<CompletionItem>,
     line: u32,
-    source: &str,
-    line_starts: &[u32],
+    sv: SourceView<'_>,
     doc: Option<&ParsedDoc>,
 ) {
     for stmt in stmts {
         match &stmt.kind {
             StmtKind::Expression(e) => {
                 // Only add variables if they appear at or before the cursor line
-                let stmt_line = offset_to_position(source, line_starts, stmt.span.start).line;
+                let stmt_line = sv.position_of(stmt.span.start).line;
                 if stmt_line <= line {
                     collect_from_expression(e, items);
                 }
             }
             StmtKind::Namespace(ns) => {
                 if let NamespaceBody::Braced(inner) = &ns.body {
-                    collect_from_statements_before(inner, items, line, source, line_starts, doc);
+                    collect_from_statements_before(inner, items, line, sv, doc);
                 }
             }
             // Non-variable items: always include

--- a/src/completion/symbols.rs
+++ b/src/completion/symbols.rs
@@ -14,12 +14,14 @@ pub fn symbol_completions(doc: &ParsedDoc) -> Vec<CompletionItem> {
 /// Like `symbol_completions` but only includes variables declared at or before `line`.
 /// Non-variable items (functions, classes, etc.) are always included.
 pub fn symbol_completions_before(doc: &ParsedDoc, line: u32) -> Vec<CompletionItem> {
+    let line_starts = doc.line_starts();
     let mut items = Vec::new();
     collect_from_statements_before(
         &doc.program().stmts,
         &mut items,
         line,
         doc.source(),
+        line_starts,
         Some(doc),
     );
     items
@@ -30,20 +32,21 @@ fn collect_from_statements_before(
     items: &mut Vec<CompletionItem>,
     line: u32,
     source: &str,
+    line_starts: &[u32],
     doc: Option<&ParsedDoc>,
 ) {
     for stmt in stmts {
         match &stmt.kind {
             StmtKind::Expression(e) => {
                 // Only add variables if they appear at or before the cursor line
-                let stmt_line = offset_to_position(source, stmt.span.start).line;
+                let stmt_line = offset_to_position(source, line_starts, stmt.span.start).line;
                 if stmt_line <= line {
                     collect_from_expression(e, items);
                 }
             }
             StmtKind::Namespace(ns) => {
                 if let NamespaceBody::Braced(inner) = &ns.body {
-                    collect_from_statements_before(inner, items, line, source, doc);
+                    collect_from_statements_before(inner, items, line, source, line_starts, doc);
                 }
             }
             // Non-variable items: always include

--- a/src/declaration.rs
+++ b/src/declaration.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use php_ast::{ClassMemberKind, EnumMemberKind, NamespaceBody, Stmt, StmtKind};
 use tower_lsp::lsp_types::{Location, Position, Url};
 
-use crate::ast::{ParsedDoc, name_range};
+use crate::ast::{ParsedDoc, SourceView};
 use crate::util::word_at;
 
 /// Find the abstract or interface declaration of `word`.
@@ -25,11 +25,8 @@ pub fn goto_declaration(
 
     // First pass: look for an abstract or interface declaration
     for (uri, doc) in all_docs {
-        let doc_source = doc.source();
-        let line_starts = doc.line_starts();
-        if let Some(range) =
-            find_abstract_declaration(doc_source, line_starts, &doc.program().stmts, &word)
-        {
+        let sv = doc.view();
+        if let Some(range) = find_abstract_declaration(sv, &doc.program().stmts, &word) {
             return Some(Location {
                 uri: uri.clone(),
                 range,
@@ -39,11 +36,8 @@ pub fn goto_declaration(
 
     // Second pass: any declaration (same as goto_definition)
     for (uri, doc) in all_docs {
-        let doc_source = doc.source();
-        let line_starts = doc.line_starts();
-        if let Some(range) =
-            find_any_declaration(doc_source, line_starts, &doc.program().stmts, &word)
-        {
+        let sv = doc.view();
+        if let Some(range) = find_any_declaration(sv, &doc.program().stmts, &word) {
             return Some(Location {
                 uri: uri.clone(),
                 range,
@@ -55,8 +49,7 @@ pub fn goto_declaration(
 }
 
 fn find_abstract_declaration(
-    source: &str,
-    line_starts: &[u32],
+    sv: SourceView<'_>,
     stmts: &[Stmt<'_, '_>],
     word: &str,
 ) -> Option<tower_lsp::lsp_types::Range> {
@@ -68,11 +61,11 @@ fn find_abstract_declaration(
                     if let ClassMemberKind::Method(m) = &member.kind
                         && m.name == word
                     {
-                        return Some(name_range(source, line_starts, m.name));
+                        return Some(sv.name_range(m.name));
                     }
                 }
                 if i.name == word {
-                    return Some(name_range(source, line_starts, i.name));
+                    return Some(sv.name_range(i.name));
                 }
             }
             StmtKind::Class(c) => {
@@ -81,13 +74,13 @@ fn find_abstract_declaration(
                         && m.is_abstract
                         && m.name == word
                     {
-                        return Some(name_range(source, line_starts, m.name));
+                        return Some(sv.name_range(m.name));
                     }
                 }
             }
             StmtKind::Namespace(ns) => {
                 if let NamespaceBody::Braced(inner) = &ns.body
-                    && let Some(r) = find_abstract_declaration(source, line_starts, inner, word)
+                    && let Some(r) = find_abstract_declaration(sv, inner, word)
                 {
                     return Some(r);
                 }
@@ -99,53 +92,48 @@ fn find_abstract_declaration(
 }
 
 fn find_any_declaration(
-    source: &str,
-    line_starts: &[u32],
+    sv: SourceView<'_>,
     stmts: &[Stmt<'_, '_>],
     word: &str,
 ) -> Option<tower_lsp::lsp_types::Range> {
     for stmt in stmts {
         match &stmt.kind {
             StmtKind::Function(f) if f.name == word => {
-                return Some(name_range(source, line_starts, f.name));
+                return Some(sv.name_range(f.name));
             }
             StmtKind::Class(c) if c.name == Some(word) => {
-                return Some(name_range(
-                    source,
-                    line_starts,
-                    c.name.expect("match guard ensures Some"),
-                ));
+                return Some(sv.name_range(c.name.expect("match guard ensures Some")));
             }
             StmtKind::Class(c) => {
                 for member in c.members.iter() {
                     if let ClassMemberKind::Method(m) = &member.kind
                         && m.name == word
                     {
-                        return Some(name_range(source, line_starts, m.name));
+                        return Some(sv.name_range(m.name));
                     }
                 }
             }
             StmtKind::Interface(i) if i.name == word => {
-                return Some(name_range(source, line_starts, i.name));
+                return Some(sv.name_range(i.name));
             }
             StmtKind::Trait(t) if t.name == word => {
-                return Some(name_range(source, line_starts, t.name));
+                return Some(sv.name_range(t.name));
             }
             StmtKind::Enum(e) if e.name == word => {
-                return Some(name_range(source, line_starts, e.name));
+                return Some(sv.name_range(e.name));
             }
             StmtKind::Enum(e) => {
                 for member in e.members.iter() {
                     if let EnumMemberKind::Method(m) = &member.kind
                         && m.name == word
                     {
-                        return Some(name_range(source, line_starts, m.name));
+                        return Some(sv.name_range(m.name));
                     }
                 }
             }
             StmtKind::Namespace(ns) => {
                 if let NamespaceBody::Braced(inner) = &ns.body
-                    && let Some(r) = find_any_declaration(source, line_starts, inner, word)
+                    && let Some(r) = find_any_declaration(sv, inner, word)
                 {
                     return Some(r);
                 }

--- a/src/declaration.rs
+++ b/src/declaration.rs
@@ -26,7 +26,10 @@ pub fn goto_declaration(
     // First pass: look for an abstract or interface declaration
     for (uri, doc) in all_docs {
         let doc_source = doc.source();
-        if let Some(range) = find_abstract_declaration(doc_source, &doc.program().stmts, &word) {
+        let line_starts = doc.line_starts();
+        if let Some(range) =
+            find_abstract_declaration(doc_source, line_starts, &doc.program().stmts, &word)
+        {
             return Some(Location {
                 uri: uri.clone(),
                 range,
@@ -37,7 +40,10 @@ pub fn goto_declaration(
     // Second pass: any declaration (same as goto_definition)
     for (uri, doc) in all_docs {
         let doc_source = doc.source();
-        if let Some(range) = find_any_declaration(doc_source, &doc.program().stmts, &word) {
+        let line_starts = doc.line_starts();
+        if let Some(range) =
+            find_any_declaration(doc_source, line_starts, &doc.program().stmts, &word)
+        {
             return Some(Location {
                 uri: uri.clone(),
                 range,
@@ -50,6 +56,7 @@ pub fn goto_declaration(
 
 fn find_abstract_declaration(
     source: &str,
+    line_starts: &[u32],
     stmts: &[Stmt<'_, '_>],
     word: &str,
 ) -> Option<tower_lsp::lsp_types::Range> {
@@ -61,11 +68,11 @@ fn find_abstract_declaration(
                     if let ClassMemberKind::Method(m) = &member.kind
                         && m.name == word
                     {
-                        return Some(name_range(source, m.name));
+                        return Some(name_range(source, line_starts, m.name));
                     }
                 }
                 if i.name == word {
-                    return Some(name_range(source, i.name));
+                    return Some(name_range(source, line_starts, i.name));
                 }
             }
             StmtKind::Class(c) => {
@@ -74,13 +81,13 @@ fn find_abstract_declaration(
                         && m.is_abstract
                         && m.name == word
                     {
-                        return Some(name_range(source, m.name));
+                        return Some(name_range(source, line_starts, m.name));
                     }
                 }
             }
             StmtKind::Namespace(ns) => {
                 if let NamespaceBody::Braced(inner) = &ns.body
-                    && let Some(r) = find_abstract_declaration(source, inner, word)
+                    && let Some(r) = find_abstract_declaration(source, line_starts, inner, word)
                 {
                     return Some(r);
                 }
@@ -93,17 +100,19 @@ fn find_abstract_declaration(
 
 fn find_any_declaration(
     source: &str,
+    line_starts: &[u32],
     stmts: &[Stmt<'_, '_>],
     word: &str,
 ) -> Option<tower_lsp::lsp_types::Range> {
     for stmt in stmts {
         match &stmt.kind {
             StmtKind::Function(f) if f.name == word => {
-                return Some(name_range(source, f.name));
+                return Some(name_range(source, line_starts, f.name));
             }
             StmtKind::Class(c) if c.name == Some(word) => {
                 return Some(name_range(
                     source,
+                    line_starts,
                     c.name.expect("match guard ensures Some"),
                 ));
             }
@@ -112,31 +121,31 @@ fn find_any_declaration(
                     if let ClassMemberKind::Method(m) = &member.kind
                         && m.name == word
                     {
-                        return Some(name_range(source, m.name));
+                        return Some(name_range(source, line_starts, m.name));
                     }
                 }
             }
             StmtKind::Interface(i) if i.name == word => {
-                return Some(name_range(source, i.name));
+                return Some(name_range(source, line_starts, i.name));
             }
             StmtKind::Trait(t) if t.name == word => {
-                return Some(name_range(source, t.name));
+                return Some(name_range(source, line_starts, t.name));
             }
             StmtKind::Enum(e) if e.name == word => {
-                return Some(name_range(source, e.name));
+                return Some(name_range(source, line_starts, e.name));
             }
             StmtKind::Enum(e) => {
                 for member in e.members.iter() {
                     if let EnumMemberKind::Method(m) = &member.kind
                         && m.name == word
                     {
-                        return Some(name_range(source, m.name));
+                        return Some(name_range(source, line_starts, m.name));
                     }
                 }
             }
             StmtKind::Namespace(ns) => {
                 if let NamespaceBody::Braced(inner) = &ns.body
-                    && let Some(r) = find_any_declaration(source, inner, word)
+                    && let Some(r) = find_any_declaration(source, line_starts, inner, word)
                 {
                     return Some(r);
                 }

--- a/src/definition.rs
+++ b/src/definition.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use php_ast::{ClassMemberKind, EnumMemberKind, NamespaceBody, Stmt, StmtKind};
 use tower_lsp::lsp_types::{Location, Position, Range, Url};
 
-use crate::ast::{ParsedDoc, name_range, offset_to_position, str_offset};
+use crate::ast::{ParsedDoc, SourceView, str_offset};
 use crate::util::{utf16_pos_to_byte, word_at};
 use crate::walk::collect_var_refs_in_scope;
 
@@ -19,24 +19,24 @@ pub fn goto_definition(
     let word = word_at(source, position)?;
 
     // For $variable, find the first occurrence in scope (= the definition/assignment).
-    let line_starts = doc.line_starts();
+    let sv = doc.view();
     if word.starts_with('$') {
         let bare = word.trim_start_matches('$');
-        let byte_off = utf16_pos_to_byte(source, position);
+        let byte_off = utf16_pos_to_byte(sv.source(), position);
         let mut spans = Vec::new();
         collect_var_refs_in_scope(&doc.program().stmts, bare, byte_off, &mut spans);
         if let Some(span) = spans.into_iter().min_by_key(|s| s.start) {
             return Some(Location {
                 uri: uri.clone(),
                 range: Range {
-                    start: offset_to_position(source, line_starts, span.start),
-                    end: offset_to_position(source, line_starts, span.end),
+                    start: sv.position_of(span.start),
+                    end: sv.position_of(span.end),
                 },
             });
         }
     }
 
-    if let Some(range) = scan_statements(source, line_starts, &doc.program().stmts, &word) {
+    if let Some(range) = scan_statements(sv, &doc.program().stmts, &word) {
         return Some(Location {
             uri: uri.clone(),
             range,
@@ -44,14 +44,8 @@ pub fn goto_definition(
     }
 
     for (other_uri, other_doc) in other_docs {
-        let other_source = other_doc.source();
-        let other_line_starts = other_doc.line_starts();
-        if let Some(range) = scan_statements(
-            other_source,
-            other_line_starts,
-            &other_doc.program().stmts,
-            &word,
-        ) {
+        let other_sv = other_doc.view();
+        if let Some(range) = scan_statements(other_sv, &other_doc.program().stmts, &word) {
             return Some(Location {
                 uri: other_uri.clone(),
                 range,
@@ -64,61 +58,56 @@ pub fn goto_definition(
 
 /// Search an AST for a declaration named `name`, returning its selection range.
 /// Used by the PSR-4 fallback in the backend after resolving a class to a file.
-pub fn find_declaration_range(source: &str, doc: &ParsedDoc, name: &str) -> Option<Range> {
-    let line_starts = doc.line_starts();
-    scan_statements(source, line_starts, &doc.program().stmts, name)
+pub fn find_declaration_range(_source: &str, doc: &ParsedDoc, name: &str) -> Option<Range> {
+    let sv = doc.view();
+    scan_statements(sv, &doc.program().stmts, name)
 }
 
-fn scan_statements(
-    source: &str,
-    line_starts: &[u32],
-    stmts: &[Stmt<'_, '_>],
-    word: &str,
-) -> Option<Range> {
+fn scan_statements(sv: SourceView<'_>, stmts: &[Stmt<'_, '_>], word: &str) -> Option<Range> {
     // Strip a leading `$` so that `$name` matches property names stored without `$`.
     let bare = word.strip_prefix('$').unwrap_or(word);
     for stmt in stmts {
         match &stmt.kind {
             StmtKind::Function(f) if f.name == word => {
-                return Some(name_range(source, line_starts, f.name));
+                return Some(sv.name_range(f.name));
             }
             StmtKind::Class(c) if c.name == Some(word) => {
                 let name = c.name.expect("match guard ensures Some");
-                return Some(name_range(source, line_starts, name));
+                return Some(sv.name_range(name));
             }
             StmtKind::Class(c) => {
                 for member in c.members.iter() {
                     match &member.kind {
                         ClassMemberKind::Method(m) if m.name == word => {
-                            return Some(name_range(source, line_starts, m.name));
+                            return Some(sv.name_range(m.name));
                         }
                         ClassMemberKind::ClassConst(cc) if cc.name == word => {
-                            return Some(name_range(source, line_starts, cc.name));
+                            return Some(sv.name_range(cc.name));
                         }
                         ClassMemberKind::Property(p) if p.name == bare => {
-                            return Some(name_range(source, line_starts, p.name));
+                            return Some(sv.name_range(p.name));
                         }
                         _ => {}
                     }
                 }
             }
             StmtKind::Interface(i) if i.name == word => {
-                return Some(name_range(source, line_starts, i.name));
+                return Some(sv.name_range(i.name));
             }
             StmtKind::Trait(t) if t.name == word => {
-                return Some(name_range(source, line_starts, t.name));
+                return Some(sv.name_range(t.name));
             }
             StmtKind::Enum(e) if e.name == word => {
-                return Some(name_range(source, line_starts, e.name));
+                return Some(sv.name_range(e.name));
             }
             StmtKind::Enum(e) => {
                 for member in e.members.iter() {
                     match &member.kind {
                         EnumMemberKind::Method(m) if m.name == word => {
-                            return Some(name_range(source, line_starts, m.name));
+                            return Some(sv.name_range(m.name));
                         }
                         EnumMemberKind::Case(c) if c.name == word => {
-                            return Some(name_range(source, line_starts, c.name));
+                            return Some(sv.name_range(c.name));
                         }
                         _ => {}
                     }
@@ -126,7 +115,7 @@ fn scan_statements(
             }
             StmtKind::Namespace(ns) => {
                 if let NamespaceBody::Braced(inner) = &ns.body
-                    && let Some(range) = scan_statements(source, line_starts, inner, word)
+                    && let Some(range) = scan_statements(sv, inner, word)
                 {
                     return Some(range);
                 }
@@ -137,9 +126,9 @@ fn scan_statements(
     None
 }
 
-fn _name_range_from_offset(source: &str, line_starts: &[u32], name: &str) -> Range {
-    let start_offset = str_offset(source, name);
-    let start = offset_to_position(source, line_starts, start_offset);
+fn _name_range_from_offset(sv: SourceView<'_>, name: &str) -> Range {
+    let start_offset = str_offset(sv.source(), name);
+    let start = sv.position_of(start_offset);
     Range {
         start,
         end: Position {

--- a/src/definition.rs
+++ b/src/definition.rs
@@ -19,6 +19,7 @@ pub fn goto_definition(
     let word = word_at(source, position)?;
 
     // For $variable, find the first occurrence in scope (= the definition/assignment).
+    let line_starts = doc.line_starts();
     if word.starts_with('$') {
         let bare = word.trim_start_matches('$');
         let byte_off = utf16_pos_to_byte(source, position);
@@ -28,14 +29,14 @@ pub fn goto_definition(
             return Some(Location {
                 uri: uri.clone(),
                 range: Range {
-                    start: offset_to_position(source, span.start),
-                    end: offset_to_position(source, span.end),
+                    start: offset_to_position(source, line_starts, span.start),
+                    end: offset_to_position(source, line_starts, span.end),
                 },
             });
         }
     }
 
-    if let Some(range) = scan_statements(source, &doc.program().stmts, &word) {
+    if let Some(range) = scan_statements(source, line_starts, &doc.program().stmts, &word) {
         return Some(Location {
             uri: uri.clone(),
             range,
@@ -44,7 +45,13 @@ pub fn goto_definition(
 
     for (other_uri, other_doc) in other_docs {
         let other_source = other_doc.source();
-        if let Some(range) = scan_statements(other_source, &other_doc.program().stmts, &word) {
+        let other_line_starts = other_doc.line_starts();
+        if let Some(range) = scan_statements(
+            other_source,
+            other_line_starts,
+            &other_doc.program().stmts,
+            &word,
+        ) {
             return Some(Location {
                 uri: other_uri.clone(),
                 range,
@@ -58,54 +65,60 @@ pub fn goto_definition(
 /// Search an AST for a declaration named `name`, returning its selection range.
 /// Used by the PSR-4 fallback in the backend after resolving a class to a file.
 pub fn find_declaration_range(source: &str, doc: &ParsedDoc, name: &str) -> Option<Range> {
-    scan_statements(source, &doc.program().stmts, name)
+    let line_starts = doc.line_starts();
+    scan_statements(source, line_starts, &doc.program().stmts, name)
 }
 
-fn scan_statements(source: &str, stmts: &[Stmt<'_, '_>], word: &str) -> Option<Range> {
+fn scan_statements(
+    source: &str,
+    line_starts: &[u32],
+    stmts: &[Stmt<'_, '_>],
+    word: &str,
+) -> Option<Range> {
     // Strip a leading `$` so that `$name` matches property names stored without `$`.
     let bare = word.strip_prefix('$').unwrap_or(word);
     for stmt in stmts {
         match &stmt.kind {
             StmtKind::Function(f) if f.name == word => {
-                return Some(name_range(source, f.name));
+                return Some(name_range(source, line_starts, f.name));
             }
             StmtKind::Class(c) if c.name == Some(word) => {
                 let name = c.name.expect("match guard ensures Some");
-                return Some(name_range(source, name));
+                return Some(name_range(source, line_starts, name));
             }
             StmtKind::Class(c) => {
                 for member in c.members.iter() {
                     match &member.kind {
                         ClassMemberKind::Method(m) if m.name == word => {
-                            return Some(name_range(source, m.name));
+                            return Some(name_range(source, line_starts, m.name));
                         }
                         ClassMemberKind::ClassConst(cc) if cc.name == word => {
-                            return Some(name_range(source, cc.name));
+                            return Some(name_range(source, line_starts, cc.name));
                         }
                         ClassMemberKind::Property(p) if p.name == bare => {
-                            return Some(name_range(source, p.name));
+                            return Some(name_range(source, line_starts, p.name));
                         }
                         _ => {}
                     }
                 }
             }
             StmtKind::Interface(i) if i.name == word => {
-                return Some(name_range(source, i.name));
+                return Some(name_range(source, line_starts, i.name));
             }
             StmtKind::Trait(t) if t.name == word => {
-                return Some(name_range(source, t.name));
+                return Some(name_range(source, line_starts, t.name));
             }
             StmtKind::Enum(e) if e.name == word => {
-                return Some(name_range(source, e.name));
+                return Some(name_range(source, line_starts, e.name));
             }
             StmtKind::Enum(e) => {
                 for member in e.members.iter() {
                     match &member.kind {
                         EnumMemberKind::Method(m) if m.name == word => {
-                            return Some(name_range(source, m.name));
+                            return Some(name_range(source, line_starts, m.name));
                         }
                         EnumMemberKind::Case(c) if c.name == word => {
-                            return Some(name_range(source, c.name));
+                            return Some(name_range(source, line_starts, c.name));
                         }
                         _ => {}
                     }
@@ -113,7 +126,7 @@ fn scan_statements(source: &str, stmts: &[Stmt<'_, '_>], word: &str) -> Option<R
             }
             StmtKind::Namespace(ns) => {
                 if let NamespaceBody::Braced(inner) = &ns.body
-                    && let Some(range) = scan_statements(source, inner, word)
+                    && let Some(range) = scan_statements(source, line_starts, inner, word)
                 {
                     return Some(range);
                 }
@@ -124,9 +137,9 @@ fn scan_statements(source: &str, stmts: &[Stmt<'_, '_>], word: &str) -> Option<R
     None
 }
 
-fn _name_range_from_offset(source: &str, name: &str) -> Range {
+fn _name_range_from_offset(source: &str, line_starts: &[u32], name: &str) -> Range {
     let start_offset = str_offset(source, name);
-    let start = offset_to_position(source, start_offset);
+    let start = offset_to_position(source, line_starts, start_offset);
     Range {
         start,
         end: Position {

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -1,24 +1,24 @@
 use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, Position, Range};
 
-use crate::ast::{ParsedDoc, offset_to_position};
+use crate::ast::ParsedDoc;
 
 /// Parse `source` and return the (owned) `ParsedDoc` plus any parse diagnostics.
 pub fn parse_document(source: &str) -> (ParsedDoc, Vec<Diagnostic>) {
     let doc = ParsedDoc::parse(source.to_string());
-    let line_starts = doc.line_starts();
+    let sv = doc.view();
     let diagnostics = doc
         .errors
         .iter()
         .map(|e| {
             let span = e.span();
-            let start = offset_to_position(source, line_starts, span.start);
+            let start = sv.position_of(span.start);
             let end = if span.end > span.start {
-                offset_to_position(source, line_starts, span.end)
+                sv.position_of(span.end)
             } else {
                 // Zero-width span: advance by the UTF-16 width of the character
                 // at the error position so the range is never a mid-surrogate
                 // slice (characters outside the BMP take 2 UTF-16 code units).
-                let ch_width = source[span.start as usize..]
+                let ch_width = sv.source()[span.start as usize..]
                     .chars()
                     .next()
                     .map(|c| c.len_utf16() as u32)

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -5,14 +5,15 @@ use crate::ast::{ParsedDoc, offset_to_position};
 /// Parse `source` and return the (owned) `ParsedDoc` plus any parse diagnostics.
 pub fn parse_document(source: &str) -> (ParsedDoc, Vec<Diagnostic>) {
     let doc = ParsedDoc::parse(source.to_string());
+    let line_starts = doc.line_starts();
     let diagnostics = doc
         .errors
         .iter()
         .map(|e| {
             let span = e.span();
-            let start = offset_to_position(source, span.start);
+            let start = offset_to_position(source, line_starts, span.start);
             let end = if span.end > span.start {
-                offset_to_position(source, span.end)
+                offset_to_position(source, line_starts, span.end)
             } else {
                 // Zero-width span: advance by the UTF-16 width of the character
                 // at the error position so the range is never a mid-surrogate

--- a/src/document_highlight.rs
+++ b/src/document_highlight.rs
@@ -29,10 +29,11 @@ pub fn document_highlights(
         refs_in_stmts(source, &doc.program().stmts, &word, &mut spans);
     }
 
+    let line_starts = doc.line_starts();
     spans
         .into_iter()
         .map(|span| {
-            let start = offset_to_position(source, span.start);
+            let start = offset_to_position(source, line_starts, span.start);
             let end = Position {
                 line: start.line,
                 character: start.character + word_utf16_len,

--- a/src/document_highlight.rs
+++ b/src/document_highlight.rs
@@ -1,6 +1,6 @@
 use tower_lsp::lsp_types::{DocumentHighlight, DocumentHighlightKind, Position, Range};
 
-use crate::ast::{ParsedDoc, offset_to_position};
+use crate::ast::ParsedDoc;
 use crate::util::{utf16_pos_to_byte, word_at};
 use crate::walk::{collect_var_refs_in_scope, refs_in_stmts};
 
@@ -29,11 +29,11 @@ pub fn document_highlights(
         refs_in_stmts(source, &doc.program().stmts, &word, &mut spans);
     }
 
-    let line_starts = doc.line_starts();
+    let sv = doc.view();
     spans
         .into_iter()
         .map(|span| {
-            let start = offset_to_position(source, line_starts, span.start);
+            let start = sv.position_of(span.start);
             let end = Position {
                 line: start.line,
                 character: start.character + word_utf16_len,

--- a/src/document_link.rs
+++ b/src/document_link.rs
@@ -2,58 +2,56 @@
 use php_ast::{ExprKind, NamespaceBody, Stmt, StmtKind};
 use tower_lsp::lsp_types::{DocumentLink, Position, Range, Url};
 
-use crate::ast::{ParsedDoc, offset_to_position};
+use crate::ast::{ParsedDoc, SourceView};
 use crate::util::byte_to_utf16;
 
-pub fn document_links(uri: &Url, doc: &ParsedDoc, source: &str) -> Vec<DocumentLink> {
-    let line_starts = doc.line_starts();
+pub fn document_links(uri: &Url, doc: &ParsedDoc, _source: &str) -> Vec<DocumentLink> {
+    let sv = doc.view();
     let mut links = Vec::new();
-    collect_in_stmts(&doc.program().stmts, source, line_starts, uri, &mut links);
-    collect_docblock_links(source, &mut links);
+    collect_in_stmts(&doc.program().stmts, sv, uri, &mut links);
+    collect_docblock_links(sv.source(), &mut links);
     links
 }
 
 fn collect_in_stmts(
     stmts: &[Stmt<'_, '_>],
-    source: &str,
-    line_starts: &[u32],
+    sv: SourceView<'_>,
     uri: &Url,
     out: &mut Vec<DocumentLink>,
 ) {
     for stmt in stmts {
-        collect_in_stmt(stmt, source, line_starts, uri, out);
+        collect_in_stmt(stmt, sv, uri, out);
     }
 }
 
 fn collect_in_stmt(
     stmt: &Stmt<'_, '_>,
-    source: &str,
-    line_starts: &[u32],
+    sv: SourceView<'_>,
     uri: &Url,
     out: &mut Vec<DocumentLink>,
 ) {
     match &stmt.kind {
-        StmtKind::Expression(e) => collect_in_expr(e, source, line_starts, uri, out),
-        StmtKind::Return(Some(v)) => collect_in_expr(v, source, line_starts, uri, out),
+        StmtKind::Expression(e) => collect_in_expr(e, sv, uri, out),
+        StmtKind::Return(Some(v)) => collect_in_expr(v, sv, uri, out),
         StmtKind::Echo(exprs) => {
             for expr in exprs.iter() {
-                collect_in_expr(expr, source, line_starts, uri, out);
+                collect_in_expr(expr, sv, uri, out);
             }
         }
-        StmtKind::Function(f) => collect_in_stmts(&f.body, source, line_starts, uri, out),
+        StmtKind::Function(f) => collect_in_stmts(&f.body, sv, uri, out),
         StmtKind::Class(c) => {
             use php_ast::ClassMemberKind;
             for member in c.members.iter() {
                 if let ClassMemberKind::Method(m) = &member.kind
                     && let Some(body) = &m.body
                 {
-                    collect_in_stmts(body, source, line_starts, uri, out);
+                    collect_in_stmts(body, sv, uri, out);
                 }
             }
         }
         StmtKind::Namespace(ns) => {
             if let NamespaceBody::Braced(inner) = &ns.body {
-                collect_in_stmts(inner, source, line_starts, uri, out);
+                collect_in_stmts(inner, sv, uri, out);
             }
         }
         _ => {}
@@ -62,13 +60,12 @@ fn collect_in_stmt(
 
 fn collect_in_expr(
     expr: &php_ast::Expr<'_, '_>,
-    source: &str,
-    line_starts: &[u32],
+    sv: SourceView<'_>,
     uri: &Url,
     out: &mut Vec<DocumentLink>,
 ) {
     if let ExprKind::Include(_, path_expr) = &expr.kind
-        && let Some(link) = link_from_path_expr(path_expr, source, line_starts, uri)
+        && let Some(link) = link_from_path_expr(path_expr, sv, uri)
     {
         out.push(link);
     }
@@ -76,8 +73,7 @@ fn collect_in_expr(
 
 fn link_from_path_expr(
     path_expr: &php_ast::Expr<'_, '_>,
-    source: &str,
-    line_starts: &[u32],
+    sv: SourceView<'_>,
     uri: &Url,
 ) -> Option<DocumentLink> {
     let ExprKind::String(s) = &path_expr.kind else {
@@ -90,7 +86,7 @@ fn link_from_path_expr(
     // span.start points to the opening quote; content starts one byte after
     let quote_offset = path_expr.span.start;
     let content_offset = quote_offset + 1;
-    let start = offset_to_position(source, line_starts, content_offset);
+    let start = sv.position_of(content_offset);
     let end = Position {
         line: start.line,
         character: start.character + raw.chars().map(|c| c.len_utf16() as u32).sum::<u32>(),
@@ -118,7 +114,7 @@ fn link_from_path_expr(
     })
 }
 
-/// Scan source text for `@link` and `@see` tags with HTTP(S) URLs in docblock/line comments.
+/// Scan sv.source() text for `@link` and `@see` tags with HTTP(S) URLs in docblock/line comments.
 fn collect_docblock_links(source: &str, out: &mut Vec<DocumentLink>) {
     for (line_idx, line) in source.lines().enumerate() {
         let trimmed = line.trim();

--- a/src/document_link.rs
+++ b/src/document_link.rs
@@ -6,41 +6,54 @@ use crate::ast::{ParsedDoc, offset_to_position};
 use crate::util::byte_to_utf16;
 
 pub fn document_links(uri: &Url, doc: &ParsedDoc, source: &str) -> Vec<DocumentLink> {
+    let line_starts = doc.line_starts();
     let mut links = Vec::new();
-    collect_in_stmts(&doc.program().stmts, source, uri, &mut links);
+    collect_in_stmts(&doc.program().stmts, source, line_starts, uri, &mut links);
     collect_docblock_links(source, &mut links);
     links
 }
 
-fn collect_in_stmts(stmts: &[Stmt<'_, '_>], source: &str, uri: &Url, out: &mut Vec<DocumentLink>) {
+fn collect_in_stmts(
+    stmts: &[Stmt<'_, '_>],
+    source: &str,
+    line_starts: &[u32],
+    uri: &Url,
+    out: &mut Vec<DocumentLink>,
+) {
     for stmt in stmts {
-        collect_in_stmt(stmt, source, uri, out);
+        collect_in_stmt(stmt, source, line_starts, uri, out);
     }
 }
 
-fn collect_in_stmt(stmt: &Stmt<'_, '_>, source: &str, uri: &Url, out: &mut Vec<DocumentLink>) {
+fn collect_in_stmt(
+    stmt: &Stmt<'_, '_>,
+    source: &str,
+    line_starts: &[u32],
+    uri: &Url,
+    out: &mut Vec<DocumentLink>,
+) {
     match &stmt.kind {
-        StmtKind::Expression(e) => collect_in_expr(e, source, uri, out),
-        StmtKind::Return(Some(v)) => collect_in_expr(v, source, uri, out),
+        StmtKind::Expression(e) => collect_in_expr(e, source, line_starts, uri, out),
+        StmtKind::Return(Some(v)) => collect_in_expr(v, source, line_starts, uri, out),
         StmtKind::Echo(exprs) => {
             for expr in exprs.iter() {
-                collect_in_expr(expr, source, uri, out);
+                collect_in_expr(expr, source, line_starts, uri, out);
             }
         }
-        StmtKind::Function(f) => collect_in_stmts(&f.body, source, uri, out),
+        StmtKind::Function(f) => collect_in_stmts(&f.body, source, line_starts, uri, out),
         StmtKind::Class(c) => {
             use php_ast::ClassMemberKind;
             for member in c.members.iter() {
                 if let ClassMemberKind::Method(m) = &member.kind
                     && let Some(body) = &m.body
                 {
-                    collect_in_stmts(body, source, uri, out);
+                    collect_in_stmts(body, source, line_starts, uri, out);
                 }
             }
         }
         StmtKind::Namespace(ns) => {
             if let NamespaceBody::Braced(inner) = &ns.body {
-                collect_in_stmts(inner, source, uri, out);
+                collect_in_stmts(inner, source, line_starts, uri, out);
             }
         }
         _ => {}
@@ -50,11 +63,12 @@ fn collect_in_stmt(stmt: &Stmt<'_, '_>, source: &str, uri: &Url, out: &mut Vec<D
 fn collect_in_expr(
     expr: &php_ast::Expr<'_, '_>,
     source: &str,
+    line_starts: &[u32],
     uri: &Url,
     out: &mut Vec<DocumentLink>,
 ) {
     if let ExprKind::Include(_, path_expr) = &expr.kind
-        && let Some(link) = link_from_path_expr(path_expr, source, uri)
+        && let Some(link) = link_from_path_expr(path_expr, source, line_starts, uri)
     {
         out.push(link);
     }
@@ -63,6 +77,7 @@ fn collect_in_expr(
 fn link_from_path_expr(
     path_expr: &php_ast::Expr<'_, '_>,
     source: &str,
+    line_starts: &[u32],
     uri: &Url,
 ) -> Option<DocumentLink> {
     let ExprKind::String(s) = &path_expr.kind else {
@@ -75,7 +90,7 @@ fn link_from_path_expr(
     // span.start points to the opening quote; content starts one byte after
     let quote_offset = path_expr.span.start;
     let content_offset = quote_offset + 1;
-    let start = offset_to_position(source, content_offset);
+    let start = offset_to_position(source, line_starts, content_offset);
     let end = Position {
         line: start.line,
         character: start.character + raw.chars().map(|c| c.len_utf16() as u32).sum::<u32>(),

--- a/src/extract_method_action.rs
+++ b/src/extract_method_action.rs
@@ -32,11 +32,13 @@ pub fn extract_method_actions(
     }
 
     // Find the enclosing class and method.
+    let line_starts = doc.line_starts();
     let stmts = &doc.program().stmts;
-    let (class_end_offset, method_is_static) = match find_enclosing_class(stmts, source, range) {
-        Some(info) => info,
-        None => return vec![],
-    };
+    let (class_end_offset, method_is_static) =
+        match find_enclosing_class(stmts, source, line_starts, range) {
+            Some(info) => info,
+            None => return vec![],
+        };
 
     let selected = selected_text(source, range);
     if selected.trim().is_empty() {
@@ -103,7 +105,8 @@ pub fn extract_method_actions(
     );
 
     // Insert the new method just before the closing brace of the class.
-    let closing_line = offset_to_position(source, class_end_offset.saturating_sub(1)).line;
+    let closing_line =
+        offset_to_position(source, line_starts, class_end_offset.saturating_sub(1)).line;
     let insert_pos = Position {
         line: closing_line,
         character: 0,
@@ -147,20 +150,23 @@ pub fn extract_method_actions(
 fn find_enclosing_class(
     stmts: &[php_ast::Stmt<'_, '_>],
     source: &str,
+    line_starts: &[u32],
     range: Range,
 ) -> Option<(u32, bool)> {
     for stmt in stmts {
         match &stmt.kind {
             StmtKind::Class(c) => {
-                let class_start = offset_to_position(source, stmt.span.start).line;
-                let class_end = offset_to_position(source, stmt.span.end).line;
+                let class_start = offset_to_position(source, line_starts, stmt.span.start).line;
+                let class_end = offset_to_position(source, line_starts, stmt.span.end).line;
                 if range.start.line < class_start || range.end.line > class_end {
                     continue;
                 }
                 for member in c.members.iter() {
                     if let ClassMemberKind::Method(m) = &member.kind {
-                        let method_start = offset_to_position(source, member.span.start).line;
-                        let method_end = offset_to_position(source, member.span.end).line;
+                        let method_start =
+                            offset_to_position(source, line_starts, member.span.start).line;
+                        let method_end =
+                            offset_to_position(source, line_starts, member.span.end).line;
                         if range.start.line >= method_start && range.end.line <= method_end {
                             return Some((stmt.span.end, m.is_static));
                         }
@@ -169,7 +175,7 @@ fn find_enclosing_class(
             }
             StmtKind::Namespace(ns) => {
                 if let NamespaceBody::Braced(inner) = &ns.body
-                    && let Some(r) = find_enclosing_class(inner, source, range)
+                    && let Some(r) = find_enclosing_class(inner, source, line_starts, range)
                 {
                     return Some(r);
                 }

--- a/src/extract_method_action.rs
+++ b/src/extract_method_action.rs
@@ -13,7 +13,7 @@ use tower_lsp::lsp_types::{
     CodeAction, CodeActionKind, CodeActionOrCommand, Position, Range, TextEdit, Url, WorkspaceEdit,
 };
 
-use crate::ast::{ParsedDoc, offset_to_position};
+use crate::ast::{ParsedDoc, SourceView};
 use crate::util::utf16_offset_to_byte;
 
 // ── Public entry point ────────────────────────────────────────────────────────
@@ -32,13 +32,12 @@ pub fn extract_method_actions(
     }
 
     // Find the enclosing class and method.
-    let line_starts = doc.line_starts();
+    let sv = doc.view();
     let stmts = &doc.program().stmts;
-    let (class_end_offset, method_is_static) =
-        match find_enclosing_class(stmts, source, line_starts, range) {
-            Some(info) => info,
-            None => return vec![],
-        };
+    let (class_end_offset, method_is_static) = match find_enclosing_class(stmts, sv, range) {
+        Some(info) => info,
+        None => return vec![],
+    };
 
     let selected = selected_text(source, range);
     if selected.trim().is_empty() {
@@ -105,8 +104,7 @@ pub fn extract_method_actions(
     );
 
     // Insert the new method just before the closing brace of the class.
-    let closing_line =
-        offset_to_position(source, line_starts, class_end_offset.saturating_sub(1)).line;
+    let closing_line = sv.position_of(class_end_offset.saturating_sub(1)).line;
     let insert_pos = Position {
         line: closing_line,
         character: 0,
@@ -149,24 +147,21 @@ pub fn extract_method_actions(
 /// class method body, walking into namespaced blocks as needed.
 fn find_enclosing_class(
     stmts: &[php_ast::Stmt<'_, '_>],
-    source: &str,
-    line_starts: &[u32],
+    sv: SourceView<'_>,
     range: Range,
 ) -> Option<(u32, bool)> {
     for stmt in stmts {
         match &stmt.kind {
             StmtKind::Class(c) => {
-                let class_start = offset_to_position(source, line_starts, stmt.span.start).line;
-                let class_end = offset_to_position(source, line_starts, stmt.span.end).line;
+                let class_start = sv.position_of(stmt.span.start).line;
+                let class_end = sv.position_of(stmt.span.end).line;
                 if range.start.line < class_start || range.end.line > class_end {
                     continue;
                 }
                 for member in c.members.iter() {
                     if let ClassMemberKind::Method(m) = &member.kind {
-                        let method_start =
-                            offset_to_position(source, line_starts, member.span.start).line;
-                        let method_end =
-                            offset_to_position(source, line_starts, member.span.end).line;
+                        let method_start = sv.position_of(member.span.start).line;
+                        let method_end = sv.position_of(member.span.end).line;
                         if range.start.line >= method_start && range.end.line <= method_end {
                             return Some((stmt.span.end, m.is_static));
                         }
@@ -175,7 +170,7 @@ fn find_enclosing_class(
             }
             StmtKind::Namespace(ns) => {
                 if let NamespaceBody::Braced(inner) = &ns.body
-                    && let Some(r) = find_enclosing_class(inner, source, line_starts, range)
+                    && let Some(r) = find_enclosing_class(inner, sv, range)
                 {
                     return Some(r);
                 }

--- a/src/folding.rs
+++ b/src/folding.rs
@@ -4,160 +4,174 @@ use tower_lsp::lsp_types::{FoldingRange, FoldingRangeKind};
 use crate::ast::{ParsedDoc, offset_to_position};
 
 pub fn folding_ranges(source: &str, doc: &ParsedDoc) -> Vec<FoldingRange> {
+    let line_starts = doc.line_starts();
     let mut ranges = Vec::new();
-    fold_stmts(&doc.program().stmts, source, &mut ranges);
-    fold_use_groups(&doc.program().stmts, source, &mut ranges);
-    fold_comments(source, &mut ranges);
+    fold_stmts(&doc.program().stmts, source, line_starts, &mut ranges);
+    fold_use_groups(&doc.program().stmts, source, line_starts, &mut ranges);
+    fold_comments(source, line_starts, &mut ranges);
     fold_regions(source, &mut ranges);
     ranges
 }
 
-fn fold_stmts(stmts: &[Stmt<'_, '_>], source: &str, out: &mut Vec<FoldingRange>) {
+fn fold_stmts(
+    stmts: &[Stmt<'_, '_>],
+    source: &str,
+    line_starts: &[u32],
+    out: &mut Vec<FoldingRange>,
+) {
     for stmt in stmts {
-        fold_stmt(stmt, source, out);
+        fold_stmt(stmt, source, line_starts, out);
     }
 }
 
 /// Fold the contents of a block body without emitting a fold for the block itself.
 /// Used for control-flow statements (`if`, `while`, `for`, `foreach`, `do-while`)
 /// where the outer statement already covers the same span as the inner `Block`.
-fn fold_body(body: &Stmt<'_, '_>, source: &str, out: &mut Vec<FoldingRange>) {
+fn fold_body(body: &Stmt<'_, '_>, source: &str, line_starts: &[u32], out: &mut Vec<FoldingRange>) {
     if let StmtKind::Block(stmts) = &body.kind {
-        fold_stmts(stmts, source, out);
+        fold_stmts(stmts, source, line_starts, out);
     }
 }
 
-fn fold_stmt(stmt: &Stmt<'_, '_>, source: &str, out: &mut Vec<FoldingRange>) {
+fn fold_stmt(stmt: &Stmt<'_, '_>, source: &str, line_starts: &[u32], out: &mut Vec<FoldingRange>) {
     match &stmt.kind {
         StmtKind::Function(f) => {
-            let start_line = offset_to_position(source, stmt.span.start).line;
-            let end_line = offset_to_position(source, stmt.span.end).line;
+            let start_line = offset_to_position(source, line_starts, stmt.span.start).line;
+            let end_line = offset_to_position(source, line_starts, stmt.span.end).line;
             push(out, start_line, end_line, None);
-            fold_stmts(&f.body, source, out);
+            fold_stmts(&f.body, source, line_starts, out);
         }
         StmtKind::Class(c) => {
-            let start_line = offset_to_position(source, stmt.span.start).line;
-            let end_line = offset_to_position(source, stmt.span.end).line;
+            let start_line = offset_to_position(source, line_starts, stmt.span.start).line;
+            let end_line = offset_to_position(source, line_starts, stmt.span.end).line;
             push(out, start_line, end_line, None);
             for member in c.members.iter() {
                 if let ClassMemberKind::Method(m) = &member.kind {
-                    let m_start = offset_to_position(source, member.span.start).line;
+                    let m_start = offset_to_position(source, line_starts, member.span.start).line;
                     // member.span.end is exclusive and includes the trailing newline;
                     // subtract 1 so the end line is the line containing the closing `}`.
-                    let m_end = offset_to_position(source, member.span.end.saturating_sub(1)).line;
+                    let m_end =
+                        offset_to_position(source, line_starts, member.span.end.saturating_sub(1))
+                            .line;
                     push(out, m_start, m_end, None);
                     if let Some(body) = &m.body {
-                        fold_stmts(body, source, out);
+                        fold_stmts(body, source, line_starts, out);
                     }
                 }
             }
         }
         StmtKind::Interface(i) => {
-            let start_line = offset_to_position(source, stmt.span.start).line;
-            let end_line = offset_to_position(source, stmt.span.end).line;
+            let start_line = offset_to_position(source, line_starts, stmt.span.start).line;
+            let end_line = offset_to_position(source, line_starts, stmt.span.end).line;
             push(out, start_line, end_line, None);
             // Interface methods are abstract (no body) — nothing to fold per method.
             for member in i.members.iter() {
                 if let ClassMemberKind::Method(m) = &member.kind
                     && let Some(body) = &m.body
                 {
-                    let m_start = offset_to_position(source, member.span.start).line;
-                    let m_end = offset_to_position(source, member.span.end.saturating_sub(1)).line;
+                    let m_start = offset_to_position(source, line_starts, member.span.start).line;
+                    let m_end =
+                        offset_to_position(source, line_starts, member.span.end.saturating_sub(1))
+                            .line;
                     push(out, m_start, m_end, None);
-                    fold_stmts(body, source, out);
+                    fold_stmts(body, source, line_starts, out);
                 }
             }
         }
         StmtKind::Trait(t) => {
-            let start_line = offset_to_position(source, stmt.span.start).line;
-            let end_line = offset_to_position(source, stmt.span.end).line;
+            let start_line = offset_to_position(source, line_starts, stmt.span.start).line;
+            let end_line = offset_to_position(source, line_starts, stmt.span.end).line;
             push(out, start_line, end_line, None);
             for member in t.members.iter() {
                 if let ClassMemberKind::Method(m) = &member.kind {
-                    let m_start = offset_to_position(source, member.span.start).line;
-                    let m_end = offset_to_position(source, member.span.end.saturating_sub(1)).line;
+                    let m_start = offset_to_position(source, line_starts, member.span.start).line;
+                    let m_end =
+                        offset_to_position(source, line_starts, member.span.end.saturating_sub(1))
+                            .line;
                     push(out, m_start, m_end, None);
                     if let Some(body) = &m.body {
-                        fold_stmts(body, source, out);
+                        fold_stmts(body, source, line_starts, out);
                     }
                 }
             }
         }
         StmtKind::Enum(e) => {
-            let start_line = offset_to_position(source, stmt.span.start).line;
-            let end_line = offset_to_position(source, stmt.span.end).line;
+            let start_line = offset_to_position(source, line_starts, stmt.span.start).line;
+            let end_line = offset_to_position(source, line_starts, stmt.span.end).line;
             push(out, start_line, end_line, None);
             for member in e.members.iter() {
                 if let EnumMemberKind::Method(m) = &member.kind {
-                    let m_start = offset_to_position(source, member.span.start).line;
-                    let m_end = offset_to_position(source, member.span.end.saturating_sub(1)).line;
+                    let m_start = offset_to_position(source, line_starts, member.span.start).line;
+                    let m_end =
+                        offset_to_position(source, line_starts, member.span.end.saturating_sub(1))
+                            .line;
                     push(out, m_start, m_end, None);
                     if let Some(body) = &m.body {
-                        fold_stmts(body, source, out);
+                        fold_stmts(body, source, line_starts, out);
                     }
                 }
             }
         }
         StmtKind::If(i) => {
-            let start_line = offset_to_position(source, stmt.span.start).line;
-            let end_line = offset_to_position(source, stmt.span.end).line;
+            let start_line = offset_to_position(source, line_starts, stmt.span.start).line;
+            let end_line = offset_to_position(source, line_starts, stmt.span.end).line;
             push(out, start_line, end_line, None);
-            fold_body(i.then_branch, source, out);
+            fold_body(i.then_branch, source, line_starts, out);
             for ei in i.elseif_branches.iter() {
-                fold_body(&ei.body, source, out);
+                fold_body(&ei.body, source, line_starts, out);
             }
             if let Some(e) = &i.else_branch {
-                fold_body(e, source, out);
+                fold_body(e, source, line_starts, out);
             }
         }
         StmtKind::While(w) => {
-            let start_line = offset_to_position(source, stmt.span.start).line;
-            let end_line = offset_to_position(source, stmt.span.end).line;
+            let start_line = offset_to_position(source, line_starts, stmt.span.start).line;
+            let end_line = offset_to_position(source, line_starts, stmt.span.end).line;
             push(out, start_line, end_line, None);
-            fold_body(w.body, source, out);
+            fold_body(w.body, source, line_starts, out);
         }
         StmtKind::For(f) => {
-            let start_line = offset_to_position(source, stmt.span.start).line;
-            let end_line = offset_to_position(source, stmt.span.end).line;
+            let start_line = offset_to_position(source, line_starts, stmt.span.start).line;
+            let end_line = offset_to_position(source, line_starts, stmt.span.end).line;
             push(out, start_line, end_line, None);
-            fold_body(f.body, source, out);
+            fold_body(f.body, source, line_starts, out);
         }
         StmtKind::Foreach(f) => {
-            let start_line = offset_to_position(source, stmt.span.start).line;
-            let end_line = offset_to_position(source, stmt.span.end).line;
+            let start_line = offset_to_position(source, line_starts, stmt.span.start).line;
+            let end_line = offset_to_position(source, line_starts, stmt.span.end).line;
             push(out, start_line, end_line, None);
-            fold_body(f.body, source, out);
+            fold_body(f.body, source, line_starts, out);
         }
         StmtKind::DoWhile(d) => {
-            let start_line = offset_to_position(source, stmt.span.start).line;
-            let end_line = offset_to_position(source, stmt.span.end).line;
+            let start_line = offset_to_position(source, line_starts, stmt.span.start).line;
+            let end_line = offset_to_position(source, line_starts, stmt.span.end).line;
             push(out, start_line, end_line, None);
-            fold_body(d.body, source, out);
+            fold_body(d.body, source, line_starts, out);
         }
         StmtKind::TryCatch(t) => {
-            let start_line = offset_to_position(source, stmt.span.start).line;
-            let end_line = offset_to_position(source, stmt.span.end).line;
+            let start_line = offset_to_position(source, line_starts, stmt.span.start).line;
+            let end_line = offset_to_position(source, line_starts, stmt.span.end).line;
             push(out, start_line, end_line, None);
-            fold_stmts(&t.body, source, out);
+            fold_stmts(&t.body, source, line_starts, out);
             for catch in t.catches.iter() {
-                fold_stmts(&catch.body, source, out);
+                fold_stmts(&catch.body, source, line_starts, out);
             }
             if let Some(finally) = &t.finally {
-                fold_stmts(finally, source, out);
+                fold_stmts(finally, source, line_starts, out);
             }
         }
         StmtKind::Block(stmts) => {
-            let start_line = offset_to_position(source, stmt.span.start).line;
-            let end_line = offset_to_position(source, stmt.span.end).line;
+            let start_line = offset_to_position(source, line_starts, stmt.span.start).line;
+            let end_line = offset_to_position(source, line_starts, stmt.span.end).line;
             push(out, start_line, end_line, None);
-            fold_stmts(stmts, source, out);
+            fold_stmts(stmts, source, line_starts, out);
         }
         StmtKind::Namespace(ns) => {
-            let start_line = offset_to_position(source, stmt.span.start).line;
-            let end_line = offset_to_position(source, stmt.span.end).line;
+            let start_line = offset_to_position(source, line_starts, stmt.span.start).line;
+            let end_line = offset_to_position(source, line_starts, stmt.span.end).line;
             push(out, start_line, end_line, None);
             if let NamespaceBody::Braced(inner) = &ns.body {
-                fold_stmts(inner, source, out);
+                fold_stmts(inner, source, line_starts, out);
             }
         }
         _ => {}
@@ -165,16 +179,21 @@ fn fold_stmt(stmt: &Stmt<'_, '_>, source: &str, out: &mut Vec<FoldingRange>) {
 }
 
 /// Fold consecutive top-level `use` statements into a single range.
-fn fold_use_groups(stmts: &[Stmt<'_, '_>], source: &str, out: &mut Vec<FoldingRange>) {
+fn fold_use_groups(
+    stmts: &[Stmt<'_, '_>],
+    source: &str,
+    line_starts: &[u32],
+    out: &mut Vec<FoldingRange>,
+) {
     let mut group_start: Option<u32> = None;
     let mut group_end: u32 = 0;
     for stmt in stmts {
         if matches!(stmt.kind, StmtKind::Use(_)) {
-            let line = offset_to_position(source, stmt.span.start).line;
+            let line = offset_to_position(source, line_starts, stmt.span.start).line;
             if group_start.is_none() {
                 group_start = Some(line);
             }
-            group_end = offset_to_position(source, stmt.span.end).line;
+            group_end = offset_to_position(source, line_starts, stmt.span.end).line;
         } else {
             if let Some(start) = group_start.take() {
                 push(out, start, group_end, Some(FoldingRangeKind::Imports));
@@ -187,18 +206,18 @@ fn fold_use_groups(stmts: &[Stmt<'_, '_>], source: &str, out: &mut Vec<FoldingRa
 }
 
 /// Fold `/* ... */` and `/** ... */` multi-line block comments.
-fn fold_comments(source: &str, out: &mut Vec<FoldingRange>) {
+fn fold_comments(source: &str, line_starts: &[u32], out: &mut Vec<FoldingRange>) {
     let bytes = source.as_bytes();
     let len = bytes.len();
     let mut i = 0;
     while i + 1 < len {
         if bytes[i] == b'/' && bytes[i + 1] == b'*' {
-            let start_line = line_at(source, i);
+            let start_line = line_at(source, line_starts, i);
             // find closing */
             let mut j = i + 2;
             while j + 1 < len {
                 if bytes[j] == b'*' && bytes[j + 1] == b'/' {
-                    let end_line = line_at(source, j + 1);
+                    let end_line = line_at(source, line_starts, j + 1);
                     push(out, start_line, end_line, Some(FoldingRangeKind::Comment));
                     i = j + 2;
                     break;
@@ -229,11 +248,12 @@ fn fold_regions(source: &str, out: &mut Vec<FoldingRange>) {
     }
 }
 
-fn line_at(source: &str, byte_offset: usize) -> u32 {
-    source[..byte_offset]
-        .bytes()
-        .filter(|&b| b == b'\n')
-        .count() as u32
+fn line_at(source: &str, line_starts: &[u32], byte_offset: usize) -> u32 {
+    let _ = source;
+    match line_starts.partition_point(|&s| s <= byte_offset as u32) {
+        0 => 0,
+        i => (i - 1) as u32,
+    }
 }
 
 fn push(

--- a/src/folding.rs
+++ b/src/folding.rs
@@ -1,177 +1,164 @@
 use php_ast::{ClassMemberKind, EnumMemberKind, NamespaceBody, Stmt, StmtKind};
 use tower_lsp::lsp_types::{FoldingRange, FoldingRangeKind};
 
-use crate::ast::{ParsedDoc, offset_to_position};
+use crate::ast::{ParsedDoc, SourceView};
 
-pub fn folding_ranges(source: &str, doc: &ParsedDoc) -> Vec<FoldingRange> {
-    let line_starts = doc.line_starts();
+pub fn folding_ranges(_source: &str, doc: &ParsedDoc) -> Vec<FoldingRange> {
+    let sv = doc.view();
     let mut ranges = Vec::new();
-    fold_stmts(&doc.program().stmts, source, line_starts, &mut ranges);
-    fold_use_groups(&doc.program().stmts, source, line_starts, &mut ranges);
-    fold_comments(source, line_starts, &mut ranges);
-    fold_regions(source, &mut ranges);
+    fold_stmts(&doc.program().stmts, sv, &mut ranges);
+    fold_use_groups(&doc.program().stmts, sv, &mut ranges);
+    fold_comments(sv, &mut ranges);
+    fold_regions(sv.source(), &mut ranges);
     ranges
 }
 
-fn fold_stmts(
-    stmts: &[Stmt<'_, '_>],
-    source: &str,
-    line_starts: &[u32],
-    out: &mut Vec<FoldingRange>,
-) {
+fn fold_stmts(stmts: &[Stmt<'_, '_>], sv: SourceView<'_>, out: &mut Vec<FoldingRange>) {
     for stmt in stmts {
-        fold_stmt(stmt, source, line_starts, out);
+        fold_stmt(stmt, sv, out);
     }
 }
 
 /// Fold the contents of a block body without emitting a fold for the block itself.
 /// Used for control-flow statements (`if`, `while`, `for`, `foreach`, `do-while`)
 /// where the outer statement already covers the same span as the inner `Block`.
-fn fold_body(body: &Stmt<'_, '_>, source: &str, line_starts: &[u32], out: &mut Vec<FoldingRange>) {
+fn fold_body(body: &Stmt<'_, '_>, sv: SourceView<'_>, out: &mut Vec<FoldingRange>) {
     if let StmtKind::Block(stmts) = &body.kind {
-        fold_stmts(stmts, source, line_starts, out);
+        fold_stmts(stmts, sv, out);
     }
 }
 
-fn fold_stmt(stmt: &Stmt<'_, '_>, source: &str, line_starts: &[u32], out: &mut Vec<FoldingRange>) {
+fn fold_stmt(stmt: &Stmt<'_, '_>, sv: SourceView<'_>, out: &mut Vec<FoldingRange>) {
     match &stmt.kind {
         StmtKind::Function(f) => {
-            let start_line = offset_to_position(source, line_starts, stmt.span.start).line;
-            let end_line = offset_to_position(source, line_starts, stmt.span.end).line;
+            let start_line = sv.position_of(stmt.span.start).line;
+            let end_line = sv.position_of(stmt.span.end).line;
             push(out, start_line, end_line, None);
-            fold_stmts(&f.body, source, line_starts, out);
+            fold_stmts(&f.body, sv, out);
         }
         StmtKind::Class(c) => {
-            let start_line = offset_to_position(source, line_starts, stmt.span.start).line;
-            let end_line = offset_to_position(source, line_starts, stmt.span.end).line;
+            let start_line = sv.position_of(stmt.span.start).line;
+            let end_line = sv.position_of(stmt.span.end).line;
             push(out, start_line, end_line, None);
             for member in c.members.iter() {
                 if let ClassMemberKind::Method(m) = &member.kind {
-                    let m_start = offset_to_position(source, line_starts, member.span.start).line;
+                    let m_start = sv.position_of(member.span.start).line;
                     // member.span.end is exclusive and includes the trailing newline;
                     // subtract 1 so the end line is the line containing the closing `}`.
-                    let m_end =
-                        offset_to_position(source, line_starts, member.span.end.saturating_sub(1))
-                            .line;
+                    let m_end = sv.position_of(member.span.end.saturating_sub(1)).line;
                     push(out, m_start, m_end, None);
                     if let Some(body) = &m.body {
-                        fold_stmts(body, source, line_starts, out);
+                        fold_stmts(body, sv, out);
                     }
                 }
             }
         }
         StmtKind::Interface(i) => {
-            let start_line = offset_to_position(source, line_starts, stmt.span.start).line;
-            let end_line = offset_to_position(source, line_starts, stmt.span.end).line;
+            let start_line = sv.position_of(stmt.span.start).line;
+            let end_line = sv.position_of(stmt.span.end).line;
             push(out, start_line, end_line, None);
             // Interface methods are abstract (no body) — nothing to fold per method.
             for member in i.members.iter() {
                 if let ClassMemberKind::Method(m) = &member.kind
                     && let Some(body) = &m.body
                 {
-                    let m_start = offset_to_position(source, line_starts, member.span.start).line;
-                    let m_end =
-                        offset_to_position(source, line_starts, member.span.end.saturating_sub(1))
-                            .line;
+                    let m_start = sv.position_of(member.span.start).line;
+                    let m_end = sv.position_of(member.span.end.saturating_sub(1)).line;
                     push(out, m_start, m_end, None);
-                    fold_stmts(body, source, line_starts, out);
+                    fold_stmts(body, sv, out);
                 }
             }
         }
         StmtKind::Trait(t) => {
-            let start_line = offset_to_position(source, line_starts, stmt.span.start).line;
-            let end_line = offset_to_position(source, line_starts, stmt.span.end).line;
+            let start_line = sv.position_of(stmt.span.start).line;
+            let end_line = sv.position_of(stmt.span.end).line;
             push(out, start_line, end_line, None);
             for member in t.members.iter() {
                 if let ClassMemberKind::Method(m) = &member.kind {
-                    let m_start = offset_to_position(source, line_starts, member.span.start).line;
-                    let m_end =
-                        offset_to_position(source, line_starts, member.span.end.saturating_sub(1))
-                            .line;
+                    let m_start = sv.position_of(member.span.start).line;
+                    let m_end = sv.position_of(member.span.end.saturating_sub(1)).line;
                     push(out, m_start, m_end, None);
                     if let Some(body) = &m.body {
-                        fold_stmts(body, source, line_starts, out);
+                        fold_stmts(body, sv, out);
                     }
                 }
             }
         }
         StmtKind::Enum(e) => {
-            let start_line = offset_to_position(source, line_starts, stmt.span.start).line;
-            let end_line = offset_to_position(source, line_starts, stmt.span.end).line;
+            let start_line = sv.position_of(stmt.span.start).line;
+            let end_line = sv.position_of(stmt.span.end).line;
             push(out, start_line, end_line, None);
             for member in e.members.iter() {
                 if let EnumMemberKind::Method(m) = &member.kind {
-                    let m_start = offset_to_position(source, line_starts, member.span.start).line;
-                    let m_end =
-                        offset_to_position(source, line_starts, member.span.end.saturating_sub(1))
-                            .line;
+                    let m_start = sv.position_of(member.span.start).line;
+                    let m_end = sv.position_of(member.span.end.saturating_sub(1)).line;
                     push(out, m_start, m_end, None);
                     if let Some(body) = &m.body {
-                        fold_stmts(body, source, line_starts, out);
+                        fold_stmts(body, sv, out);
                     }
                 }
             }
         }
         StmtKind::If(i) => {
-            let start_line = offset_to_position(source, line_starts, stmt.span.start).line;
-            let end_line = offset_to_position(source, line_starts, stmt.span.end).line;
+            let start_line = sv.position_of(stmt.span.start).line;
+            let end_line = sv.position_of(stmt.span.end).line;
             push(out, start_line, end_line, None);
-            fold_body(i.then_branch, source, line_starts, out);
+            fold_body(i.then_branch, sv, out);
             for ei in i.elseif_branches.iter() {
-                fold_body(&ei.body, source, line_starts, out);
+                fold_body(&ei.body, sv, out);
             }
             if let Some(e) = &i.else_branch {
-                fold_body(e, source, line_starts, out);
+                fold_body(e, sv, out);
             }
         }
         StmtKind::While(w) => {
-            let start_line = offset_to_position(source, line_starts, stmt.span.start).line;
-            let end_line = offset_to_position(source, line_starts, stmt.span.end).line;
+            let start_line = sv.position_of(stmt.span.start).line;
+            let end_line = sv.position_of(stmt.span.end).line;
             push(out, start_line, end_line, None);
-            fold_body(w.body, source, line_starts, out);
+            fold_body(w.body, sv, out);
         }
         StmtKind::For(f) => {
-            let start_line = offset_to_position(source, line_starts, stmt.span.start).line;
-            let end_line = offset_to_position(source, line_starts, stmt.span.end).line;
+            let start_line = sv.position_of(stmt.span.start).line;
+            let end_line = sv.position_of(stmt.span.end).line;
             push(out, start_line, end_line, None);
-            fold_body(f.body, source, line_starts, out);
+            fold_body(f.body, sv, out);
         }
         StmtKind::Foreach(f) => {
-            let start_line = offset_to_position(source, line_starts, stmt.span.start).line;
-            let end_line = offset_to_position(source, line_starts, stmt.span.end).line;
+            let start_line = sv.position_of(stmt.span.start).line;
+            let end_line = sv.position_of(stmt.span.end).line;
             push(out, start_line, end_line, None);
-            fold_body(f.body, source, line_starts, out);
+            fold_body(f.body, sv, out);
         }
         StmtKind::DoWhile(d) => {
-            let start_line = offset_to_position(source, line_starts, stmt.span.start).line;
-            let end_line = offset_to_position(source, line_starts, stmt.span.end).line;
+            let start_line = sv.position_of(stmt.span.start).line;
+            let end_line = sv.position_of(stmt.span.end).line;
             push(out, start_line, end_line, None);
-            fold_body(d.body, source, line_starts, out);
+            fold_body(d.body, sv, out);
         }
         StmtKind::TryCatch(t) => {
-            let start_line = offset_to_position(source, line_starts, stmt.span.start).line;
-            let end_line = offset_to_position(source, line_starts, stmt.span.end).line;
+            let start_line = sv.position_of(stmt.span.start).line;
+            let end_line = sv.position_of(stmt.span.end).line;
             push(out, start_line, end_line, None);
-            fold_stmts(&t.body, source, line_starts, out);
+            fold_stmts(&t.body, sv, out);
             for catch in t.catches.iter() {
-                fold_stmts(&catch.body, source, line_starts, out);
+                fold_stmts(&catch.body, sv, out);
             }
             if let Some(finally) = &t.finally {
-                fold_stmts(finally, source, line_starts, out);
+                fold_stmts(finally, sv, out);
             }
         }
         StmtKind::Block(stmts) => {
-            let start_line = offset_to_position(source, line_starts, stmt.span.start).line;
-            let end_line = offset_to_position(source, line_starts, stmt.span.end).line;
+            let start_line = sv.position_of(stmt.span.start).line;
+            let end_line = sv.position_of(stmt.span.end).line;
             push(out, start_line, end_line, None);
-            fold_stmts(stmts, source, line_starts, out);
+            fold_stmts(stmts, sv, out);
         }
         StmtKind::Namespace(ns) => {
-            let start_line = offset_to_position(source, line_starts, stmt.span.start).line;
-            let end_line = offset_to_position(source, line_starts, stmt.span.end).line;
+            let start_line = sv.position_of(stmt.span.start).line;
+            let end_line = sv.position_of(stmt.span.end).line;
             push(out, start_line, end_line, None);
             if let NamespaceBody::Braced(inner) = &ns.body {
-                fold_stmts(inner, source, line_starts, out);
+                fold_stmts(inner, sv, out);
             }
         }
         _ => {}
@@ -179,21 +166,16 @@ fn fold_stmt(stmt: &Stmt<'_, '_>, source: &str, line_starts: &[u32], out: &mut V
 }
 
 /// Fold consecutive top-level `use` statements into a single range.
-fn fold_use_groups(
-    stmts: &[Stmt<'_, '_>],
-    source: &str,
-    line_starts: &[u32],
-    out: &mut Vec<FoldingRange>,
-) {
+fn fold_use_groups(stmts: &[Stmt<'_, '_>], sv: SourceView<'_>, out: &mut Vec<FoldingRange>) {
     let mut group_start: Option<u32> = None;
     let mut group_end: u32 = 0;
     for stmt in stmts {
         if matches!(stmt.kind, StmtKind::Use(_)) {
-            let line = offset_to_position(source, line_starts, stmt.span.start).line;
+            let line = sv.position_of(stmt.span.start).line;
             if group_start.is_none() {
                 group_start = Some(line);
             }
-            group_end = offset_to_position(source, line_starts, stmt.span.end).line;
+            group_end = sv.position_of(stmt.span.end).line;
         } else {
             if let Some(start) = group_start.take() {
                 push(out, start, group_end, Some(FoldingRangeKind::Imports));
@@ -206,18 +188,18 @@ fn fold_use_groups(
 }
 
 /// Fold `/* ... */` and `/** ... */` multi-line block comments.
-fn fold_comments(source: &str, line_starts: &[u32], out: &mut Vec<FoldingRange>) {
-    let bytes = source.as_bytes();
+fn fold_comments(sv: SourceView<'_>, out: &mut Vec<FoldingRange>) {
+    let bytes = sv.source().as_bytes();
     let len = bytes.len();
     let mut i = 0;
     while i + 1 < len {
         if bytes[i] == b'/' && bytes[i + 1] == b'*' {
-            let start_line = line_at(source, line_starts, i);
+            let start_line = line_at(sv, i);
             // find closing */
             let mut j = i + 2;
             while j + 1 < len {
                 if bytes[j] == b'*' && bytes[j + 1] == b'/' {
-                    let end_line = line_at(source, line_starts, j + 1);
+                    let end_line = line_at(sv, j + 1);
                     push(out, start_line, end_line, Some(FoldingRangeKind::Comment));
                     i = j + 2;
                     break;
@@ -248,12 +230,8 @@ fn fold_regions(source: &str, out: &mut Vec<FoldingRange>) {
     }
 }
 
-fn line_at(source: &str, line_starts: &[u32], byte_offset: usize) -> u32 {
-    let _ = source;
-    match line_starts.partition_point(|&s| s <= byte_offset as u32) {
-        0 => 0,
-        i => (i - 1) as u32,
-    }
+fn line_at(sv: SourceView<'_>, byte_offset: usize) -> u32 {
+    sv.position_of(byte_offset as u32).line
 }
 
 fn push(

--- a/src/generate_action.rs
+++ b/src/generate_action.rs
@@ -16,8 +16,16 @@ pub fn generate_constructor_actions(
     range: Range,
     uri: &Url,
 ) -> Vec<CodeActionOrCommand> {
+    let line_starts = doc.line_starts();
     let mut out = Vec::new();
-    collect_constructor(&doc.program().stmts, source, range, uri, &mut out);
+    collect_constructor(
+        &doc.program().stmts,
+        source,
+        line_starts,
+        range,
+        uri,
+        &mut out,
+    );
     out
 }
 
@@ -27,8 +35,16 @@ pub fn generate_getters_setters_actions(
     range: Range,
     uri: &Url,
 ) -> Vec<CodeActionOrCommand> {
+    let line_starts = doc.line_starts();
     let mut out = Vec::new();
-    collect_getters_setters(&doc.program().stmts, source, range, uri, &mut out);
+    collect_getters_setters(
+        &doc.program().stmts,
+        source,
+        line_starts,
+        range,
+        uri,
+        &mut out,
+    );
     out
 }
 
@@ -42,6 +58,7 @@ struct Prop {
 fn collect_constructor<'a>(
     stmts: &[Stmt<'a, 'a>],
     source: &str,
+    line_starts: &[u32],
     range: Range,
     uri: &Url,
     out: &mut Vec<CodeActionOrCommand>,
@@ -49,8 +66,8 @@ fn collect_constructor<'a>(
     for stmt in stmts {
         match &stmt.kind {
             StmtKind::Class(c) => {
-                let class_start = offset_to_position(source, stmt.span.start).line;
-                let class_end = offset_to_position(source, stmt.span.end).line;
+                let class_start = offset_to_position(source, line_starts, stmt.span.start).line;
+                let class_end = offset_to_position(source, line_starts, stmt.span.end).line;
                 if class_start > range.end.line || class_end < range.start.line {
                     continue;
                 }
@@ -71,6 +88,7 @@ fn collect_constructor<'a>(
                 let text = generate_constructor_text(&props);
                 push_action(
                     source,
+                    line_starts,
                     stmt.span.end,
                     text,
                     "Generate constructor",
@@ -80,7 +98,7 @@ fn collect_constructor<'a>(
             }
             StmtKind::Namespace(ns) => {
                 if let NamespaceBody::Braced(inner) = &ns.body {
-                    collect_constructor(inner, source, range, uri, out);
+                    collect_constructor(inner, source, line_starts, range, uri, out);
                 }
             }
             _ => {}
@@ -91,6 +109,7 @@ fn collect_constructor<'a>(
 fn collect_getters_setters<'a>(
     stmts: &[Stmt<'a, 'a>],
     source: &str,
+    line_starts: &[u32],
     range: Range,
     uri: &Url,
     out: &mut Vec<CodeActionOrCommand>,
@@ -98,8 +117,8 @@ fn collect_getters_setters<'a>(
     for stmt in stmts {
         match &stmt.kind {
             StmtKind::Class(c) => {
-                let class_start = offset_to_position(source, stmt.span.start).line;
-                let class_end = offset_to_position(source, stmt.span.end).line;
+                let class_start = offset_to_position(source, line_starts, stmt.span.start).line;
+                let class_end = offset_to_position(source, line_starts, stmt.span.end).line;
                 if class_start > range.end.line || class_end < range.start.line {
                     continue;
                 }
@@ -163,11 +182,11 @@ fn collect_getters_setters<'a>(
                 } else {
                     format!("Generate {count} getters/setters")
                 };
-                push_action(source, stmt.span.end, text, &title, uri, out);
+                push_action(source, line_starts, stmt.span.end, text, &title, uri, out);
             }
             StmtKind::Namespace(ns) => {
                 if let NamespaceBody::Braced(inner) = &ns.body {
-                    collect_getters_setters(inner, source, range, uri, out);
+                    collect_getters_setters(inner, source, line_starts, range, uri, out);
                 }
             }
             _ => {}
@@ -235,13 +254,15 @@ fn generate_constructor_text(props: &[Prop]) -> String {
 
 fn push_action(
     source: &str,
+    line_starts: &[u32],
     class_end_offset: u32,
     new_text: String,
     title: &str,
     uri: &Url,
     out: &mut Vec<CodeActionOrCommand>,
 ) {
-    let closing_line = offset_to_position(source, class_end_offset.saturating_sub(1)).line;
+    let closing_line =
+        offset_to_position(source, line_starts, class_end_offset.saturating_sub(1)).line;
     let pos = Position {
         line: closing_line,
         character: 0,

--- a/src/generate_action.rs
+++ b/src/generate_action.rs
@@ -6,45 +6,31 @@ use tower_lsp::lsp_types::{
     CodeAction, CodeActionKind, CodeActionOrCommand, Position, Range, TextEdit, Url, WorkspaceEdit,
 };
 
-use crate::ast::{ParsedDoc, format_type_hint, offset_to_position};
+use crate::ast::{ParsedDoc, SourceView, format_type_hint};
 
 // ── Public entry points ───────────────────────────────────────────────────────
 
 pub fn generate_constructor_actions(
-    source: &str,
+    _source: &str,
     doc: &ParsedDoc,
     range: Range,
     uri: &Url,
 ) -> Vec<CodeActionOrCommand> {
-    let line_starts = doc.line_starts();
+    let sv = doc.view();
     let mut out = Vec::new();
-    collect_constructor(
-        &doc.program().stmts,
-        source,
-        line_starts,
-        range,
-        uri,
-        &mut out,
-    );
+    collect_constructor(&doc.program().stmts, sv, range, uri, &mut out);
     out
 }
 
 pub fn generate_getters_setters_actions(
-    source: &str,
+    _source: &str,
     doc: &ParsedDoc,
     range: Range,
     uri: &Url,
 ) -> Vec<CodeActionOrCommand> {
-    let line_starts = doc.line_starts();
+    let sv = doc.view();
     let mut out = Vec::new();
-    collect_getters_setters(
-        &doc.program().stmts,
-        source,
-        line_starts,
-        range,
-        uri,
-        &mut out,
-    );
+    collect_getters_setters(&doc.program().stmts, sv, range, uri, &mut out);
     out
 }
 
@@ -57,8 +43,7 @@ struct Prop {
 
 fn collect_constructor<'a>(
     stmts: &[Stmt<'a, 'a>],
-    source: &str,
-    line_starts: &[u32],
+    sv: SourceView<'_>,
     range: Range,
     uri: &Url,
     out: &mut Vec<CodeActionOrCommand>,
@@ -66,8 +51,8 @@ fn collect_constructor<'a>(
     for stmt in stmts {
         match &stmt.kind {
             StmtKind::Class(c) => {
-                let class_start = offset_to_position(source, line_starts, stmt.span.start).line;
-                let class_end = offset_to_position(source, line_starts, stmt.span.end).line;
+                let class_start = sv.position_of(stmt.span.start).line;
+                let class_end = sv.position_of(stmt.span.end).line;
                 if class_start > range.end.line || class_end < range.start.line {
                     continue;
                 }
@@ -86,19 +71,11 @@ fn collect_constructor<'a>(
                 }
 
                 let text = generate_constructor_text(&props);
-                push_action(
-                    source,
-                    line_starts,
-                    stmt.span.end,
-                    text,
-                    "Generate constructor",
-                    uri,
-                    out,
-                );
+                push_action(sv, stmt.span.end, text, "Generate constructor", uri, out);
             }
             StmtKind::Namespace(ns) => {
                 if let NamespaceBody::Braced(inner) = &ns.body {
-                    collect_constructor(inner, source, line_starts, range, uri, out);
+                    collect_constructor(inner, sv, range, uri, out);
                 }
             }
             _ => {}
@@ -108,8 +85,7 @@ fn collect_constructor<'a>(
 
 fn collect_getters_setters<'a>(
     stmts: &[Stmt<'a, 'a>],
-    source: &str,
-    line_starts: &[u32],
+    sv: SourceView<'_>,
     range: Range,
     uri: &Url,
     out: &mut Vec<CodeActionOrCommand>,
@@ -117,8 +93,8 @@ fn collect_getters_setters<'a>(
     for stmt in stmts {
         match &stmt.kind {
             StmtKind::Class(c) => {
-                let class_start = offset_to_position(source, line_starts, stmt.span.start).line;
-                let class_end = offset_to_position(source, line_starts, stmt.span.end).line;
+                let class_start = sv.position_of(stmt.span.start).line;
+                let class_end = sv.position_of(stmt.span.end).line;
                 if class_start > range.end.line || class_end < range.start.line {
                     continue;
                 }
@@ -182,11 +158,11 @@ fn collect_getters_setters<'a>(
                 } else {
                     format!("Generate {count} getters/setters")
                 };
-                push_action(source, line_starts, stmt.span.end, text, &title, uri, out);
+                push_action(sv, stmt.span.end, text, &title, uri, out);
             }
             StmtKind::Namespace(ns) => {
                 if let NamespaceBody::Braced(inner) = &ns.body {
-                    collect_getters_setters(inner, source, line_starts, range, uri, out);
+                    collect_getters_setters(inner, sv, range, uri, out);
                 }
             }
             _ => {}
@@ -253,16 +229,14 @@ fn generate_constructor_text(props: &[Prop]) -> String {
 }
 
 fn push_action(
-    source: &str,
-    line_starts: &[u32],
+    sv: SourceView<'_>,
     class_end_offset: u32,
     new_text: String,
     title: &str,
     uri: &Url,
     out: &mut Vec<CodeActionOrCommand>,
 ) {
-    let closing_line =
-        offset_to_position(source, line_starts, class_end_offset.saturating_sub(1)).line;
+    let closing_line = sv.position_of(class_end_offset.saturating_sub(1)).line;
     let pos = Position {
         line: closing_line,
         character: 0,

--- a/src/implement_action.rs
+++ b/src/implement_action.rs
@@ -30,10 +30,12 @@ pub fn implement_missing_actions(
     uri: &Url,
     file_imports: &HashMap<String, String>,
 ) -> Vec<CodeActionOrCommand> {
+    let line_starts = doc.line_starts();
     let mut actions = Vec::new();
     collect_actions(
         &doc.program().stmts,
         source,
+        line_starts,
         all_docs,
         file_imports,
         range,
@@ -46,6 +48,7 @@ pub fn implement_missing_actions(
 fn collect_actions(
     stmts: &[Stmt<'_, '_>],
     source: &str,
+    line_starts: &[u32],
     all_docs: &[(Url, Arc<ParsedDoc>)],
     file_imports: &HashMap<String, String>,
     range: Range,
@@ -56,8 +59,8 @@ fn collect_actions(
         match &stmt.kind {
             StmtKind::Class(c) => {
                 // Only consider classes whose declaration overlaps the requested range.
-                let class_start = offset_to_position(source, stmt.span.start).line;
-                let class_end = offset_to_position(source, stmt.span.end).line;
+                let class_start = offset_to_position(source, line_starts, stmt.span.start).line;
+                let class_end = offset_to_position(source, line_starts, stmt.span.end).line;
                 if class_start > range.end.line || class_end < range.start.line {
                     continue;
                 }
@@ -114,7 +117,8 @@ fn collect_actions(
 
                 let stub_text = generate_stub_text(&missing);
                 // Insert just before the closing `}` of the class.
-                let closing_line = offset_to_position(source, stmt.span.end.saturating_sub(1)).line;
+                let closing_line =
+                    offset_to_position(source, line_starts, stmt.span.end.saturating_sub(1)).line;
                 let insert_pos = Position {
                     line: closing_line,
                     character: 0,
@@ -147,7 +151,16 @@ fn collect_actions(
             }
             StmtKind::Namespace(ns) => {
                 if let NamespaceBody::Braced(inner) = &ns.body {
-                    collect_actions(inner, source, all_docs, file_imports, range, uri, out);
+                    collect_actions(
+                        inner,
+                        source,
+                        line_starts,
+                        all_docs,
+                        file_imports,
+                        range,
+                        uri,
+                        out,
+                    );
                 }
             }
             _ => {}

--- a/src/implement_action.rs
+++ b/src/implement_action.rs
@@ -11,7 +11,7 @@ use tower_lsp::lsp_types::{
     CodeAction, CodeActionKind, CodeActionOrCommand, Position, Range, TextEdit, Url, WorkspaceEdit,
 };
 
-use crate::ast::{ParsedDoc, format_type_hint, offset_to_position};
+use crate::ast::{ParsedDoc, SourceView, format_type_hint};
 use crate::hover::format_params_str;
 
 struct MethodStub {
@@ -23,19 +23,18 @@ struct MethodStub {
 }
 
 pub fn implement_missing_actions(
-    source: &str,
+    _source: &str,
     doc: &ParsedDoc,
     all_docs: &[(Url, Arc<ParsedDoc>)],
     range: Range,
     uri: &Url,
     file_imports: &HashMap<String, String>,
 ) -> Vec<CodeActionOrCommand> {
-    let line_starts = doc.line_starts();
+    let sv = doc.view();
     let mut actions = Vec::new();
     collect_actions(
         &doc.program().stmts,
-        source,
-        line_starts,
+        sv,
         all_docs,
         file_imports,
         range,
@@ -47,8 +46,7 @@ pub fn implement_missing_actions(
 
 fn collect_actions(
     stmts: &[Stmt<'_, '_>],
-    source: &str,
-    line_starts: &[u32],
+    sv: SourceView<'_>,
     all_docs: &[(Url, Arc<ParsedDoc>)],
     file_imports: &HashMap<String, String>,
     range: Range,
@@ -59,8 +57,8 @@ fn collect_actions(
         match &stmt.kind {
             StmtKind::Class(c) => {
                 // Only consider classes whose declaration overlaps the requested range.
-                let class_start = offset_to_position(source, line_starts, stmt.span.start).line;
-                let class_end = offset_to_position(source, line_starts, stmt.span.end).line;
+                let class_start = sv.position_of(stmt.span.start).line;
+                let class_end = sv.position_of(stmt.span.end).line;
                 if class_start > range.end.line || class_end < range.start.line {
                     continue;
                 }
@@ -117,8 +115,7 @@ fn collect_actions(
 
                 let stub_text = generate_stub_text(&missing);
                 // Insert just before the closing `}` of the class.
-                let closing_line =
-                    offset_to_position(source, line_starts, stmt.span.end.saturating_sub(1)).line;
+                let closing_line = sv.position_of(stmt.span.end.saturating_sub(1)).line;
                 let insert_pos = Position {
                     line: closing_line,
                     character: 0,
@@ -151,16 +148,7 @@ fn collect_actions(
             }
             StmtKind::Namespace(ns) => {
                 if let NamespaceBody::Braced(inner) = &ns.body {
-                    collect_actions(
-                        inner,
-                        source,
-                        line_starts,
-                        all_docs,
-                        file_imports,
-                        range,
-                        uri,
-                        out,
-                    );
+                    collect_actions(inner, sv, all_docs, file_imports, range, uri, out);
                 }
             }
             _ => {}

--- a/src/implementation.rs
+++ b/src/implementation.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use php_ast::{NamespaceBody, Stmt, StmtKind};
 use tower_lsp::lsp_types::{Location, Position, Url};
 
-use crate::ast::{ParsedDoc, name_range};
+use crate::ast::{ParsedDoc, SourceView};
 use crate::util::word_at;
 
 /// Returns `true` when the name written in an `extends`/`implements` clause
@@ -39,17 +39,8 @@ pub fn find_implementations(
 ) -> Vec<Location> {
     let mut locations = Vec::new();
     for (uri, doc) in all_docs {
-        let source = doc.source();
-        let line_starts = doc.line_starts();
-        collect_implementations(
-            &doc.program().stmts,
-            word,
-            fqn,
-            source,
-            line_starts,
-            uri,
-            &mut locations,
-        );
+        let sv = doc.view();
+        collect_implementations(&doc.program().stmts, word, fqn, sv, uri, &mut locations);
     }
     locations
 }
@@ -79,8 +70,7 @@ fn collect_implementations(
     stmts: &[Stmt<'_, '_>],
     word: &str,
     fqn: Option<&str>,
-    source: &str,
-    line_starts: &[u32],
+    sv: SourceView<'_>,
     uri: &Url,
     out: &mut Vec<Location>,
 ) {
@@ -103,7 +93,7 @@ fn collect_implementations(
                 {
                     out.push(Location {
                         uri: uri.clone(),
-                        range: name_range(source, line_starts, class_name),
+                        range: sv.name_range(class_name),
                     });
                 }
             }
@@ -115,13 +105,13 @@ fn collect_implementations(
                 if implements_match {
                     out.push(Location {
                         uri: uri.clone(),
-                        range: name_range(source, line_starts, e.name),
+                        range: sv.name_range(e.name),
                     });
                 }
             }
             StmtKind::Namespace(ns) => {
                 if let NamespaceBody::Braced(inner) = &ns.body {
-                    collect_implementations(inner, word, fqn, source, line_starts, uri, out);
+                    collect_implementations(inner, word, fqn, sv, uri, out);
                 }
             }
             _ => {}

--- a/src/implementation.rs
+++ b/src/implementation.rs
@@ -40,7 +40,16 @@ pub fn find_implementations(
     let mut locations = Vec::new();
     for (uri, doc) in all_docs {
         let source = doc.source();
-        collect_implementations(&doc.program().stmts, word, fqn, source, uri, &mut locations);
+        let line_starts = doc.line_starts();
+        collect_implementations(
+            &doc.program().stmts,
+            word,
+            fqn,
+            source,
+            line_starts,
+            uri,
+            &mut locations,
+        );
     }
     locations
 }
@@ -71,6 +80,7 @@ fn collect_implementations(
     word: &str,
     fqn: Option<&str>,
     source: &str,
+    line_starts: &[u32],
     uri: &Url,
     out: &mut Vec<Location>,
 ) {
@@ -93,7 +103,7 @@ fn collect_implementations(
                 {
                     out.push(Location {
                         uri: uri.clone(),
-                        range: name_range(source, class_name),
+                        range: name_range(source, line_starts, class_name),
                     });
                 }
             }
@@ -105,13 +115,13 @@ fn collect_implementations(
                 if implements_match {
                     out.push(Location {
                         uri: uri.clone(),
-                        range: name_range(source, e.name),
+                        range: name_range(source, line_starts, e.name),
                     });
                 }
             }
             StmtKind::Namespace(ns) => {
                 if let NamespaceBody::Braced(inner) = &ns.body {
-                    collect_implementations(inner, word, fqn, source, uri, out);
+                    collect_implementations(inner, word, fqn, source, line_starts, uri, out);
                 }
             }
             _ => {}

--- a/src/inlay_hints.rs
+++ b/src/inlay_hints.rs
@@ -6,7 +6,7 @@ use php_ast::{
 use serde_json::json;
 use tower_lsp::lsp_types::{InlayHint, InlayHintKind, InlayHintLabel, Position, Range};
 
-use crate::ast::{ParsedDoc, format_type_hint, offset_to_position};
+use crate::ast::{ParsedDoc, SourceView, format_type_hint};
 use crate::type_map::TypeMap;
 
 struct FuncDef {
@@ -18,14 +18,13 @@ struct FuncDef {
 
 /// Returns parameter-name inlay hints AND return-type hints for all
 /// function/method declarations and calls in `doc`.
-pub fn inlay_hints(source: &str, doc: &ParsedDoc, range: Range) -> Vec<InlayHint> {
-    let line_starts = doc.line_starts();
+pub fn inlay_hints(_source: &str, doc: &ParsedDoc, range: Range) -> Vec<InlayHint> {
+    let sv = doc.view();
     let defs = collect_defs(&doc.program().stmts);
     let type_map = TypeMap::from_doc(doc);
     let mut hints = Vec::new();
     hints_in_stmts(
-        source,
-        line_starts,
+        sv,
         &doc.program().stmts,
         &defs,
         &type_map,
@@ -174,8 +173,7 @@ fn collect_defs_stmts(stmts: &[Stmt<'_, '_>], map: &mut HashMap<String, FuncDef>
 // === AST walking ===
 
 fn hints_in_stmts(
-    source: &str,
-    line_starts: &[u32],
+    sv: SourceView<'_>,
     stmts: &[Stmt<'_, '_>],
     defs: &HashMap<String, FuncDef>,
     type_map: &TypeMap,
@@ -183,13 +181,12 @@ fn hints_in_stmts(
     out: &mut Vec<InlayHint>,
 ) {
     for stmt in stmts {
-        hints_in_stmt(source, line_starts, stmt, defs, type_map, range, out);
+        hints_in_stmt(sv, stmt, defs, type_map, range, out);
     }
 }
 
 fn hints_in_stmt(
-    source: &str,
-    line_starts: &[u32],
+    sv: SourceView<'_>,
     stmt: &Stmt<'_, '_>,
     defs: &HashMap<String, FuncDef>,
     type_map: &TypeMap,
@@ -197,26 +194,22 @@ fn hints_in_stmt(
     out: &mut Vec<InlayHint>,
 ) {
     match &stmt.kind {
-        StmtKind::Expression(e) => {
-            hints_in_expr(source, line_starts, e, defs, type_map, range, out)
-        }
-        StmtKind::Return(Some(v)) => {
-            hints_in_expr(source, line_starts, v, defs, type_map, range, out)
-        }
+        StmtKind::Expression(e) => hints_in_expr(sv, e, defs, type_map, range, out),
+        StmtKind::Return(Some(v)) => hints_in_expr(sv, v, defs, type_map, range, out),
         StmtKind::Echo(exprs) => {
             for expr in exprs.iter() {
-                hints_in_expr(source, line_starts, expr, defs, type_map, range, out);
+                hints_in_expr(sv, expr, defs, type_map, range, out);
             }
         }
         StmtKind::Function(f) => {
-            hints_in_stmts(source, line_starts, &f.body, defs, type_map, range, out);
+            hints_in_stmts(sv, &f.body, defs, type_map, range, out);
         }
         StmtKind::Class(c) => {
             for member in c.members.iter() {
                 if let ClassMemberKind::Method(m) = &member.kind
                     && let Some(body) = &m.body
                 {
-                    hints_in_stmts(source, line_starts, body, defs, type_map, range, out);
+                    hints_in_stmts(sv, body, defs, type_map, range, out);
                 }
             }
         }
@@ -225,7 +218,7 @@ fn hints_in_stmt(
                 if let ClassMemberKind::Method(m) = &member.kind
                     && let Some(body) = &m.body
                 {
-                    hints_in_stmts(source, line_starts, body, defs, type_map, range, out);
+                    hints_in_stmts(sv, body, defs, type_map, range, out);
                 }
             }
         }
@@ -234,81 +227,49 @@ fn hints_in_stmt(
                 if let EnumMemberKind::Method(m) = &member.kind
                     && let Some(body) = &m.body
                 {
-                    hints_in_stmts(source, line_starts, body, defs, type_map, range, out);
+                    hints_in_stmts(sv, body, defs, type_map, range, out);
                 }
             }
         }
         StmtKind::Namespace(ns) => {
             if let NamespaceBody::Braced(inner) = &ns.body {
-                hints_in_stmts(source, line_starts, inner, defs, type_map, range, out);
+                hints_in_stmts(sv, inner, defs, type_map, range, out);
             }
         }
         StmtKind::If(i) => {
-            hints_in_expr(
-                source,
-                line_starts,
-                &i.condition,
-                defs,
-                type_map,
-                range,
-                out,
-            );
-            hints_in_stmt(
-                source,
-                line_starts,
-                i.then_branch,
-                defs,
-                type_map,
-                range,
-                out,
-            );
+            hints_in_expr(sv, &i.condition, defs, type_map, range, out);
+            hints_in_stmt(sv, i.then_branch, defs, type_map, range, out);
             for ei in i.elseif_branches.iter() {
-                hints_in_expr(
-                    source,
-                    line_starts,
-                    &ei.condition,
-                    defs,
-                    type_map,
-                    range,
-                    out,
-                );
-                hints_in_stmt(source, line_starts, &ei.body, defs, type_map, range, out);
+                hints_in_expr(sv, &ei.condition, defs, type_map, range, out);
+                hints_in_stmt(sv, &ei.body, defs, type_map, range, out);
             }
             if let Some(e) = &i.else_branch {
-                hints_in_stmt(source, line_starts, e, defs, type_map, range, out);
+                hints_in_stmt(sv, e, defs, type_map, range, out);
             }
         }
         StmtKind::While(w) => {
-            hints_in_expr(
-                source,
-                line_starts,
-                &w.condition,
-                defs,
-                type_map,
-                range,
-                out,
-            );
-            hints_in_stmt(source, line_starts, w.body, defs, type_map, range, out);
+            hints_in_expr(sv, &w.condition, defs, type_map, range, out);
+            hints_in_stmt(sv, w.body, defs, type_map, range, out);
         }
         StmtKind::For(f) => {
             for e in f.init.iter() {
-                hints_in_expr(source, line_starts, e, defs, type_map, range, out);
+                hints_in_expr(sv, e, defs, type_map, range, out);
             }
             for cond in f.condition.iter() {
-                hints_in_expr(source, line_starts, cond, defs, type_map, range, out);
+                hints_in_expr(sv, cond, defs, type_map, range, out);
             }
             for e in f.update.iter() {
-                hints_in_expr(source, line_starts, e, defs, type_map, range, out);
+                hints_in_expr(sv, e, defs, type_map, range, out);
             }
-            hints_in_stmt(source, line_starts, f.body, defs, type_map, range, out);
+            hints_in_stmt(sv, f.body, defs, type_map, range, out);
         }
         StmtKind::Foreach(f) => {
-            hints_in_expr(source, line_starts, &f.expr, defs, type_map, range, out);
+            hints_in_expr(sv, &f.expr, defs, type_map, range, out);
             // Emit type hint after the value variable, e.g. `foreach ($arr as $item /* : Foo */)`.
             if let ExprKind::Variable(val_name) = &f.value.kind {
                 let key = format!("${}", val_name.as_str());
                 if let Some(ty) = type_map.get(&key) {
-                    let pos = offset_to_position(source, line_starts, f.value.span.end);
+                    let pos = sv.position_of(f.value.span.end);
                     if pos_in_range(pos, range) {
                         out.push(make_foreach_type_hint(pos, ty));
                     }
@@ -320,33 +281,30 @@ fn hints_in_stmt(
             {
                 let key = format!("${}", key_name.as_str());
                 if let Some(ty) = type_map.get(&key) {
-                    let pos = offset_to_position(source, line_starts, key_expr.span.end);
+                    let pos = sv.position_of(key_expr.span.end);
                     if pos_in_range(pos, range) {
                         out.push(make_foreach_type_hint(pos, ty));
                     }
                 }
             }
-            hints_in_stmt(source, line_starts, f.body, defs, type_map, range, out);
+            hints_in_stmt(sv, f.body, defs, type_map, range, out);
         }
         StmtKind::TryCatch(t) => {
-            hints_in_stmts(source, line_starts, &t.body, defs, type_map, range, out);
+            hints_in_stmts(sv, &t.body, defs, type_map, range, out);
             for catch in t.catches.iter() {
-                hints_in_stmts(source, line_starts, &catch.body, defs, type_map, range, out);
+                hints_in_stmts(sv, &catch.body, defs, type_map, range, out);
             }
             if let Some(finally) = &t.finally {
-                hints_in_stmts(source, line_starts, finally, defs, type_map, range, out);
+                hints_in_stmts(sv, finally, defs, type_map, range, out);
             }
         }
-        StmtKind::Block(stmts) => {
-            hints_in_stmts(source, line_starts, stmts, defs, type_map, range, out)
-        }
+        StmtKind::Block(stmts) => hints_in_stmts(sv, stmts, defs, type_map, range, out),
         _ => {}
     }
 }
 
 fn hints_in_expr(
-    source: &str,
-    line_starts: &[u32],
+    sv: SourceView<'_>,
     expr: &Expr<'_, '_>,
     defs: &HashMap<String, FuncDef>,
     type_map: &TypeMap,
@@ -366,47 +324,47 @@ fn hints_in_expr(
             if let Some(k) = key
                 && let Some(def) = defs.get(&k)
             {
-                emit_param_hints(source, line_starts, &f.args, def, &k, range, out);
+                emit_param_hints(sv, &f.args, def, &k, range, out);
             }
-            hints_in_expr(source, line_starts, f.name, defs, type_map, range, out);
+            hints_in_expr(sv, f.name, defs, type_map, range, out);
             for arg in f.args.iter() {
-                hints_in_expr(source, line_starts, &arg.value, defs, type_map, range, out);
+                hints_in_expr(sv, &arg.value, defs, type_map, range, out);
             }
         }
         ExprKind::MethodCall(m) => {
             if let Some(name) = ident_name(m.method)
                 && let Some(def) = defs.get(name)
             {
-                emit_param_hints(source, line_starts, &m.args, def, name, range, out);
+                emit_param_hints(sv, &m.args, def, name, range, out);
             }
-            hints_in_expr(source, line_starts, m.object, defs, type_map, range, out);
+            hints_in_expr(sv, m.object, defs, type_map, range, out);
             for arg in m.args.iter() {
-                hints_in_expr(source, line_starts, &arg.value, defs, type_map, range, out);
+                hints_in_expr(sv, &arg.value, defs, type_map, range, out);
             }
         }
         ExprKind::New(n) => {
             if let Some(class_name) = ident_name(n.class)
                 && let Some(def) = defs.get(class_name)
             {
-                emit_param_hints(source, line_starts, &n.args, def, class_name, range, out);
+                emit_param_hints(sv, &n.args, def, class_name, range, out);
             }
             for arg in n.args.iter() {
-                hints_in_expr(source, line_starts, &arg.value, defs, type_map, range, out);
+                hints_in_expr(sv, &arg.value, defs, type_map, range, out);
             }
         }
         ExprKind::Assign(a) => {
             // Emit return-type hint after a function call on the RHS
-            emit_return_type_hint(source, line_starts, a.value, defs, range, out);
-            hints_in_expr(source, line_starts, a.target, defs, type_map, range, out);
-            hints_in_expr(source, line_starts, a.value, defs, type_map, range, out);
+            emit_return_type_hint(sv, a.value, defs, range, out);
+            hints_in_expr(sv, a.target, defs, type_map, range, out);
+            hints_in_expr(sv, a.value, defs, type_map, range, out);
         }
         // Walk into closure bodies so nested function calls get hints.
         ExprKind::Closure(c) => {
-            hints_in_stmts(source, line_starts, &c.body, defs, type_map, range, out);
+            hints_in_stmts(sv, &c.body, defs, type_map, range, out);
         }
         // Walk into arrow function bodies and emit an explicit return type hint when
         // the arrow function carries a declared return type (e.g. `fn(int $x): int => …`).
-        // We only emit here when there is NO explicit annotation already in source
+        // We only emit here when there is NO explicit annotation already in sv.source()
         // (i.e. the return_type field is None), so we infer nothing — we only surface
         // what the programmer wrote when they omitted the annotation entirely.
         // Actually: emit only when return_type IS present (declared by programmer).
@@ -416,39 +374,36 @@ fn hints_in_expr(
             if let Some(ret) = &a.return_type {
                 let ret_str = format_type_hint(ret);
                 if ret_str != "void" {
-                    let pos = offset_to_position(source, line_starts, expr.span.end);
+                    let pos = sv.position_of(expr.span.end);
                     if pos_in_range(pos, range) {
                         out.push(make_return_hint(pos, &ret_str, "arrow_fn"));
                     }
                 }
             }
-            hints_in_expr(source, line_starts, a.body, defs, type_map, range, out);
+            hints_in_expr(sv, a.body, defs, type_map, range, out);
         }
-        ExprKind::Parenthesized(e) => {
-            hints_in_expr(source, line_starts, e, defs, type_map, range, out)
-        }
+        ExprKind::Parenthesized(e) => hints_in_expr(sv, e, defs, type_map, range, out),
         ExprKind::Ternary(t) => {
-            hints_in_expr(source, line_starts, t.condition, defs, type_map, range, out);
+            hints_in_expr(sv, t.condition, defs, type_map, range, out);
             if let Some(then_expr) = t.then_expr {
-                hints_in_expr(source, line_starts, then_expr, defs, type_map, range, out);
+                hints_in_expr(sv, then_expr, defs, type_map, range, out);
             }
-            hints_in_expr(source, line_starts, t.else_expr, defs, type_map, range, out);
+            hints_in_expr(sv, t.else_expr, defs, type_map, range, out);
         }
         ExprKind::NullCoalesce(n) => {
-            hints_in_expr(source, line_starts, n.left, defs, type_map, range, out);
-            hints_in_expr(source, line_starts, n.right, defs, type_map, range, out);
+            hints_in_expr(sv, n.left, defs, type_map, range, out);
+            hints_in_expr(sv, n.right, defs, type_map, range, out);
         }
         ExprKind::Binary(b) => {
-            hints_in_expr(source, line_starts, b.left, defs, type_map, range, out);
-            hints_in_expr(source, line_starts, b.right, defs, type_map, range, out);
+            hints_in_expr(sv, b.left, defs, type_map, range, out);
+            hints_in_expr(sv, b.right, defs, type_map, range, out);
         }
         _ => {}
     }
 }
 
 fn emit_param_hints(
-    source: &str,
-    line_starts: &[u32],
+    sv: SourceView<'_>,
     args: &[php_ast::Arg<'_, '_>],
     def: &FuncDef,
     func_name: &str,
@@ -456,7 +411,7 @@ fn emit_param_hints(
     out: &mut Vec<InlayHint>,
 ) {
     for (i, arg) in args.iter().enumerate() {
-        // Skip named arguments (they already have the label in source)
+        // Skip named arguments (they already have the label in sv.source())
         if arg.name.is_some() {
             continue;
         }
@@ -471,7 +426,7 @@ fn emit_param_hints(
         } else {
             continue;
         };
-        let pos = offset_to_position(source, line_starts, arg.span.start);
+        let pos = sv.position_of(arg.span.start);
         if pos_in_range(pos, range) {
             out.push(make_param_hint(pos, param, func_name));
         }
@@ -479,8 +434,7 @@ fn emit_param_hints(
 }
 
 fn emit_return_type_hint(
-    source: &str,
-    line_starts: &[u32],
+    sv: SourceView<'_>,
     expr: &Expr<'_, '_>,
     defs: &HashMap<String, FuncDef>,
     range: Range,
@@ -498,7 +452,7 @@ fn emit_return_type_hint(
         if ret_type == "void" {
             return;
         }
-        let pos = offset_to_position(source, line_starts, expr.span.end);
+        let pos = sv.position_of(expr.span.end);
         if pos_in_range(pos, range) {
             out.push(make_return_hint(pos, ret_type, name));
         }

--- a/src/inlay_hints.rs
+++ b/src/inlay_hints.rs
@@ -19,11 +19,13 @@ struct FuncDef {
 /// Returns parameter-name inlay hints AND return-type hints for all
 /// function/method declarations and calls in `doc`.
 pub fn inlay_hints(source: &str, doc: &ParsedDoc, range: Range) -> Vec<InlayHint> {
+    let line_starts = doc.line_starts();
     let defs = collect_defs(&doc.program().stmts);
     let type_map = TypeMap::from_doc(doc);
     let mut hints = Vec::new();
     hints_in_stmts(
         source,
+        line_starts,
         &doc.program().stmts,
         &defs,
         &type_map,
@@ -173,6 +175,7 @@ fn collect_defs_stmts(stmts: &[Stmt<'_, '_>], map: &mut HashMap<String, FuncDef>
 
 fn hints_in_stmts(
     source: &str,
+    line_starts: &[u32],
     stmts: &[Stmt<'_, '_>],
     defs: &HashMap<String, FuncDef>,
     type_map: &TypeMap,
@@ -180,12 +183,13 @@ fn hints_in_stmts(
     out: &mut Vec<InlayHint>,
 ) {
     for stmt in stmts {
-        hints_in_stmt(source, stmt, defs, type_map, range, out);
+        hints_in_stmt(source, line_starts, stmt, defs, type_map, range, out);
     }
 }
 
 fn hints_in_stmt(
     source: &str,
+    line_starts: &[u32],
     stmt: &Stmt<'_, '_>,
     defs: &HashMap<String, FuncDef>,
     type_map: &TypeMap,
@@ -193,22 +197,26 @@ fn hints_in_stmt(
     out: &mut Vec<InlayHint>,
 ) {
     match &stmt.kind {
-        StmtKind::Expression(e) => hints_in_expr(source, e, defs, type_map, range, out),
-        StmtKind::Return(Some(v)) => hints_in_expr(source, v, defs, type_map, range, out),
+        StmtKind::Expression(e) => {
+            hints_in_expr(source, line_starts, e, defs, type_map, range, out)
+        }
+        StmtKind::Return(Some(v)) => {
+            hints_in_expr(source, line_starts, v, defs, type_map, range, out)
+        }
         StmtKind::Echo(exprs) => {
             for expr in exprs.iter() {
-                hints_in_expr(source, expr, defs, type_map, range, out);
+                hints_in_expr(source, line_starts, expr, defs, type_map, range, out);
             }
         }
         StmtKind::Function(f) => {
-            hints_in_stmts(source, &f.body, defs, type_map, range, out);
+            hints_in_stmts(source, line_starts, &f.body, defs, type_map, range, out);
         }
         StmtKind::Class(c) => {
             for member in c.members.iter() {
                 if let ClassMemberKind::Method(m) = &member.kind
                     && let Some(body) = &m.body
                 {
-                    hints_in_stmts(source, body, defs, type_map, range, out);
+                    hints_in_stmts(source, line_starts, body, defs, type_map, range, out);
                 }
             }
         }
@@ -217,7 +225,7 @@ fn hints_in_stmt(
                 if let ClassMemberKind::Method(m) = &member.kind
                     && let Some(body) = &m.body
                 {
-                    hints_in_stmts(source, body, defs, type_map, range, out);
+                    hints_in_stmts(source, line_starts, body, defs, type_map, range, out);
                 }
             }
         }
@@ -226,49 +234,81 @@ fn hints_in_stmt(
                 if let EnumMemberKind::Method(m) = &member.kind
                     && let Some(body) = &m.body
                 {
-                    hints_in_stmts(source, body, defs, type_map, range, out);
+                    hints_in_stmts(source, line_starts, body, defs, type_map, range, out);
                 }
             }
         }
         StmtKind::Namespace(ns) => {
             if let NamespaceBody::Braced(inner) = &ns.body {
-                hints_in_stmts(source, inner, defs, type_map, range, out);
+                hints_in_stmts(source, line_starts, inner, defs, type_map, range, out);
             }
         }
         StmtKind::If(i) => {
-            hints_in_expr(source, &i.condition, defs, type_map, range, out);
-            hints_in_stmt(source, i.then_branch, defs, type_map, range, out);
+            hints_in_expr(
+                source,
+                line_starts,
+                &i.condition,
+                defs,
+                type_map,
+                range,
+                out,
+            );
+            hints_in_stmt(
+                source,
+                line_starts,
+                i.then_branch,
+                defs,
+                type_map,
+                range,
+                out,
+            );
             for ei in i.elseif_branches.iter() {
-                hints_in_expr(source, &ei.condition, defs, type_map, range, out);
-                hints_in_stmt(source, &ei.body, defs, type_map, range, out);
+                hints_in_expr(
+                    source,
+                    line_starts,
+                    &ei.condition,
+                    defs,
+                    type_map,
+                    range,
+                    out,
+                );
+                hints_in_stmt(source, line_starts, &ei.body, defs, type_map, range, out);
             }
             if let Some(e) = &i.else_branch {
-                hints_in_stmt(source, e, defs, type_map, range, out);
+                hints_in_stmt(source, line_starts, e, defs, type_map, range, out);
             }
         }
         StmtKind::While(w) => {
-            hints_in_expr(source, &w.condition, defs, type_map, range, out);
-            hints_in_stmt(source, w.body, defs, type_map, range, out);
+            hints_in_expr(
+                source,
+                line_starts,
+                &w.condition,
+                defs,
+                type_map,
+                range,
+                out,
+            );
+            hints_in_stmt(source, line_starts, w.body, defs, type_map, range, out);
         }
         StmtKind::For(f) => {
             for e in f.init.iter() {
-                hints_in_expr(source, e, defs, type_map, range, out);
+                hints_in_expr(source, line_starts, e, defs, type_map, range, out);
             }
             for cond in f.condition.iter() {
-                hints_in_expr(source, cond, defs, type_map, range, out);
+                hints_in_expr(source, line_starts, cond, defs, type_map, range, out);
             }
             for e in f.update.iter() {
-                hints_in_expr(source, e, defs, type_map, range, out);
+                hints_in_expr(source, line_starts, e, defs, type_map, range, out);
             }
-            hints_in_stmt(source, f.body, defs, type_map, range, out);
+            hints_in_stmt(source, line_starts, f.body, defs, type_map, range, out);
         }
         StmtKind::Foreach(f) => {
-            hints_in_expr(source, &f.expr, defs, type_map, range, out);
+            hints_in_expr(source, line_starts, &f.expr, defs, type_map, range, out);
             // Emit type hint after the value variable, e.g. `foreach ($arr as $item /* : Foo */)`.
             if let ExprKind::Variable(val_name) = &f.value.kind {
                 let key = format!("${}", val_name.as_str());
                 if let Some(ty) = type_map.get(&key) {
-                    let pos = offset_to_position(source, f.value.span.end);
+                    let pos = offset_to_position(source, line_starts, f.value.span.end);
                     if pos_in_range(pos, range) {
                         out.push(make_foreach_type_hint(pos, ty));
                     }
@@ -280,30 +320,33 @@ fn hints_in_stmt(
             {
                 let key = format!("${}", key_name.as_str());
                 if let Some(ty) = type_map.get(&key) {
-                    let pos = offset_to_position(source, key_expr.span.end);
+                    let pos = offset_to_position(source, line_starts, key_expr.span.end);
                     if pos_in_range(pos, range) {
                         out.push(make_foreach_type_hint(pos, ty));
                     }
                 }
             }
-            hints_in_stmt(source, f.body, defs, type_map, range, out);
+            hints_in_stmt(source, line_starts, f.body, defs, type_map, range, out);
         }
         StmtKind::TryCatch(t) => {
-            hints_in_stmts(source, &t.body, defs, type_map, range, out);
+            hints_in_stmts(source, line_starts, &t.body, defs, type_map, range, out);
             for catch in t.catches.iter() {
-                hints_in_stmts(source, &catch.body, defs, type_map, range, out);
+                hints_in_stmts(source, line_starts, &catch.body, defs, type_map, range, out);
             }
             if let Some(finally) = &t.finally {
-                hints_in_stmts(source, finally, defs, type_map, range, out);
+                hints_in_stmts(source, line_starts, finally, defs, type_map, range, out);
             }
         }
-        StmtKind::Block(stmts) => hints_in_stmts(source, stmts, defs, type_map, range, out),
+        StmtKind::Block(stmts) => {
+            hints_in_stmts(source, line_starts, stmts, defs, type_map, range, out)
+        }
         _ => {}
     }
 }
 
 fn hints_in_expr(
     source: &str,
+    line_starts: &[u32],
     expr: &Expr<'_, '_>,
     defs: &HashMap<String, FuncDef>,
     type_map: &TypeMap,
@@ -323,43 +366,43 @@ fn hints_in_expr(
             if let Some(k) = key
                 && let Some(def) = defs.get(&k)
             {
-                emit_param_hints(source, &f.args, def, &k, range, out);
+                emit_param_hints(source, line_starts, &f.args, def, &k, range, out);
             }
-            hints_in_expr(source, f.name, defs, type_map, range, out);
+            hints_in_expr(source, line_starts, f.name, defs, type_map, range, out);
             for arg in f.args.iter() {
-                hints_in_expr(source, &arg.value, defs, type_map, range, out);
+                hints_in_expr(source, line_starts, &arg.value, defs, type_map, range, out);
             }
         }
         ExprKind::MethodCall(m) => {
             if let Some(name) = ident_name(m.method)
                 && let Some(def) = defs.get(name)
             {
-                emit_param_hints(source, &m.args, def, name, range, out);
+                emit_param_hints(source, line_starts, &m.args, def, name, range, out);
             }
-            hints_in_expr(source, m.object, defs, type_map, range, out);
+            hints_in_expr(source, line_starts, m.object, defs, type_map, range, out);
             for arg in m.args.iter() {
-                hints_in_expr(source, &arg.value, defs, type_map, range, out);
+                hints_in_expr(source, line_starts, &arg.value, defs, type_map, range, out);
             }
         }
         ExprKind::New(n) => {
             if let Some(class_name) = ident_name(n.class)
                 && let Some(def) = defs.get(class_name)
             {
-                emit_param_hints(source, &n.args, def, class_name, range, out);
+                emit_param_hints(source, line_starts, &n.args, def, class_name, range, out);
             }
             for arg in n.args.iter() {
-                hints_in_expr(source, &arg.value, defs, type_map, range, out);
+                hints_in_expr(source, line_starts, &arg.value, defs, type_map, range, out);
             }
         }
         ExprKind::Assign(a) => {
             // Emit return-type hint after a function call on the RHS
-            emit_return_type_hint(source, a.value, defs, range, out);
-            hints_in_expr(source, a.target, defs, type_map, range, out);
-            hints_in_expr(source, a.value, defs, type_map, range, out);
+            emit_return_type_hint(source, line_starts, a.value, defs, range, out);
+            hints_in_expr(source, line_starts, a.target, defs, type_map, range, out);
+            hints_in_expr(source, line_starts, a.value, defs, type_map, range, out);
         }
         // Walk into closure bodies so nested function calls get hints.
         ExprKind::Closure(c) => {
-            hints_in_stmts(source, &c.body, defs, type_map, range, out);
+            hints_in_stmts(source, line_starts, &c.body, defs, type_map, range, out);
         }
         // Walk into arrow function bodies and emit an explicit return type hint when
         // the arrow function carries a declared return type (e.g. `fn(int $x): int => …`).
@@ -373,29 +416,31 @@ fn hints_in_expr(
             if let Some(ret) = &a.return_type {
                 let ret_str = format_type_hint(ret);
                 if ret_str != "void" {
-                    let pos = offset_to_position(source, expr.span.end);
+                    let pos = offset_to_position(source, line_starts, expr.span.end);
                     if pos_in_range(pos, range) {
                         out.push(make_return_hint(pos, &ret_str, "arrow_fn"));
                     }
                 }
             }
-            hints_in_expr(source, a.body, defs, type_map, range, out);
+            hints_in_expr(source, line_starts, a.body, defs, type_map, range, out);
         }
-        ExprKind::Parenthesized(e) => hints_in_expr(source, e, defs, type_map, range, out),
+        ExprKind::Parenthesized(e) => {
+            hints_in_expr(source, line_starts, e, defs, type_map, range, out)
+        }
         ExprKind::Ternary(t) => {
-            hints_in_expr(source, t.condition, defs, type_map, range, out);
+            hints_in_expr(source, line_starts, t.condition, defs, type_map, range, out);
             if let Some(then_expr) = t.then_expr {
-                hints_in_expr(source, then_expr, defs, type_map, range, out);
+                hints_in_expr(source, line_starts, then_expr, defs, type_map, range, out);
             }
-            hints_in_expr(source, t.else_expr, defs, type_map, range, out);
+            hints_in_expr(source, line_starts, t.else_expr, defs, type_map, range, out);
         }
         ExprKind::NullCoalesce(n) => {
-            hints_in_expr(source, n.left, defs, type_map, range, out);
-            hints_in_expr(source, n.right, defs, type_map, range, out);
+            hints_in_expr(source, line_starts, n.left, defs, type_map, range, out);
+            hints_in_expr(source, line_starts, n.right, defs, type_map, range, out);
         }
         ExprKind::Binary(b) => {
-            hints_in_expr(source, b.left, defs, type_map, range, out);
-            hints_in_expr(source, b.right, defs, type_map, range, out);
+            hints_in_expr(source, line_starts, b.left, defs, type_map, range, out);
+            hints_in_expr(source, line_starts, b.right, defs, type_map, range, out);
         }
         _ => {}
     }
@@ -403,6 +448,7 @@ fn hints_in_expr(
 
 fn emit_param_hints(
     source: &str,
+    line_starts: &[u32],
     args: &[php_ast::Arg<'_, '_>],
     def: &FuncDef,
     func_name: &str,
@@ -425,7 +471,7 @@ fn emit_param_hints(
         } else {
             continue;
         };
-        let pos = offset_to_position(source, arg.span.start);
+        let pos = offset_to_position(source, line_starts, arg.span.start);
         if pos_in_range(pos, range) {
             out.push(make_param_hint(pos, param, func_name));
         }
@@ -434,6 +480,7 @@ fn emit_param_hints(
 
 fn emit_return_type_hint(
     source: &str,
+    line_starts: &[u32],
     expr: &Expr<'_, '_>,
     defs: &HashMap<String, FuncDef>,
     range: Range,
@@ -451,7 +498,7 @@ fn emit_return_type_hint(
         if ret_type == "void" {
             return;
         }
-        let pos = offset_to_position(source, expr.span.end);
+        let pos = offset_to_position(source, line_starts, expr.span.end);
         if pos_in_range(pos, range) {
             out.push(make_return_hint(pos, ret_type, name));
         }

--- a/src/organize_imports.rs
+++ b/src/organize_imports.rs
@@ -102,8 +102,8 @@ fn render_group(stmts: &[UseStatement], indent: &str, keyword: Option<&str>) -> 
 
 /// Sort a group alphabetically (case-insensitive) and deduplicate by FQN.
 fn sort_and_dedup(group: &mut Vec<UseStatement>) {
-    group.sort_by(|a, b| a.fqn.to_lowercase().cmp(&b.fqn.to_lowercase()));
-    group.dedup_by(|a, b| a.fqn.to_lowercase() == b.fqn.to_lowercase());
+    group.sort_by_cached_key(|u| u.fqn.to_lowercase());
+    group.dedup_by(|a, b| a.fqn.eq_ignore_ascii_case(&b.fqn));
 }
 
 fn make_action(uri: &Url, edit: TextEdit) -> CodeActionOrCommand {

--- a/src/phpdoc_action.rs
+++ b/src/phpdoc_action.rs
@@ -15,8 +15,16 @@ pub fn phpdoc_actions(
     source: &str,
     range: Range,
 ) -> Vec<CodeActionOrCommand> {
+    let line_starts = doc.line_starts();
     let mut actions = Vec::new();
-    collect(&doc.program().stmts, uri, source, range, &mut actions);
+    collect(
+        &doc.program().stmts,
+        uri,
+        source,
+        line_starts,
+        range,
+        &mut actions,
+    );
     actions
 }
 
@@ -24,13 +32,14 @@ fn collect(
     stmts: &[Stmt<'_, '_>],
     uri: &Url,
     source: &str,
+    line_starts: &[u32],
     range: Range,
     out: &mut Vec<CodeActionOrCommand>,
 ) {
     for stmt in stmts {
         match &stmt.kind {
             StmtKind::Function(f) => {
-                let fn_line = offset_to_position(source, stmt.span.start).line;
+                let fn_line = offset_to_position(source, line_starts, stmt.span.start).line;
                 if line_in_range(fn_line, range)
                     && docblock_before(source, stmt.span.start).is_none()
                 {
@@ -43,7 +52,8 @@ fn collect(
             StmtKind::Class(c) => {
                 for member in c.members.iter() {
                     if let ClassMemberKind::Method(m) = &member.kind {
-                        let fn_line = offset_to_position(source, member.span.start).line;
+                        let fn_line =
+                            offset_to_position(source, line_starts, member.span.start).line;
                         if line_in_range(fn_line, range)
                             && docblock_before(source, member.span.start).is_none()
                         {
@@ -59,7 +69,8 @@ fn collect(
             StmtKind::Trait(t) => {
                 for member in t.members.iter() {
                     if let ClassMemberKind::Method(m) = &member.kind {
-                        let fn_line = offset_to_position(source, member.span.start).line;
+                        let fn_line =
+                            offset_to_position(source, line_starts, member.span.start).line;
                         if line_in_range(fn_line, range)
                             && docblock_before(source, member.span.start).is_none()
                         {
@@ -75,7 +86,8 @@ fn collect(
             StmtKind::Enum(e) => {
                 for member in e.members.iter() {
                     if let EnumMemberKind::Method(m) = &member.kind {
-                        let fn_line = offset_to_position(source, member.span.start).line;
+                        let fn_line =
+                            offset_to_position(source, line_starts, member.span.start).line;
                         if line_in_range(fn_line, range)
                             && docblock_before(source, member.span.start).is_none()
                         {
@@ -90,7 +102,7 @@ fn collect(
             }
             StmtKind::Namespace(ns) => {
                 if let NamespaceBody::Braced(inner) = &ns.body {
-                    collect(inner, uri, source, range, out);
+                    collect(inner, uri, source, line_starts, range, out);
                 }
             }
             _ => {}

--- a/src/phpdoc_action.rs
+++ b/src/phpdoc_action.rs
@@ -4,7 +4,7 @@ use tower_lsp::lsp_types::{
     CodeAction, CodeActionKind, CodeActionOrCommand, Position, Range, TextEdit, Url, WorkspaceEdit,
 };
 
-use crate::ast::{ParsedDoc, format_type_hint, offset_to_position};
+use crate::ast::{ParsedDoc, SourceView, format_type_hint};
 use crate::docblock::docblock_before;
 
 /// Return "Generate PHPDoc" code actions for any function/method whose declaration line
@@ -12,39 +12,31 @@ use crate::docblock::docblock_before;
 pub fn phpdoc_actions(
     uri: &Url,
     doc: &ParsedDoc,
-    source: &str,
+    _source: &str,
     range: Range,
 ) -> Vec<CodeActionOrCommand> {
-    let line_starts = doc.line_starts();
+    let sv = doc.view();
     let mut actions = Vec::new();
-    collect(
-        &doc.program().stmts,
-        uri,
-        source,
-        line_starts,
-        range,
-        &mut actions,
-    );
+    collect(&doc.program().stmts, uri, sv, range, &mut actions);
     actions
 }
 
 fn collect(
     stmts: &[Stmt<'_, '_>],
     uri: &Url,
-    source: &str,
-    line_starts: &[u32],
+    sv: SourceView<'_>,
     range: Range,
     out: &mut Vec<CodeActionOrCommand>,
 ) {
     for stmt in stmts {
         match &stmt.kind {
             StmtKind::Function(f) => {
-                let fn_line = offset_to_position(source, line_starts, stmt.span.start).line;
+                let fn_line = sv.position_of(stmt.span.start).line;
                 if line_in_range(fn_line, range)
-                    && docblock_before(source, stmt.span.start).is_none()
+                    && docblock_before(sv.source(), stmt.span.start).is_none()
                 {
                     let ret = f.return_type.as_ref().map(|t| format_type_hint(t));
-                    if let Some(action) = make_action(uri, source, fn_line, &f.params, ret) {
+                    if let Some(action) = make_action(uri, sv.source(), fn_line, &f.params, ret) {
                         out.push(action);
                     }
                 }
@@ -52,13 +44,13 @@ fn collect(
             StmtKind::Class(c) => {
                 for member in c.members.iter() {
                     if let ClassMemberKind::Method(m) = &member.kind {
-                        let fn_line =
-                            offset_to_position(source, line_starts, member.span.start).line;
+                        let fn_line = sv.position_of(member.span.start).line;
                         if line_in_range(fn_line, range)
-                            && docblock_before(source, member.span.start).is_none()
+                            && docblock_before(sv.source(), member.span.start).is_none()
                         {
                             let ret = m.return_type.as_ref().map(|t| format_type_hint(t));
-                            if let Some(action) = make_action(uri, source, fn_line, &m.params, ret)
+                            if let Some(action) =
+                                make_action(uri, sv.source(), fn_line, &m.params, ret)
                             {
                                 out.push(action);
                             }
@@ -69,13 +61,13 @@ fn collect(
             StmtKind::Trait(t) => {
                 for member in t.members.iter() {
                     if let ClassMemberKind::Method(m) = &member.kind {
-                        let fn_line =
-                            offset_to_position(source, line_starts, member.span.start).line;
+                        let fn_line = sv.position_of(member.span.start).line;
                         if line_in_range(fn_line, range)
-                            && docblock_before(source, member.span.start).is_none()
+                            && docblock_before(sv.source(), member.span.start).is_none()
                         {
                             let ret = m.return_type.as_ref().map(|t| format_type_hint(t));
-                            if let Some(action) = make_action(uri, source, fn_line, &m.params, ret)
+                            if let Some(action) =
+                                make_action(uri, sv.source(), fn_line, &m.params, ret)
                             {
                                 out.push(action);
                             }
@@ -86,13 +78,13 @@ fn collect(
             StmtKind::Enum(e) => {
                 for member in e.members.iter() {
                     if let EnumMemberKind::Method(m) = &member.kind {
-                        let fn_line =
-                            offset_to_position(source, line_starts, member.span.start).line;
+                        let fn_line = sv.position_of(member.span.start).line;
                         if line_in_range(fn_line, range)
-                            && docblock_before(source, member.span.start).is_none()
+                            && docblock_before(sv.source(), member.span.start).is_none()
                         {
                             let ret = m.return_type.as_ref().map(|t| format_type_hint(t));
-                            if let Some(action) = make_action(uri, source, fn_line, &m.params, ret)
+                            if let Some(action) =
+                                make_action(uri, sv.source(), fn_line, &m.params, ret)
                             {
                                 out.push(action);
                             }
@@ -102,7 +94,7 @@ fn collect(
             }
             StmtKind::Namespace(ns) => {
                 if let NamespaceBody::Braced(inner) = &ns.body {
-                    collect(inner, uri, source, line_starts, range, out);
+                    collect(inner, uri, sv, range, out);
                 }
             }
             _ => {}

--- a/src/promote_action.rs
+++ b/src/promote_action.rs
@@ -25,26 +25,19 @@ use tower_lsp::lsp_types::{
     CodeAction, CodeActionKind, CodeActionOrCommand, Range, TextEdit, Url, WorkspaceEdit,
 };
 
-use crate::ast::{ParsedDoc, offset_to_position};
+use crate::ast::{ParsedDoc, SourceView};
 
 // ── Public entry point ────────────────────────────────────────────────────────
 
 pub fn promote_constructor_actions(
-    source: &str,
+    _source: &str,
     doc: &ParsedDoc,
     range: Range,
     uri: &Url,
 ) -> Vec<CodeActionOrCommand> {
-    let line_starts = doc.line_starts();
+    let sv = doc.view();
     let mut out = Vec::new();
-    collect_promote(
-        &doc.program().stmts,
-        source,
-        line_starts,
-        range,
-        uri,
-        &mut out,
-    );
+    collect_promote(&doc.program().stmts, sv, range, uri, &mut out);
     out
 }
 
@@ -68,8 +61,7 @@ struct Promotion {
 
 fn collect_promote<'a>(
     stmts: &[Stmt<'a, 'a>],
-    source: &str,
-    line_starts: &[u32],
+    sv: SourceView<'_>,
     range: Range,
     uri: &Url,
     out: &mut Vec<CodeActionOrCommand>,
@@ -77,8 +69,8 @@ fn collect_promote<'a>(
     for stmt in stmts {
         match &stmt.kind {
             StmtKind::Class(c) => {
-                let class_start = offset_to_position(source, line_starts, stmt.span.start).line;
-                let class_end = offset_to_position(source, line_starts, stmt.span.end).line;
+                let class_start = sv.position_of(stmt.span.start).line;
+                let class_end = sv.position_of(stmt.span.end).line;
                 if class_start > range.end.line || class_end < range.start.line {
                     continue;
                 }
@@ -144,7 +136,7 @@ fn collect_promote<'a>(
                     };
 
                     // Search constructor body for `$this->paramName = $paramName`.
-                    let assign_span = find_this_assign(source, ctor_body, param_name);
+                    let assign_span = find_this_assign(sv.source(), ctor_body, param_name);
                     let (assign_start, assign_end) = match assign_span {
                         Some(s) => s,
                         None => continue,
@@ -172,13 +164,13 @@ fn collect_promote<'a>(
                     format!("Promote {count} constructor parameters")
                 };
 
-                if let Some(action) = build_action(source, line_starts, uri, &promotions, &title) {
+                if let Some(action) = build_action(sv, uri, &promotions, &title) {
                     out.push(action);
                 }
             }
             StmtKind::Namespace(ns) => {
                 if let NamespaceBody::Braced(inner) = &ns.body {
-                    collect_promote(inner, source, line_starts, range, uri, out);
+                    collect_promote(inner, sv, range, uri, out);
                 }
             }
             _ => {}
@@ -215,8 +207,7 @@ fn find_this_assign(source: &str, stmts: &[Stmt<'_, '_>], param_name: &str) -> O
 
 /// Build the code action with text edits.
 fn build_action(
-    source: &str,
-    line_starts: &[u32],
+    sv: SourceView<'_>,
     uri: &Url,
     promotions: &[Promotion],
     title: &str,
@@ -225,15 +216,14 @@ fn build_action(
 
     for p in promotions {
         // 1. Remove the property declaration (the whole line including newline).
-        let prop_remove_range =
-            whole_line_range(source, line_starts, p.prop_span_start, p.prop_span_end);
+        let prop_remove_range = whole_line_range(sv, p.prop_span_start, p.prop_span_end);
         edits.push(TextEdit {
             range: prop_remove_range,
             new_text: String::new(),
         });
 
         // 2. Insert `visibility ` (and optionally `readonly `) before the param.
-        let insert_pos = offset_to_position(source, line_starts, p.param_span_start);
+        let insert_pos = sv.position_of(p.param_span_start);
         let prefix = if p.is_readonly {
             format!("{} readonly ", p.visibility)
         } else {
@@ -248,8 +238,7 @@ fn build_action(
         });
 
         // 3. Remove the `$this->prop = $param;` assignment (whole line including newline).
-        let assign_remove_range =
-            whole_line_range(source, line_starts, p.assign_span_start, p.assign_span_end);
+        let assign_remove_range = whole_line_range(sv, p.assign_span_start, p.assign_span_end);
         edits.push(TextEdit {
             range: assign_remove_range,
             new_text: String::new(),
@@ -282,27 +271,30 @@ fn build_action(
 
 /// Return a `Range` that covers the full line(s) containing `[span_start, span_end]`,
 /// including the trailing newline so the blank line is removed entirely.
-fn whole_line_range(source: &str, line_starts: &[u32], span_start: u32, span_end: u32) -> Range {
+fn whole_line_range(sv: SourceView<'_>, span_start: u32, span_end: u32) -> Range {
     let start_off = span_start as usize;
-    let end_off = (span_end as usize).min(source.len());
+    let end_off = (span_end as usize).min(sv.source().len());
 
     // Walk backwards to find the start of the line.
-    let line_start = source[..start_off].rfind('\n').map(|i| i + 1).unwrap_or(0);
+    let line_start = sv.source()[..start_off]
+        .rfind('\n')
+        .map(|i| i + 1)
+        .unwrap_or(0);
 
     // Walk forward to include the trailing newline.
-    let line_end = if end_off < source.len() && source.as_bytes()[end_off] == b'\n' {
+    let line_end = if end_off < sv.source().len() && sv.source().as_bytes()[end_off] == b'\n' {
         end_off + 1
     } else {
         // No trailing newline — just use a byte scan to end of the current line.
-        source[end_off..]
+        sv.source()[end_off..]
             .find('\n')
             .map(|i| end_off + i + 1)
-            .unwrap_or(source.len())
+            .unwrap_or(sv.source().len())
     };
 
     Range {
-        start: offset_to_position(source, line_starts, line_start as u32),
-        end: offset_to_position(source, line_starts, line_end as u32),
+        start: sv.position_of(line_start as u32),
+        end: sv.position_of(line_end as u32),
     }
 }
 

--- a/src/promote_action.rs
+++ b/src/promote_action.rs
@@ -35,8 +35,16 @@ pub fn promote_constructor_actions(
     range: Range,
     uri: &Url,
 ) -> Vec<CodeActionOrCommand> {
+    let line_starts = doc.line_starts();
     let mut out = Vec::new();
-    collect_promote(&doc.program().stmts, source, range, uri, &mut out);
+    collect_promote(
+        &doc.program().stmts,
+        source,
+        line_starts,
+        range,
+        uri,
+        &mut out,
+    );
     out
 }
 
@@ -61,6 +69,7 @@ struct Promotion {
 fn collect_promote<'a>(
     stmts: &[Stmt<'a, 'a>],
     source: &str,
+    line_starts: &[u32],
     range: Range,
     uri: &Url,
     out: &mut Vec<CodeActionOrCommand>,
@@ -68,8 +77,8 @@ fn collect_promote<'a>(
     for stmt in stmts {
         match &stmt.kind {
             StmtKind::Class(c) => {
-                let class_start = offset_to_position(source, stmt.span.start).line;
-                let class_end = offset_to_position(source, stmt.span.end).line;
+                let class_start = offset_to_position(source, line_starts, stmt.span.start).line;
+                let class_end = offset_to_position(source, line_starts, stmt.span.end).line;
                 if class_start > range.end.line || class_end < range.start.line {
                     continue;
                 }
@@ -163,13 +172,13 @@ fn collect_promote<'a>(
                     format!("Promote {count} constructor parameters")
                 };
 
-                if let Some(action) = build_action(source, uri, &promotions, &title) {
+                if let Some(action) = build_action(source, line_starts, uri, &promotions, &title) {
                     out.push(action);
                 }
             }
             StmtKind::Namespace(ns) => {
                 if let NamespaceBody::Braced(inner) = &ns.body {
-                    collect_promote(inner, source, range, uri, out);
+                    collect_promote(inner, source, line_starts, range, uri, out);
                 }
             }
             _ => {}
@@ -207,6 +216,7 @@ fn find_this_assign(source: &str, stmts: &[Stmt<'_, '_>], param_name: &str) -> O
 /// Build the code action with text edits.
 fn build_action(
     source: &str,
+    line_starts: &[u32],
     uri: &Url,
     promotions: &[Promotion],
     title: &str,
@@ -215,14 +225,15 @@ fn build_action(
 
     for p in promotions {
         // 1. Remove the property declaration (the whole line including newline).
-        let prop_remove_range = whole_line_range(source, p.prop_span_start, p.prop_span_end);
+        let prop_remove_range =
+            whole_line_range(source, line_starts, p.prop_span_start, p.prop_span_end);
         edits.push(TextEdit {
             range: prop_remove_range,
             new_text: String::new(),
         });
 
         // 2. Insert `visibility ` (and optionally `readonly `) before the param.
-        let insert_pos = offset_to_position(source, p.param_span_start);
+        let insert_pos = offset_to_position(source, line_starts, p.param_span_start);
         let prefix = if p.is_readonly {
             format!("{} readonly ", p.visibility)
         } else {
@@ -237,7 +248,8 @@ fn build_action(
         });
 
         // 3. Remove the `$this->prop = $param;` assignment (whole line including newline).
-        let assign_remove_range = whole_line_range(source, p.assign_span_start, p.assign_span_end);
+        let assign_remove_range =
+            whole_line_range(source, line_starts, p.assign_span_start, p.assign_span_end);
         edits.push(TextEdit {
             range: assign_remove_range,
             new_text: String::new(),
@@ -270,7 +282,7 @@ fn build_action(
 
 /// Return a `Range` that covers the full line(s) containing `[span_start, span_end]`,
 /// including the trailing newline so the blank line is removed entirely.
-fn whole_line_range(source: &str, span_start: u32, span_end: u32) -> Range {
+fn whole_line_range(source: &str, line_starts: &[u32], span_start: u32, span_end: u32) -> Range {
     let start_off = span_start as usize;
     let end_off = (span_end as usize).min(source.len());
 
@@ -289,8 +301,8 @@ fn whole_line_range(source: &str, span_start: u32, span_end: u32) -> Range {
     };
 
     Range {
-        start: offset_to_position(source, line_start as u32),
-        end: offset_to_position(source, line_end as u32),
+        start: offset_to_position(source, line_starts, line_start as u32),
+        end: offset_to_position(source, line_starts, line_end as u32),
     }
 }
 

--- a/src/references.rs
+++ b/src/references.rs
@@ -73,8 +73,9 @@ pub fn find_references_codebase(
     let spans_to_location = |file: &str, start: u32, end: u32| -> Option<Location> {
         let (url, doc) = doc_map.get(file)?;
         let source = doc.source();
-        let start_pos = offset_to_position(source, start);
-        let end_pos = offset_to_position(source, end);
+        let line_starts = doc.line_starts();
+        let start_pos = offset_to_position(source, line_starts, start);
+        let end_pos = offset_to_position(source, line_starts, end);
         Some(Location {
             uri: (*url).clone(),
             range: Range {
@@ -233,8 +234,9 @@ fn find_references_inner(
             }
         }
 
+        let line_starts = doc.line_starts();
         for span in spans {
-            let start = offset_to_position(source, span.start);
+            let start = offset_to_position(source, line_starts, span.start);
             let end = Position {
                 line: start.line,
                 character: start.character

--- a/src/references.rs
+++ b/src/references.rs
@@ -4,8 +4,7 @@ use std::sync::Arc;
 use php_ast::{ClassMemberKind, EnumMemberKind, NamespaceBody, Span, Stmt, StmtKind};
 use tower_lsp::lsp_types::{Location, Position, Range, Url};
 
-use crate::ast::str_offset;
-use crate::ast::{ParsedDoc, offset_to_position};
+use crate::ast::{ParsedDoc, str_offset};
 use crate::walk::{
     class_refs_in_stmts, function_refs_in_stmts, method_refs_in_stmts, refs_in_stmts,
     refs_in_stmts_with_use,
@@ -72,10 +71,9 @@ pub fn find_references_codebase(
 
     let spans_to_location = |file: &str, start: u32, end: u32| -> Option<Location> {
         let (url, doc) = doc_map.get(file)?;
-        let source = doc.source();
-        let line_starts = doc.line_starts();
-        let start_pos = offset_to_position(source, line_starts, start);
-        let end_pos = offset_to_position(source, line_starts, end);
+        let sv = doc.view();
+        let start_pos = sv.position_of(start);
+        let end_pos = sv.position_of(end);
         Some(Location {
             uri: (*url).clone(),
             range: Range {
@@ -234,9 +232,9 @@ fn find_references_inner(
             }
         }
 
-        let line_starts = doc.line_starts();
+        let sv = doc.view();
         for span in spans {
-            let start = offset_to_position(source, line_starts, span.start);
+            let start = sv.position_of(span.start);
             let end = Position {
                 line: start.line,
                 character: start.character

--- a/src/rename.rs
+++ b/src/rename.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use tower_lsp::lsp_types::{Position, Range, TextEdit, Url, WorkspaceEdit};
 
-use crate::ast::{ParsedDoc, offset_to_position};
+use crate::ast::ParsedDoc;
 use crate::references::find_references_with_use;
 use crate::util::utf16_pos_to_byte;
 use crate::walk::{collect_var_refs_in_scope, property_refs_in_stmts};
@@ -83,7 +83,7 @@ pub fn rename_variable(
 
     let byte_off = utf16_pos_to_byte(source, position);
     let stmts = &doc.program().stmts;
-    let line_starts = doc.line_starts();
+    let sv = doc.view();
 
     let mut spans = Vec::new();
     collect_var_refs_in_scope(stmts, bare, byte_off, &mut spans);
@@ -92,8 +92,8 @@ pub fn rename_variable(
     let mut edits: Vec<TextEdit> = spans
         .into_iter()
         .filter_map(|span| {
-            let start = offset_to_position(source, line_starts, span.start);
-            let end = offset_to_position(source, line_starts, span.end);
+            let start = sv.position_of(span.start);
+            let end = sv.position_of(span.end);
             seen.insert((start.line, start.character))
                 .then_some(TextEdit {
                     range: Range { start, end },
@@ -128,17 +128,16 @@ pub fn rename_property(
 ) -> WorkspaceEdit {
     let mut changes: HashMap<Url, Vec<TextEdit>> = HashMap::new();
     for (uri, doc) in all_docs {
-        let source = doc.source();
-        let line_starts = doc.line_starts();
+        let sv = doc.view();
         let mut spans = Vec::new();
-        property_refs_in_stmts(source, &doc.program().stmts, prop_name, &mut spans);
+        property_refs_in_stmts(sv.source(), &doc.program().stmts, prop_name, &mut spans);
         if !spans.is_empty() {
             let mut seen = std::collections::HashSet::new();
             let mut edits: Vec<TextEdit> = spans
                 .into_iter()
                 .filter_map(|span| {
-                    let start = offset_to_position(source, line_starts, span.start);
-                    let end = offset_to_position(source, line_starts, span.end);
+                    let start = sv.position_of(span.start);
+                    let end = sv.position_of(span.end);
                     seen.insert((start.line, start.character))
                         .then_some(TextEdit {
                             range: Range { start, end },

--- a/src/rename.rs
+++ b/src/rename.rs
@@ -83,6 +83,7 @@ pub fn rename_variable(
 
     let byte_off = utf16_pos_to_byte(source, position);
     let stmts = &doc.program().stmts;
+    let line_starts = doc.line_starts();
 
     let mut spans = Vec::new();
     collect_var_refs_in_scope(stmts, bare, byte_off, &mut spans);
@@ -91,8 +92,8 @@ pub fn rename_variable(
     let mut edits: Vec<TextEdit> = spans
         .into_iter()
         .filter_map(|span| {
-            let start = offset_to_position(source, span.start);
-            let end = offset_to_position(source, span.end);
+            let start = offset_to_position(source, line_starts, span.start);
+            let end = offset_to_position(source, line_starts, span.end);
             seen.insert((start.line, start.character))
                 .then_some(TextEdit {
                     range: Range { start, end },
@@ -128,6 +129,7 @@ pub fn rename_property(
     let mut changes: HashMap<Url, Vec<TextEdit>> = HashMap::new();
     for (uri, doc) in all_docs {
         let source = doc.source();
+        let line_starts = doc.line_starts();
         let mut spans = Vec::new();
         property_refs_in_stmts(source, &doc.program().stmts, prop_name, &mut spans);
         if !spans.is_empty() {
@@ -135,8 +137,8 @@ pub fn rename_property(
             let mut edits: Vec<TextEdit> = spans
                 .into_iter()
                 .filter_map(|span| {
-                    let start = offset_to_position(source, span.start);
-                    let end = offset_to_position(source, span.end);
+                    let start = offset_to_position(source, line_starts, span.start);
+                    let end = offset_to_position(source, line_starts, span.end);
                     seen.insert((start.line, start.character))
                         .then_some(TextEdit {
                             range: Range { start, end },

--- a/src/selection_range.rs
+++ b/src/selection_range.rs
@@ -10,10 +10,11 @@ pub fn selection_ranges(
     doc: &ParsedDoc,
     positions: &[Position],
 ) -> Vec<SelectionRange> {
+    let line_starts = doc.line_starts();
     let fr = file_range(source);
     positions
         .iter()
-        .map(|pos| build_chain(source, &doc.program().stmts, *pos, fr))
+        .map(|pos| build_chain(source, line_starts, &doc.program().stmts, *pos, fr))
         .collect()
 }
 
@@ -40,9 +41,15 @@ fn file_range(source: &str) -> Range {
 }
 
 /// Build the innermost-to-outermost chain for a cursor position.
-fn build_chain(source: &str, stmts: &[Stmt<'_, '_>], pos: Position, fr: Range) -> SelectionRange {
+fn build_chain(
+    source: &str,
+    line_starts: &[u32],
+    stmts: &[Stmt<'_, '_>],
+    pos: Position,
+    fr: Range,
+) -> SelectionRange {
     let mut ranges: Vec<Range> = Vec::new();
-    collect_ranges_stmts(source, stmts, pos, &mut ranges);
+    collect_ranges_stmts(source, line_starts, stmts, pos, &mut ranges);
 
     // Sort from smallest span to largest (innermost first)
     ranges.sort_by_key(|r| {
@@ -90,28 +97,40 @@ fn contains(range: Range, pos: Position) -> bool {
     true
 }
 
-fn span_range(source: &str, start: u32, end: u32) -> Range {
+fn span_range(source: &str, line_starts: &[u32], start: u32, end: u32) -> Range {
     Range {
-        start: offset_to_position(source, start),
-        end: offset_to_position(source, end),
+        start: offset_to_position(source, line_starts, start),
+        end: offset_to_position(source, line_starts, end),
     }
 }
 
-fn collect_ranges_stmts(source: &str, stmts: &[Stmt<'_, '_>], pos: Position, out: &mut Vec<Range>) {
+fn collect_ranges_stmts(
+    source: &str,
+    line_starts: &[u32],
+    stmts: &[Stmt<'_, '_>],
+    pos: Position,
+    out: &mut Vec<Range>,
+) {
     for stmt in stmts {
-        collect_ranges_stmt(source, stmt, pos, out);
+        collect_ranges_stmt(source, line_starts, stmt, pos, out);
     }
 }
 
-fn collect_ranges_stmt(source: &str, stmt: &Stmt<'_, '_>, pos: Position, out: &mut Vec<Range>) {
-    let range = span_range(source, stmt.span.start, stmt.span.end);
+fn collect_ranges_stmt(
+    source: &str,
+    line_starts: &[u32],
+    stmt: &Stmt<'_, '_>,
+    pos: Position,
+    out: &mut Vec<Range>,
+) {
+    let range = span_range(source, line_starts, stmt.span.start, stmt.span.end);
     match &stmt.kind {
         StmtKind::Function(f) => {
             if !contains(range, pos) {
                 return;
             }
             out.push(range);
-            collect_ranges_stmts(source, &f.body, pos, out);
+            collect_ranges_stmts(source, line_starts, &f.body, pos, out);
         }
         StmtKind::Class(c) => {
             if !contains(range, pos) {
@@ -119,7 +138,7 @@ fn collect_ranges_stmt(source: &str, stmt: &Stmt<'_, '_>, pos: Position, out: &m
             }
             out.push(range);
             for member in c.members.iter() {
-                let m_range = span_range(source, member.span.start, member.span.end);
+                let m_range = span_range(source, line_starts, member.span.start, member.span.end);
                 if !contains(m_range, pos) {
                     continue;
                 }
@@ -127,7 +146,7 @@ fn collect_ranges_stmt(source: &str, stmt: &Stmt<'_, '_>, pos: Position, out: &m
                 if let ClassMemberKind::Method(m) = &member.kind
                     && let Some(body) = &m.body
                 {
-                    collect_ranges_stmts(source, body, pos, out);
+                    collect_ranges_stmts(source, line_starts, body, pos, out);
                 }
             }
         }
@@ -135,7 +154,8 @@ fn collect_ranges_stmt(source: &str, stmt: &Stmt<'_, '_>, pos: Position, out: &m
             if contains(range, pos) {
                 out.push(range);
                 for member in i.members.iter() {
-                    let m_range = span_range(source, member.span.start, member.span.end);
+                    let m_range =
+                        span_range(source, line_starts, member.span.start, member.span.end);
                     if contains(m_range, pos) {
                         out.push(m_range);
                     }
@@ -148,7 +168,7 @@ fn collect_ranges_stmt(source: &str, stmt: &Stmt<'_, '_>, pos: Position, out: &m
             }
             out.push(range);
             for member in t.members.iter() {
-                let m_range = span_range(source, member.span.start, member.span.end);
+                let m_range = span_range(source, line_starts, member.span.start, member.span.end);
                 if !contains(m_range, pos) {
                     continue;
                 }
@@ -156,7 +176,7 @@ fn collect_ranges_stmt(source: &str, stmt: &Stmt<'_, '_>, pos: Position, out: &m
                 if let ClassMemberKind::Method(m) = &member.kind
                     && let Some(body) = &m.body
                 {
-                    collect_ranges_stmts(source, body, pos, out);
+                    collect_ranges_stmts(source, line_starts, body, pos, out);
                 }
             }
         }
@@ -166,7 +186,7 @@ fn collect_ranges_stmt(source: &str, stmt: &Stmt<'_, '_>, pos: Position, out: &m
             }
             out.push(range);
             for member in e.members.iter() {
-                let m_range = span_range(source, member.span.start, member.span.end);
+                let m_range = span_range(source, line_starts, member.span.start, member.span.end);
                 if !contains(m_range, pos) {
                     continue;
                 }
@@ -174,7 +194,7 @@ fn collect_ranges_stmt(source: &str, stmt: &Stmt<'_, '_>, pos: Position, out: &m
                 if let EnumMemberKind::Method(m) = &member.kind
                     && let Some(body) = &m.body
                 {
-                    collect_ranges_stmts(source, body, pos, out);
+                    collect_ranges_stmts(source, line_starts, body, pos, out);
                 }
             }
         }
@@ -184,7 +204,7 @@ fn collect_ranges_stmt(source: &str, stmt: &Stmt<'_, '_>, pos: Position, out: &m
             }
             out.push(range);
             if let NamespaceBody::Braced(inner) = &ns.body {
-                collect_ranges_stmts(source, inner, pos, out);
+                collect_ranges_stmts(source, line_starts, inner, pos, out);
             }
         }
         StmtKind::If(i) => {
@@ -192,36 +212,36 @@ fn collect_ranges_stmt(source: &str, stmt: &Stmt<'_, '_>, pos: Position, out: &m
                 return;
             }
             out.push(range);
-            collect_ranges_stmt(source, i.then_branch, pos, out);
+            collect_ranges_stmt(source, line_starts, i.then_branch, pos, out);
             for ei in i.elseif_branches.iter() {
-                collect_ranges_stmt(source, &ei.body, pos, out);
+                collect_ranges_stmt(source, line_starts, &ei.body, pos, out);
             }
             if let Some(e) = &i.else_branch {
-                collect_ranges_stmt(source, e, pos, out);
+                collect_ranges_stmt(source, line_starts, e, pos, out);
             }
         }
         StmtKind::While(w) => {
             if contains(range, pos) {
                 out.push(range);
-                collect_ranges_stmt(source, w.body, pos, out);
+                collect_ranges_stmt(source, line_starts, w.body, pos, out);
             }
         }
         StmtKind::For(f) => {
             if contains(range, pos) {
                 out.push(range);
-                collect_ranges_stmt(source, f.body, pos, out);
+                collect_ranges_stmt(source, line_starts, f.body, pos, out);
             }
         }
         StmtKind::Foreach(f) => {
             if contains(range, pos) {
                 out.push(range);
-                collect_ranges_stmt(source, f.body, pos, out);
+                collect_ranges_stmt(source, line_starts, f.body, pos, out);
             }
         }
         StmtKind::DoWhile(d) => {
             if contains(range, pos) {
                 out.push(range);
-                collect_ranges_stmt(source, d.body, pos, out);
+                collect_ranges_stmt(source, line_starts, d.body, pos, out);
             }
         }
         StmtKind::TryCatch(t) => {
@@ -229,18 +249,18 @@ fn collect_ranges_stmt(source: &str, stmt: &Stmt<'_, '_>, pos: Position, out: &m
                 return;
             }
             out.push(range);
-            collect_ranges_stmts(source, &t.body, pos, out);
+            collect_ranges_stmts(source, line_starts, &t.body, pos, out);
             for catch in t.catches.iter() {
-                collect_ranges_stmts(source, &catch.body, pos, out);
+                collect_ranges_stmts(source, line_starts, &catch.body, pos, out);
             }
             if let Some(finally) = &t.finally {
-                collect_ranges_stmts(source, finally, pos, out);
+                collect_ranges_stmts(source, line_starts, finally, pos, out);
             }
         }
         StmtKind::Block(stmts) => {
             if contains(range, pos) {
                 out.push(range);
-                collect_ranges_stmts(source, stmts, pos, out);
+                collect_ranges_stmts(source, line_starts, stmts, pos, out);
             }
         }
         _ => {}

--- a/src/selection_range.rs
+++ b/src/selection_range.rs
@@ -1,20 +1,20 @@
 use php_ast::{ClassMemberKind, EnumMemberKind, NamespaceBody, Stmt, StmtKind};
 use tower_lsp::lsp_types::{Position, Range, SelectionRange};
 
-use crate::ast::{ParsedDoc, offset_to_position};
+use crate::ast::{ParsedDoc, SourceView};
 
 /// Build a selection-range chain for each cursor position.
 /// Levels go from innermost to outermost via `parent` links.
 pub fn selection_ranges(
-    source: &str,
+    _source: &str,
     doc: &ParsedDoc,
     positions: &[Position],
 ) -> Vec<SelectionRange> {
-    let line_starts = doc.line_starts();
-    let fr = file_range(source);
+    let sv = doc.view();
+    let fr = file_range(sv.source());
     positions
         .iter()
-        .map(|pos| build_chain(source, line_starts, &doc.program().stmts, *pos, fr))
+        .map(|pos| build_chain(sv, &doc.program().stmts, *pos, fr))
         .collect()
 }
 
@@ -42,14 +42,13 @@ fn file_range(source: &str) -> Range {
 
 /// Build the innermost-to-outermost chain for a cursor position.
 fn build_chain(
-    source: &str,
-    line_starts: &[u32],
+    sv: SourceView<'_>,
     stmts: &[Stmt<'_, '_>],
     pos: Position,
     fr: Range,
 ) -> SelectionRange {
     let mut ranges: Vec<Range> = Vec::new();
-    collect_ranges_stmts(source, line_starts, stmts, pos, &mut ranges);
+    collect_ranges_stmts(sv, stmts, pos, &mut ranges);
 
     // Sort from smallest span to largest (innermost first)
     ranges.sort_by_key(|r| {
@@ -97,40 +96,38 @@ fn contains(range: Range, pos: Position) -> bool {
     true
 }
 
-fn span_range(source: &str, line_starts: &[u32], start: u32, end: u32) -> Range {
+fn span_range(sv: SourceView<'_>, start: u32, end: u32) -> Range {
     Range {
-        start: offset_to_position(source, line_starts, start),
-        end: offset_to_position(source, line_starts, end),
+        start: sv.position_of(start),
+        end: sv.position_of(end),
     }
 }
 
 fn collect_ranges_stmts(
-    source: &str,
-    line_starts: &[u32],
+    sv: SourceView<'_>,
     stmts: &[Stmt<'_, '_>],
     pos: Position,
     out: &mut Vec<Range>,
 ) {
     for stmt in stmts {
-        collect_ranges_stmt(source, line_starts, stmt, pos, out);
+        collect_ranges_stmt(sv, stmt, pos, out);
     }
 }
 
 fn collect_ranges_stmt(
-    source: &str,
-    line_starts: &[u32],
+    sv: SourceView<'_>,
     stmt: &Stmt<'_, '_>,
     pos: Position,
     out: &mut Vec<Range>,
 ) {
-    let range = span_range(source, line_starts, stmt.span.start, stmt.span.end);
+    let range = span_range(sv, stmt.span.start, stmt.span.end);
     match &stmt.kind {
         StmtKind::Function(f) => {
             if !contains(range, pos) {
                 return;
             }
             out.push(range);
-            collect_ranges_stmts(source, line_starts, &f.body, pos, out);
+            collect_ranges_stmts(sv, &f.body, pos, out);
         }
         StmtKind::Class(c) => {
             if !contains(range, pos) {
@@ -138,7 +135,7 @@ fn collect_ranges_stmt(
             }
             out.push(range);
             for member in c.members.iter() {
-                let m_range = span_range(source, line_starts, member.span.start, member.span.end);
+                let m_range = span_range(sv, member.span.start, member.span.end);
                 if !contains(m_range, pos) {
                     continue;
                 }
@@ -146,7 +143,7 @@ fn collect_ranges_stmt(
                 if let ClassMemberKind::Method(m) = &member.kind
                     && let Some(body) = &m.body
                 {
-                    collect_ranges_stmts(source, line_starts, body, pos, out);
+                    collect_ranges_stmts(sv, body, pos, out);
                 }
             }
         }
@@ -154,8 +151,7 @@ fn collect_ranges_stmt(
             if contains(range, pos) {
                 out.push(range);
                 for member in i.members.iter() {
-                    let m_range =
-                        span_range(source, line_starts, member.span.start, member.span.end);
+                    let m_range = span_range(sv, member.span.start, member.span.end);
                     if contains(m_range, pos) {
                         out.push(m_range);
                     }
@@ -168,7 +164,7 @@ fn collect_ranges_stmt(
             }
             out.push(range);
             for member in t.members.iter() {
-                let m_range = span_range(source, line_starts, member.span.start, member.span.end);
+                let m_range = span_range(sv, member.span.start, member.span.end);
                 if !contains(m_range, pos) {
                     continue;
                 }
@@ -176,7 +172,7 @@ fn collect_ranges_stmt(
                 if let ClassMemberKind::Method(m) = &member.kind
                     && let Some(body) = &m.body
                 {
-                    collect_ranges_stmts(source, line_starts, body, pos, out);
+                    collect_ranges_stmts(sv, body, pos, out);
                 }
             }
         }
@@ -186,7 +182,7 @@ fn collect_ranges_stmt(
             }
             out.push(range);
             for member in e.members.iter() {
-                let m_range = span_range(source, line_starts, member.span.start, member.span.end);
+                let m_range = span_range(sv, member.span.start, member.span.end);
                 if !contains(m_range, pos) {
                     continue;
                 }
@@ -194,7 +190,7 @@ fn collect_ranges_stmt(
                 if let EnumMemberKind::Method(m) = &member.kind
                     && let Some(body) = &m.body
                 {
-                    collect_ranges_stmts(source, line_starts, body, pos, out);
+                    collect_ranges_stmts(sv, body, pos, out);
                 }
             }
         }
@@ -204,7 +200,7 @@ fn collect_ranges_stmt(
             }
             out.push(range);
             if let NamespaceBody::Braced(inner) = &ns.body {
-                collect_ranges_stmts(source, line_starts, inner, pos, out);
+                collect_ranges_stmts(sv, inner, pos, out);
             }
         }
         StmtKind::If(i) => {
@@ -212,36 +208,36 @@ fn collect_ranges_stmt(
                 return;
             }
             out.push(range);
-            collect_ranges_stmt(source, line_starts, i.then_branch, pos, out);
+            collect_ranges_stmt(sv, i.then_branch, pos, out);
             for ei in i.elseif_branches.iter() {
-                collect_ranges_stmt(source, line_starts, &ei.body, pos, out);
+                collect_ranges_stmt(sv, &ei.body, pos, out);
             }
             if let Some(e) = &i.else_branch {
-                collect_ranges_stmt(source, line_starts, e, pos, out);
+                collect_ranges_stmt(sv, e, pos, out);
             }
         }
         StmtKind::While(w) => {
             if contains(range, pos) {
                 out.push(range);
-                collect_ranges_stmt(source, line_starts, w.body, pos, out);
+                collect_ranges_stmt(sv, w.body, pos, out);
             }
         }
         StmtKind::For(f) => {
             if contains(range, pos) {
                 out.push(range);
-                collect_ranges_stmt(source, line_starts, f.body, pos, out);
+                collect_ranges_stmt(sv, f.body, pos, out);
             }
         }
         StmtKind::Foreach(f) => {
             if contains(range, pos) {
                 out.push(range);
-                collect_ranges_stmt(source, line_starts, f.body, pos, out);
+                collect_ranges_stmt(sv, f.body, pos, out);
             }
         }
         StmtKind::DoWhile(d) => {
             if contains(range, pos) {
                 out.push(range);
-                collect_ranges_stmt(source, line_starts, d.body, pos, out);
+                collect_ranges_stmt(sv, d.body, pos, out);
             }
         }
         StmtKind::TryCatch(t) => {
@@ -249,18 +245,18 @@ fn collect_ranges_stmt(
                 return;
             }
             out.push(range);
-            collect_ranges_stmts(source, line_starts, &t.body, pos, out);
+            collect_ranges_stmts(sv, &t.body, pos, out);
             for catch in t.catches.iter() {
-                collect_ranges_stmts(source, line_starts, &catch.body, pos, out);
+                collect_ranges_stmts(sv, &catch.body, pos, out);
             }
             if let Some(finally) = &t.finally {
-                collect_ranges_stmts(source, line_starts, finally, pos, out);
+                collect_ranges_stmts(sv, finally, pos, out);
             }
         }
         StmtKind::Block(stmts) => {
             if contains(range, pos) {
                 out.push(range);
-                collect_ranges_stmts(source, line_starts, stmts, pos, out);
+                collect_ranges_stmts(sv, stmts, pos, out);
             }
         }
         _ => {}

--- a/src/semantic_diagnostics.rs
+++ b/src/semantic_diagnostics.rs
@@ -176,16 +176,24 @@ pub fn deprecated_call_diagnostics(
     if !cfg.enabled || !cfg.deprecated_calls {
         return vec![];
     }
+    let line_starts = doc.line_starts();
     let mut diags = Vec::new();
     let all_sources: Vec<(&str, &ParsedDoc)> = std::iter::once((source, doc))
         .chain(other_docs.iter().map(|d| (d.source(), d.as_ref())))
         .collect();
-    collect_deprecated_calls(source, &doc.program().stmts, &all_sources, &mut diags);
+    collect_deprecated_calls(
+        source,
+        line_starts,
+        &doc.program().stmts,
+        &all_sources,
+        &mut diags,
+    );
     diags
 }
 
 fn collect_deprecated_calls(
     source: &str,
+    line_starts: &[u32],
     stmts: &[Stmt<'_, '_>],
     all_sources: &[(&str, &ParsedDoc)],
     diags: &mut Vec<Diagnostic>,
@@ -193,22 +201,22 @@ fn collect_deprecated_calls(
     for stmt in stmts {
         match &stmt.kind {
             StmtKind::Expression(e) => {
-                check_expr_for_deprecated(source, e, all_sources, diags);
+                check_expr_for_deprecated(source, line_starts, e, all_sources, diags);
             }
             StmtKind::Namespace(ns) => {
                 if let NamespaceBody::Braced(inner) = &ns.body {
-                    collect_deprecated_calls(source, inner, all_sources, diags);
+                    collect_deprecated_calls(source, line_starts, inner, all_sources, diags);
                 }
             }
             StmtKind::Function(f) => {
-                collect_deprecated_calls(source, &f.body, all_sources, diags);
+                collect_deprecated_calls(source, line_starts, &f.body, all_sources, diags);
             }
             StmtKind::Class(c) => {
                 for member in c.members.iter() {
                     if let ClassMemberKind::Method(m) = &member.kind
                         && let Some(body) = &m.body
                     {
-                        collect_deprecated_calls(source, body, all_sources, diags);
+                        collect_deprecated_calls(source, line_starts, body, all_sources, diags);
                     }
                 }
             }
@@ -217,7 +225,7 @@ fn collect_deprecated_calls(
                     if let ClassMemberKind::Method(m) = &member.kind
                         && let Some(body) = &m.body
                     {
-                        collect_deprecated_calls(source, body, all_sources, diags);
+                        collect_deprecated_calls(source, line_starts, body, all_sources, diags);
                     }
                 }
             }
@@ -226,7 +234,7 @@ fn collect_deprecated_calls(
                     if let EnumMemberKind::Method(m) = &member.kind
                         && let Some(body) = &m.body
                     {
-                        collect_deprecated_calls(source, body, all_sources, diags);
+                        collect_deprecated_calls(source, line_starts, body, all_sources, diags);
                     }
                 }
             }
@@ -237,12 +245,13 @@ fn collect_deprecated_calls(
 
 fn check_expr_for_deprecated(
     source: &str,
+    line_starts: &[u32],
     expr: &php_ast::Expr<'_, '_>,
     all_sources: &[(&str, &ParsedDoc)],
     diags: &mut Vec<Diagnostic>,
 ) {
     if let ExprKind::Assign(a) = &expr.kind {
-        check_expr_for_deprecated(source, a.value, all_sources, diags);
+        check_expr_for_deprecated(source, line_starts, a.value, all_sources, diags);
         return;
     }
     if let ExprKind::FunctionCall(call) = &expr.kind {
@@ -255,8 +264,9 @@ fn check_expr_for_deprecated(
                 {
                     let db = parse_docblock(&raw);
                     if db.is_deprecated() {
-                        let start_pos = offset_to_position(source, call.name.span.start);
-                        let end_pos = offset_to_position(source, call.name.span.end);
+                        let start_pos =
+                            offset_to_position(source, line_starts, call.name.span.start);
+                        let end_pos = offset_to_position(source, line_starts, call.name.span.end);
                         let msg = match &db.deprecated {
                             Some(m) if !m.is_empty() => {
                                 format!("Deprecated: {} — {}", func_name.as_str(), m)
@@ -286,7 +296,7 @@ fn check_expr_for_deprecated(
         }
         // Recurse into arguments so nested calls are also checked.
         for arg in call.args.iter() {
-            check_expr_for_deprecated(source, &arg.value, all_sources, diags);
+            check_expr_for_deprecated(source, line_starts, &arg.value, all_sources, diags);
         }
     }
     if let ExprKind::MethodCall(call) = &expr.kind {
@@ -298,8 +308,9 @@ fn check_expr_for_deprecated(
                 {
                     let db = parse_docblock(&raw);
                     if db.is_deprecated() {
-                        let start_pos = offset_to_position(source, call.method.span.start);
-                        let end_pos = offset_to_position(source, call.method.span.end);
+                        let start_pos =
+                            offset_to_position(source, line_starts, call.method.span.start);
+                        let end_pos = offset_to_position(source, line_starts, call.method.span.end);
                         let msg = match &db.deprecated {
                             Some(m) if !m.is_empty() => {
                                 format!("Deprecated: {} — {}", method_name.as_str(), m)
@@ -328,9 +339,9 @@ fn check_expr_for_deprecated(
             }
         }
         // Recurse into object and arguments so nested calls are also checked.
-        check_expr_for_deprecated(source, call.object, all_sources, diags);
+        check_expr_for_deprecated(source, line_starts, call.object, all_sources, diags);
         for arg in call.args.iter() {
-            check_expr_for_deprecated(source, &arg.value, all_sources, diags);
+            check_expr_for_deprecated(source, line_starts, &arg.value, all_sources, diags);
         }
     }
 }
@@ -414,14 +425,23 @@ pub fn duplicate_declaration_diagnostics(
     if !cfg.enabled || !cfg.duplicate_declarations {
         return vec![];
     }
+    let line_starts = doc.line_starts();
     let mut seen: std::collections::HashMap<String, ()> = std::collections::HashMap::new();
     let mut diags = Vec::new();
-    collect_duplicate_decls(source, &doc.program().stmts, "", &mut seen, &mut diags);
+    collect_duplicate_decls(
+        source,
+        line_starts,
+        &doc.program().stmts,
+        "",
+        &mut seen,
+        &mut diags,
+    );
     diags
 }
 
 fn collect_duplicate_decls(
     source: &str,
+    line_starts: &[u32],
     stmts: &[php_ast::Stmt<'_, '_>],
     current_ns: &str,
     seen: &mut std::collections::HashMap<String, ()>,
@@ -450,7 +470,7 @@ fn collect_duplicate_decls(
                         } else {
                             format!("{}\\{}", current_ns, ns_name)
                         };
-                        collect_duplicate_decls(source, inner, &child_ns, seen, diags);
+                        collect_duplicate_decls(source, line_starts, inner, &child_ns, seen, diags);
                     }
                     php_ast::NamespaceBody::Simple => {
                         // Unbraced namespace: subsequent siblings belong to this namespace.
@@ -479,7 +499,8 @@ fn collect_duplicate_decls(
                     .map(|off| span_start + off as u32)
                     .unwrap_or(span_start);
 
-                let start_pos = crate::ast::offset_to_position(source, name_byte_offset);
+                let start_pos =
+                    crate::ast::offset_to_position(source, line_starts, name_byte_offset);
                 // Calculate end position by converting UTF-8 character length to UTF-16 code units
                 let name_utf16_len = name.chars().map(|c| c.len_utf16() as u32).sum::<u32>();
                 let end_pos = Position {

--- a/src/semantic_diagnostics.rs
+++ b/src/semantic_diagnostics.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use php_ast::{ClassMemberKind, EnumMemberKind, ExprKind, NamespaceBody, Stmt, StmtKind};
 use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, NumberOrString, Position, Range, Url};
 
-use crate::ast::{ParsedDoc, offset_to_position};
+use crate::ast::{ParsedDoc, SourceView};
 use crate::backend::DiagnosticsConfig;
 use crate::docblock::{docblock_before, parse_docblock};
 
@@ -168,7 +168,7 @@ pub fn index_file_references(uri: &Url, doc: &ParsedDoc, codebase: &mir_codebase
 
 /// Check for deprecated function/method calls and emit Warning diagnostics.
 pub fn deprecated_call_diagnostics(
-    source: &str,
+    _source: &str,
     doc: &ParsedDoc,
     other_docs: &[Arc<ParsedDoc>],
     cfg: &DiagnosticsConfig,
@@ -176,24 +176,17 @@ pub fn deprecated_call_diagnostics(
     if !cfg.enabled || !cfg.deprecated_calls {
         return vec![];
     }
-    let line_starts = doc.line_starts();
+    let sv = doc.view();
     let mut diags = Vec::new();
-    let all_sources: Vec<(&str, &ParsedDoc)> = std::iter::once((source, doc))
+    let all_sources: Vec<(&str, &ParsedDoc)> = std::iter::once((sv.source(), doc))
         .chain(other_docs.iter().map(|d| (d.source(), d.as_ref())))
         .collect();
-    collect_deprecated_calls(
-        source,
-        line_starts,
-        &doc.program().stmts,
-        &all_sources,
-        &mut diags,
-    );
+    collect_deprecated_calls(sv, &doc.program().stmts, &all_sources, &mut diags);
     diags
 }
 
 fn collect_deprecated_calls(
-    source: &str,
-    line_starts: &[u32],
+    sv: SourceView<'_>,
     stmts: &[Stmt<'_, '_>],
     all_sources: &[(&str, &ParsedDoc)],
     diags: &mut Vec<Diagnostic>,
@@ -201,22 +194,22 @@ fn collect_deprecated_calls(
     for stmt in stmts {
         match &stmt.kind {
             StmtKind::Expression(e) => {
-                check_expr_for_deprecated(source, line_starts, e, all_sources, diags);
+                check_expr_for_deprecated(sv, e, all_sources, diags);
             }
             StmtKind::Namespace(ns) => {
                 if let NamespaceBody::Braced(inner) = &ns.body {
-                    collect_deprecated_calls(source, line_starts, inner, all_sources, diags);
+                    collect_deprecated_calls(sv, inner, all_sources, diags);
                 }
             }
             StmtKind::Function(f) => {
-                collect_deprecated_calls(source, line_starts, &f.body, all_sources, diags);
+                collect_deprecated_calls(sv, &f.body, all_sources, diags);
             }
             StmtKind::Class(c) => {
                 for member in c.members.iter() {
                     if let ClassMemberKind::Method(m) = &member.kind
                         && let Some(body) = &m.body
                     {
-                        collect_deprecated_calls(source, line_starts, body, all_sources, diags);
+                        collect_deprecated_calls(sv, body, all_sources, diags);
                     }
                 }
             }
@@ -225,7 +218,7 @@ fn collect_deprecated_calls(
                     if let ClassMemberKind::Method(m) = &member.kind
                         && let Some(body) = &m.body
                     {
-                        collect_deprecated_calls(source, line_starts, body, all_sources, diags);
+                        collect_deprecated_calls(sv, body, all_sources, diags);
                     }
                 }
             }
@@ -234,7 +227,7 @@ fn collect_deprecated_calls(
                     if let EnumMemberKind::Method(m) = &member.kind
                         && let Some(body) = &m.body
                     {
-                        collect_deprecated_calls(source, line_starts, body, all_sources, diags);
+                        collect_deprecated_calls(sv, body, all_sources, diags);
                     }
                 }
             }
@@ -244,14 +237,13 @@ fn collect_deprecated_calls(
 }
 
 fn check_expr_for_deprecated(
-    source: &str,
-    line_starts: &[u32],
+    sv: SourceView<'_>,
     expr: &php_ast::Expr<'_, '_>,
     all_sources: &[(&str, &ParsedDoc)],
     diags: &mut Vec<Diagnostic>,
 ) {
     if let ExprKind::Assign(a) = &expr.kind {
-        check_expr_for_deprecated(source, line_starts, a.value, all_sources, diags);
+        check_expr_for_deprecated(sv, a.value, all_sources, diags);
         return;
     }
     if let ExprKind::FunctionCall(call) = &expr.kind {
@@ -264,9 +256,8 @@ fn check_expr_for_deprecated(
                 {
                     let db = parse_docblock(&raw);
                     if db.is_deprecated() {
-                        let start_pos =
-                            offset_to_position(source, line_starts, call.name.span.start);
-                        let end_pos = offset_to_position(source, line_starts, call.name.span.end);
+                        let start_pos = sv.position_of(call.name.span.start);
+                        let end_pos = sv.position_of(call.name.span.end);
                         let msg = match &db.deprecated {
                             Some(m) if !m.is_empty() => {
                                 format!("Deprecated: {} — {}", func_name.as_str(), m)
@@ -296,7 +287,7 @@ fn check_expr_for_deprecated(
         }
         // Recurse into arguments so nested calls are also checked.
         for arg in call.args.iter() {
-            check_expr_for_deprecated(source, line_starts, &arg.value, all_sources, diags);
+            check_expr_for_deprecated(sv, &arg.value, all_sources, diags);
         }
     }
     if let ExprKind::MethodCall(call) = &expr.kind {
@@ -308,9 +299,8 @@ fn check_expr_for_deprecated(
                 {
                     let db = parse_docblock(&raw);
                     if db.is_deprecated() {
-                        let start_pos =
-                            offset_to_position(source, line_starts, call.method.span.start);
-                        let end_pos = offset_to_position(source, line_starts, call.method.span.end);
+                        let start_pos = sv.position_of(call.method.span.start);
+                        let end_pos = sv.position_of(call.method.span.end);
                         let msg = match &db.deprecated {
                             Some(m) if !m.is_empty() => {
                                 format!("Deprecated: {} — {}", method_name.as_str(), m)
@@ -339,9 +329,9 @@ fn check_expr_for_deprecated(
             }
         }
         // Recurse into object and arguments so nested calls are also checked.
-        check_expr_for_deprecated(source, line_starts, call.object, all_sources, diags);
+        check_expr_for_deprecated(sv, call.object, all_sources, diags);
         for arg in call.args.iter() {
-            check_expr_for_deprecated(source, line_starts, &arg.value, all_sources, diags);
+            check_expr_for_deprecated(sv, &arg.value, all_sources, diags);
         }
     }
 }
@@ -418,30 +408,22 @@ fn find_method_span_in_stmts(stmts: &[Stmt<'_, '_>], method_name: &str) -> Optio
 
 /// Check for duplicate class/function/interface/trait/enum declarations.
 pub fn duplicate_declaration_diagnostics(
-    source: &str,
+    _source: &str,
     doc: &ParsedDoc,
     cfg: &DiagnosticsConfig,
 ) -> Vec<Diagnostic> {
     if !cfg.enabled || !cfg.duplicate_declarations {
         return vec![];
     }
-    let line_starts = doc.line_starts();
+    let sv = doc.view();
     let mut seen: std::collections::HashMap<String, ()> = std::collections::HashMap::new();
     let mut diags = Vec::new();
-    collect_duplicate_decls(
-        source,
-        line_starts,
-        &doc.program().stmts,
-        "",
-        &mut seen,
-        &mut diags,
-    );
+    collect_duplicate_decls(sv, &doc.program().stmts, "", &mut seen, &mut diags);
     diags
 }
 
 fn collect_duplicate_decls(
-    source: &str,
-    line_starts: &[u32],
+    sv: SourceView<'_>,
     stmts: &[php_ast::Stmt<'_, '_>],
     current_ns: &str,
     seen: &mut std::collections::HashMap<String, ()>,
@@ -470,7 +452,7 @@ fn collect_duplicate_decls(
                         } else {
                             format!("{}\\{}", current_ns, ns_name)
                         };
-                        collect_duplicate_decls(source, line_starts, inner, &child_ns, seen, diags);
+                        collect_duplicate_decls(sv, inner, &child_ns, seen, diags);
                     }
                     php_ast::NamespaceBody::Simple => {
                         // Unbraced namespace: subsequent siblings belong to this namespace.
@@ -495,12 +477,11 @@ fn collect_duplicate_decls(
                 // Find the byte offset of the actual name by searching forward from span_start.
                 // The span_start points to keywords like "class", "function", etc.,
                 // so we need to find where the identifier name appears.
-                let name_byte_offset = find_name_offset(&source[span_start as usize..], name)
+                let name_byte_offset = find_name_offset(&sv.source()[span_start as usize..], name)
                     .map(|off| span_start + off as u32)
                     .unwrap_or(span_start);
 
-                let start_pos =
-                    crate::ast::offset_to_position(source, line_starts, name_byte_offset);
+                let start_pos = sv.position_of(name_byte_offset);
                 // Calculate end position by converting UTF-8 character length to UTF-16 code units
                 let name_utf16_len = name.chars().map(|c| c.len_utf16() as u32).sum::<u32>();
                 let end_pos = Position {
@@ -524,7 +505,7 @@ fn collect_duplicate_decls(
     }
 }
 
-/// Find the byte offset of an identifier name within a source slice.
+/// Find the byte offset of an identifier name within a sv.source() slice.
 /// Searches for word boundary matches (not substring matches).
 fn find_name_offset(source: &str, name: &str) -> Option<usize> {
     let bytes = source.as_bytes();

--- a/src/semantic_tokens.rs
+++ b/src/semantic_tokens.rs
@@ -63,9 +63,10 @@ pub fn legend() -> SemanticTokensLegend {
 }
 
 pub fn semantic_tokens(source: &str, doc: &ParsedDoc) -> Vec<SemanticToken> {
+    let line_starts = doc.line_starts();
     let mut raw: Vec<RawToken> = Vec::new();
-    collect_comments(source, &mut raw);
-    collect_stmts(source, &doc.program().stmts, &mut raw);
+    collect_comments(source, line_starts, &mut raw);
+    collect_stmts(source, line_starts, &doc.program().stmts, &mut raw);
     raw.sort_by(|a, b| a.0.cmp(&b.0).then(a.1.cmp(&b.1)));
     delta_encode(raw)
 }
@@ -73,9 +74,10 @@ pub fn semantic_tokens(source: &str, doc: &ParsedDoc) -> Vec<SemanticToken> {
 /// Return semantic tokens restricted to the given source range.
 /// Useful for editors that only request tokens for the visible viewport.
 pub fn semantic_tokens_range(source: &str, doc: &ParsedDoc, range: Range) -> Vec<SemanticToken> {
+    let line_starts = doc.line_starts();
     let mut raw: Vec<RawToken> = Vec::new();
-    collect_comments(source, &mut raw);
-    collect_stmts(source, &doc.program().stmts, &mut raw);
+    collect_comments(source, line_starts, &mut raw);
+    collect_stmts(source, line_starts, &doc.program().stmts, &mut raw);
     raw.sort_by(|a, b| a.0.cmp(&b.0).then(a.1.cmp(&b.1)));
 
     let filtered: Vec<RawToken> = raw
@@ -161,20 +163,29 @@ pub fn compute_token_delta(
 fn push_at(
     out: &mut Vec<RawToken>,
     source: &str,
+    line_starts: &[u32],
     offset: u32,
     len: u32,
     token_type: u32,
     modifiers: u32,
 ) {
-    let pos = offset_to_position(source, offset);
+    let pos = offset_to_position(source, line_starts, offset);
     out.push((pos.line, pos.character, len, token_type, modifiers));
 }
 
-fn push_name(out: &mut Vec<RawToken>, source: &str, name: &str, token_type: u32, modifiers: u32) {
+fn push_name(
+    out: &mut Vec<RawToken>,
+    source: &str,
+    line_starts: &[u32],
+    name: &str,
+    token_type: u32,
+    modifiers: u32,
+) {
     let offset = str_offset(source, name);
     push_at(
         out,
         source,
+        line_starts,
         offset,
         name.chars().map(|c| c.len_utf16() as u32).sum::<u32>(),
         token_type,
@@ -186,7 +197,14 @@ fn push_name(out: &mut Vec<RawToken>, source: &str, name: &str, token_type: u32,
 /// precedes the name in the source.  PHP parameter names in the AST are stored
 /// without `$`, but the sigil is part of the syntax and must be highlighted
 /// consistently with variable-expression tokens which include it.
-fn push_param(out: &mut Vec<RawToken>, source: &str, name: &str, token_type: u32, modifiers: u32) {
+fn push_param(
+    out: &mut Vec<RawToken>,
+    source: &str,
+    line_starts: &[u32],
+    name: &str,
+    token_type: u32,
+    modifiers: u32,
+) {
     let name_offset = str_offset(source, name);
     let (offset, extra_len) =
         if name_offset > 0 && source.as_bytes().get(name_offset as usize - 1) == Some(&b'$') {
@@ -197,6 +215,7 @@ fn push_param(out: &mut Vec<RawToken>, source: &str, name: &str, token_type: u32
     push_at(
         out,
         source,
+        line_starts,
         offset,
         extra_len + name.chars().map(|c| c.len_utf16() as u32).sum::<u32>(),
         token_type,
@@ -204,12 +223,17 @@ fn push_param(out: &mut Vec<RawToken>, source: &str, name: &str, token_type: u32
     );
 }
 
-fn push_attributes(out: &mut Vec<RawToken>, source: &str, attrs: &[Attribute<'_, '_>]) {
+fn push_attributes(
+    out: &mut Vec<RawToken>,
+    source: &str,
+    line_starts: &[u32],
+    attrs: &[Attribute<'_, '_>],
+) {
     for attr in attrs.iter() {
         let span = attr.name.span();
         let segment = &source[span.start as usize..span.end as usize];
         let len: u32 = segment.chars().map(|c| c.len_utf16() as u32).sum();
-        push_at(out, source, span.start, len, TT_CLASS, 0);
+        push_at(out, source, line_starts, span.start, len, TT_CLASS, 0);
     }
 }
 
@@ -229,7 +253,7 @@ fn deprecated_mod(source: &str, node_start: u32) -> u32 {
 /// and emit `TT_COMMENT` tokens.  Each physical line of a multi-line comment
 /// is emitted as a separate token because the LSP protocol requires tokens to
 /// fit on a single line.
-fn collect_comments(source: &str, out: &mut Vec<RawToken>) {
+fn collect_comments(source: &str, line_starts: &[u32], out: &mut Vec<RawToken>) {
     let bytes = source.as_bytes();
     let len = bytes.len();
     let mut i = 0usize;
@@ -276,7 +300,15 @@ fn collect_comments(source: &str, out: &mut Vec<RawToken>) {
                     }
                     let text = &source[start..i];
                     let len_utf16: u32 = text.chars().map(|c| c.len_utf16() as u32).sum();
-                    push_at(out, source, start as u32, len_utf16, TT_COMMENT, 0);
+                    push_at(
+                        out,
+                        source,
+                        line_starts,
+                        start as u32,
+                        len_utf16,
+                        TT_COMMENT,
+                        0,
+                    );
                 } else if bytes[i + 1] == b'*' {
                     // Multi-line comment: `/* ... */`
                     let start = i;
@@ -289,7 +321,7 @@ fn collect_comments(source: &str, out: &mut Vec<RawToken>) {
                         i += 2;
                     }
                     // Emit per-line so the LSP single-line constraint is met
-                    emit_multiline_comment(source, start, i, out);
+                    emit_multiline_comment(source, line_starts, start, i, out);
                 } else {
                     i += 1;
                 }
@@ -303,7 +335,15 @@ fn collect_comments(source: &str, out: &mut Vec<RawToken>) {
                 }
                 let text = &source[start..i];
                 let len_utf16: u32 = text.chars().map(|c| c.len_utf16() as u32).sum();
-                push_at(out, source, start as u32, len_utf16, TT_COMMENT, 0);
+                push_at(
+                    out,
+                    source,
+                    line_starts,
+                    start as u32,
+                    len_utf16,
+                    TT_COMMENT,
+                    0,
+                );
             }
             _ => {
                 i += 1;
@@ -314,7 +354,13 @@ fn collect_comments(source: &str, out: &mut Vec<RawToken>) {
 
 /// Emit a `TT_COMMENT` raw token for each line within a block comment
 /// `source[start..end]`.  Multi-line tokens are not allowed by the LSP spec.
-fn emit_multiline_comment(source: &str, start: usize, end: usize, out: &mut Vec<RawToken>) {
+fn emit_multiline_comment(
+    source: &str,
+    line_starts: &[u32],
+    start: usize,
+    end: usize,
+    out: &mut Vec<RawToken>,
+) {
     let text = &source[start..end];
     let mut line_start = start;
     for (rel, ch) in text.char_indices() {
@@ -324,7 +370,15 @@ fn emit_multiline_comment(source: &str, start: usize, end: usize, out: &mut Vec<
                 let segment = &source[line_start..line_end];
                 let len_utf16: u32 = segment.chars().map(|c| c.len_utf16() as u32).sum();
                 if len_utf16 > 0 {
-                    push_at(out, source, line_start as u32, len_utf16, TT_COMMENT, 0);
+                    push_at(
+                        out,
+                        source,
+                        line_starts,
+                        line_start as u32,
+                        len_utf16,
+                        TT_COMMENT,
+                        0,
+                    );
                 }
             }
             line_start = start + rel + 1; // byte after '\n'
@@ -335,7 +389,15 @@ fn emit_multiline_comment(source: &str, start: usize, end: usize, out: &mut Vec<
         let segment = &source[line_start..end];
         let len_utf16: u32 = segment.chars().map(|c| c.len_utf16() as u32).sum();
         if len_utf16 > 0 {
-            push_at(out, source, line_start as u32, len_utf16, TT_COMMENT, 0);
+            push_at(
+                out,
+                source,
+                line_starts,
+                line_start as u32,
+                len_utf16,
+                TT_COMMENT,
+                0,
+            );
         }
     }
 }
@@ -345,170 +407,195 @@ fn emit_multiline_comment(source: &str, start: usize, end: usize, out: &mut Vec<
 /// Keyword types (e.g. `int`, `string`, `void`, `null`) get one token at
 /// the keyword span.  Union/intersection/nullable are recursed into so
 /// every component is covered.
-fn push_type_hint(out: &mut Vec<RawToken>, source: &str, hint: &TypeHint<'_, '_>) {
+fn push_type_hint(
+    out: &mut Vec<RawToken>,
+    source: &str,
+    line_starts: &[u32],
+    hint: &TypeHint<'_, '_>,
+) {
     match &hint.kind {
         TypeHintKind::Named(name) => {
             let span = name.span();
             let segment = &source[span.start as usize..span.end as usize];
             let len: u32 = segment.chars().map(|c| c.len_utf16() as u32).sum();
-            push_at(out, source, span.start, len, TT_TYPE, 0);
+            push_at(out, source, line_starts, span.start, len, TT_TYPE, 0);
         }
         TypeHintKind::Keyword(builtin, span) => {
             let text = builtin.as_str();
             let len_utf16: u32 = text.chars().map(|c| c.len_utf16() as u32).sum();
-            push_at(out, source, span.start, len_utf16, TT_TYPE, 0);
+            push_at(out, source, line_starts, span.start, len_utf16, TT_TYPE, 0);
         }
         TypeHintKind::Nullable(inner) => {
-            push_type_hint(out, source, inner);
+            push_type_hint(out, source, line_starts, inner);
         }
         TypeHintKind::Union(types) | TypeHintKind::Intersection(types) => {
             for t in types.iter() {
-                push_type_hint(out, source, t);
+                push_type_hint(out, source, line_starts, t);
             }
         }
     }
 }
 
-fn collect_stmts(source: &str, stmts: &[Stmt<'_, '_>], out: &mut Vec<RawToken>) {
+fn collect_stmts(
+    source: &str,
+    line_starts: &[u32],
+    stmts: &[Stmt<'_, '_>],
+    out: &mut Vec<RawToken>,
+) {
     for stmt in stmts {
-        collect_stmt(source, stmt, out);
+        collect_stmt(source, line_starts, stmt, out);
     }
 }
 
-fn collect_stmt(source: &str, stmt: &Stmt<'_, '_>, out: &mut Vec<RawToken>) {
+fn collect_stmt(source: &str, line_starts: &[u32], stmt: &Stmt<'_, '_>, out: &mut Vec<RawToken>) {
     match &stmt.kind {
         StmtKind::Function(f) => {
-            push_attributes(out, source, &f.attributes);
+            push_attributes(out, source, line_starts, &f.attributes);
             let mods = MOD_DECLARATION | deprecated_mod(source, stmt.span.start);
-            push_name(out, source, f.name, TT_FUNCTION, mods);
+            push_name(out, source, line_starts, f.name, TT_FUNCTION, mods);
             for p in f.params.iter() {
-                push_attributes(out, source, &p.attributes);
+                push_attributes(out, source, line_starts, &p.attributes);
                 if let Some(th) = &p.type_hint {
-                    push_type_hint(out, source, th);
+                    push_type_hint(out, source, line_starts, th);
                 }
-                push_param(out, source, p.name, TT_PARAMETER, MOD_DECLARATION);
+                push_param(
+                    out,
+                    source,
+                    line_starts,
+                    p.name,
+                    TT_PARAMETER,
+                    MOD_DECLARATION,
+                );
             }
             if let Some(rt) = &f.return_type {
-                push_type_hint(out, source, rt);
+                push_type_hint(out, source, line_starts, rt);
             }
-            collect_stmts(source, &f.body, out);
+            collect_stmts(source, line_starts, &f.body, out);
         }
         StmtKind::Class(c) => {
-            push_attributes(out, source, &c.attributes);
+            push_attributes(out, source, line_starts, &c.attributes);
             if let Some(name) = c.name {
                 let mods = MOD_DECLARATION | deprecated_mod(source, stmt.span.start);
-                push_name(out, source, name, TT_CLASS, mods);
+                push_name(out, source, line_starts, name, TT_CLASS, mods);
             }
             for member in c.members.iter() {
-                collect_class_member(source, member, out);
+                collect_class_member(source, line_starts, member, out);
             }
         }
         StmtKind::Interface(i) => {
-            push_attributes(out, source, &i.attributes);
+            push_attributes(out, source, line_starts, &i.attributes);
             let mods = MOD_DECLARATION | deprecated_mod(source, stmt.span.start);
-            push_name(out, source, i.name, TT_INTERFACE, mods);
+            push_name(out, source, line_starts, i.name, TT_INTERFACE, mods);
         }
         StmtKind::Trait(t) => {
-            push_attributes(out, source, &t.attributes);
+            push_attributes(out, source, line_starts, &t.attributes);
             let mods = MOD_DECLARATION | deprecated_mod(source, stmt.span.start);
-            push_name(out, source, t.name, TT_CLASS, mods);
+            push_name(out, source, line_starts, t.name, TT_CLASS, mods);
             for member in t.members.iter() {
-                collect_class_member(source, member, out);
+                collect_class_member(source, line_starts, member, out);
             }
         }
         StmtKind::Enum(e) => {
-            push_attributes(out, source, &e.attributes);
+            push_attributes(out, source, line_starts, &e.attributes);
             let mods = MOD_DECLARATION | deprecated_mod(source, stmt.span.start);
-            push_name(out, source, e.name, TT_CLASS, mods);
+            push_name(out, source, line_starts, e.name, TT_CLASS, mods);
             for member in e.members.iter() {
                 if let EnumMemberKind::Method(m) = &member.kind {
-                    push_attributes(out, source, &m.attributes);
+                    push_attributes(out, source, line_starts, &m.attributes);
                     let mut mmods = MOD_DECLARATION | deprecated_mod(source, member.span.start);
                     if m.is_static {
                         mmods |= MOD_STATIC;
                     }
-                    push_name(out, source, m.name, TT_METHOD, mmods);
+                    push_name(out, source, line_starts, m.name, TT_METHOD, mmods);
                     for p in m.params.iter() {
                         if let Some(th) = &p.type_hint {
-                            push_type_hint(out, source, th);
+                            push_type_hint(out, source, line_starts, th);
                         }
-                        push_param(out, source, p.name, TT_PARAMETER, MOD_DECLARATION);
+                        push_param(
+                            out,
+                            source,
+                            line_starts,
+                            p.name,
+                            TT_PARAMETER,
+                            MOD_DECLARATION,
+                        );
                     }
                     if let Some(rt) = &m.return_type {
-                        push_type_hint(out, source, rt);
+                        push_type_hint(out, source, line_starts, rt);
                     }
                     if let Some(body) = &m.body {
-                        collect_stmts(source, body, out);
+                        collect_stmts(source, line_starts, body, out);
                     }
                 }
             }
         }
         StmtKind::Namespace(ns) => {
             if let NamespaceBody::Braced(inner) = &ns.body {
-                collect_stmts(source, inner, out);
+                collect_stmts(source, line_starts, inner, out);
             }
         }
         StmtKind::Use(_) => {}
-        StmtKind::Expression(e) => collect_expr(source, e, out),
-        StmtKind::Return(Some(expr)) => collect_expr(source, expr, out),
+        StmtKind::Expression(e) => collect_expr(source, line_starts, e, out),
+        StmtKind::Return(Some(expr)) => collect_expr(source, line_starts, expr, out),
         StmtKind::Return(None) => {}
         StmtKind::Echo(exprs) => {
             for expr in exprs.iter() {
-                collect_expr(source, expr, out);
+                collect_expr(source, line_starts, expr, out);
             }
         }
         StmtKind::If(i) => {
-            collect_expr(source, &i.condition, out);
-            collect_stmt(source, i.then_branch, out);
+            collect_expr(source, line_starts, &i.condition, out);
+            collect_stmt(source, line_starts, i.then_branch, out);
             for ei in i.elseif_branches.iter() {
-                collect_expr(source, &ei.condition, out);
-                collect_stmt(source, &ei.body, out);
+                collect_expr(source, line_starts, &ei.condition, out);
+                collect_stmt(source, line_starts, &ei.body, out);
             }
             if let Some(e) = &i.else_branch {
-                collect_stmt(source, e, out);
+                collect_stmt(source, line_starts, e, out);
             }
         }
         StmtKind::While(w) => {
-            collect_expr(source, &w.condition, out);
-            collect_stmt(source, w.body, out);
+            collect_expr(source, line_starts, &w.condition, out);
+            collect_stmt(source, line_starts, w.body, out);
         }
         StmtKind::For(f) => {
             for e in f.init.iter() {
-                collect_expr(source, e, out);
+                collect_expr(source, line_starts, e, out);
             }
             for cond in f.condition.iter() {
-                collect_expr(source, cond, out);
+                collect_expr(source, line_starts, cond, out);
             }
             for e in f.update.iter() {
-                collect_expr(source, e, out);
+                collect_expr(source, line_starts, e, out);
             }
-            collect_stmt(source, f.body, out);
+            collect_stmt(source, line_starts, f.body, out);
         }
         StmtKind::Foreach(f) => {
-            collect_expr(source, &f.expr, out);
-            collect_stmt(source, f.body, out);
+            collect_expr(source, line_starts, &f.expr, out);
+            collect_stmt(source, line_starts, f.body, out);
         }
         StmtKind::TryCatch(t) => {
-            collect_stmts(source, &t.body, out);
+            collect_stmts(source, line_starts, &t.body, out);
             for catch in t.catches.iter() {
-                collect_stmts(source, &catch.body, out);
+                collect_stmts(source, line_starts, &catch.body, out);
             }
             if let Some(finally) = &t.finally {
-                collect_stmts(source, finally, out);
+                collect_stmts(source, line_starts, finally, out);
             }
         }
-        StmtKind::Block(stmts) => collect_stmts(source, stmts, out),
+        StmtKind::Block(stmts) => collect_stmts(source, line_starts, stmts, out),
         _ => {}
     }
 }
 
 fn collect_class_member(
     source: &str,
+    line_starts: &[u32],
     member: &php_ast::ClassMember<'_, '_>,
     out: &mut Vec<RawToken>,
 ) {
     if let ClassMemberKind::Method(m) = &member.kind {
-        push_attributes(out, source, &m.attributes);
+        push_attributes(out, source, line_starts, &m.attributes);
         let mut mods = MOD_DECLARATION | deprecated_mod(source, member.span.start);
         if m.is_static {
             mods |= MOD_STATIC;
@@ -516,68 +603,95 @@ fn collect_class_member(
         if m.is_abstract {
             mods |= MOD_ABSTRACT;
         }
-        push_name(out, source, m.name, TT_METHOD, mods);
+        push_name(out, source, line_starts, m.name, TT_METHOD, mods);
         for p in m.params.iter() {
-            push_attributes(out, source, &p.attributes);
+            push_attributes(out, source, line_starts, &p.attributes);
             if let Some(th) = &p.type_hint {
-                push_type_hint(out, source, th);
+                push_type_hint(out, source, line_starts, th);
             }
-            push_param(out, source, p.name, TT_PARAMETER, MOD_DECLARATION);
+            push_param(
+                out,
+                source,
+                line_starts,
+                p.name,
+                TT_PARAMETER,
+                MOD_DECLARATION,
+            );
         }
         if let Some(rt) = &m.return_type {
-            push_type_hint(out, source, rt);
+            push_type_hint(out, source, line_starts, rt);
         }
         if let Some(body) = &m.body {
-            collect_stmts(source, body, out);
+            collect_stmts(source, line_starts, body, out);
         }
     } else if let ClassMemberKind::Property(p) = &member.kind {
-        push_attributes(out, source, &p.attributes);
+        push_attributes(out, source, line_starts, &p.attributes);
         if let Some(th) = &p.type_hint {
-            push_type_hint(out, source, th);
+            push_type_hint(out, source, line_starts, th);
         }
-        push_name(out, source, p.name, TT_PROPERTY, MOD_DECLARATION);
+        push_name(
+            out,
+            source,
+            line_starts,
+            p.name,
+            TT_PROPERTY,
+            MOD_DECLARATION,
+        );
     }
 }
 
-fn collect_expr(source: &str, expr: &php_ast::Expr<'_, '_>, out: &mut Vec<RawToken>) {
+fn collect_expr(
+    source: &str,
+    line_starts: &[u32],
+    expr: &php_ast::Expr<'_, '_>,
+    out: &mut Vec<RawToken>,
+) {
     match &expr.kind {
         // ── Literals ──────────────────────────────────────────────────────────
         ExprKind::Int(_) | ExprKind::Float(_) => {
             let span_len = expr.span.end - expr.span.start;
-            push_at(out, source, expr.span.start, span_len, TT_NUMBER, 0);
+            push_at(
+                out,
+                source,
+                line_starts,
+                expr.span.start,
+                span_len,
+                TT_NUMBER,
+                0,
+            );
         }
         ExprKind::String(_) | ExprKind::Nowdoc { .. } => {
             let segment = &source[expr.span.start as usize..expr.span.end as usize];
             let len: u32 = segment.chars().map(|c| c.len_utf16() as u32).sum();
-            push_at(out, source, expr.span.start, len, TT_STRING, 0);
+            push_at(out, source, line_starts, expr.span.start, len, TT_STRING, 0);
         }
         ExprKind::InterpolatedString(parts) | ExprKind::ShellExec(parts) => {
             // Emit the whole span as a string; embedded variables are not
             // re-coloured here to keep the implementation simple.
             let segment = &source[expr.span.start as usize..expr.span.end as usize];
             let len: u32 = segment.chars().map(|c| c.len_utf16() as u32).sum();
-            push_at(out, source, expr.span.start, len, TT_STRING, 0);
+            push_at(out, source, line_starts, expr.span.start, len, TT_STRING, 0);
             // Still recurse into embedded expressions so method/function calls
             // inside `"... {$obj->method()} ..."` get proper tokens.
             for part in parts.iter() {
                 if let php_ast::StringPart::Expr(inner) = part {
-                    collect_expr(source, inner, out);
+                    collect_expr(source, line_starts, inner, out);
                 }
             }
         }
         ExprKind::Heredoc { parts, .. } => {
             let segment = &source[expr.span.start as usize..expr.span.end as usize];
             let len: u32 = segment.chars().map(|c| c.len_utf16() as u32).sum();
-            push_at(out, source, expr.span.start, len, TT_STRING, 0);
+            push_at(out, source, line_starts, expr.span.start, len, TT_STRING, 0);
             for part in parts.iter() {
                 if let php_ast::StringPart::Expr(inner) = part {
-                    collect_expr(source, inner, out);
+                    collect_expr(source, line_starts, inner, out);
                 }
             }
         }
         ExprKind::New(n) => {
             for arg in n.args.iter() {
-                collect_expr(source, &arg.value, out);
+                collect_expr(source, line_starts, &arg.value, out);
             }
         }
         // ── Calls ─────────────────────────────────────────────────────────────
@@ -587,25 +701,27 @@ fn collect_expr(source: &str, expr: &php_ast::Expr<'_, '_>, out: &mut Vec<RawTok
                 push_at(
                     out,
                     source,
+                    line_starts,
                     f.name.span.start,
                     name_str.chars().map(|c| c.len_utf16() as u32).sum::<u32>(),
                     TT_FUNCTION,
                     0,
                 );
             } else {
-                collect_expr(source, f.name, out);
+                collect_expr(source, line_starts, f.name, out);
             }
             for arg in f.args.iter() {
-                collect_expr(source, &arg.value, out);
+                collect_expr(source, line_starts, &arg.value, out);
             }
         }
         ExprKind::MethodCall(m) => {
-            collect_expr(source, m.object, out);
+            collect_expr(source, line_starts, m.object, out);
             if let ExprKind::Identifier(name) = &m.method.kind {
                 let name_str: &str = name;
                 push_at(
                     out,
                     source,
+                    line_starts,
                     m.method.span.start,
                     name_str.chars().map(|c| c.len_utf16() as u32).sum::<u32>(),
                     TT_METHOD,
@@ -613,16 +729,17 @@ fn collect_expr(source: &str, expr: &php_ast::Expr<'_, '_>, out: &mut Vec<RawTok
                 );
             }
             for arg in m.args.iter() {
-                collect_expr(source, &arg.value, out);
+                collect_expr(source, line_starts, &arg.value, out);
             }
         }
         ExprKind::NullsafeMethodCall(m) => {
-            collect_expr(source, m.object, out);
+            collect_expr(source, line_starts, m.object, out);
             if let ExprKind::Identifier(name) = &m.method.kind {
                 let name_str: &str = name;
                 push_at(
                     out,
                     source,
+                    line_starts,
                     m.method.span.start,
                     name_str.chars().map(|c| c.len_utf16() as u32).sum::<u32>(),
                     TT_METHOD,
@@ -630,69 +747,91 @@ fn collect_expr(source: &str, expr: &php_ast::Expr<'_, '_>, out: &mut Vec<RawTok
                 );
             }
             for arg in m.args.iter() {
-                collect_expr(source, &arg.value, out);
+                collect_expr(source, line_starts, &arg.value, out);
             }
         }
         // ── Compound expressions ──────────────────────────────────────────────
         ExprKind::Assign(a) => {
-            collect_expr(source, a.target, out);
-            collect_expr(source, a.value, out);
+            collect_expr(source, line_starts, a.target, out);
+            collect_expr(source, line_starts, a.value, out);
         }
         ExprKind::Ternary(t) => {
-            collect_expr(source, t.condition, out);
+            collect_expr(source, line_starts, t.condition, out);
             if let Some(then_expr) = t.then_expr {
-                collect_expr(source, then_expr, out);
+                collect_expr(source, line_starts, then_expr, out);
             }
-            collect_expr(source, t.else_expr, out);
+            collect_expr(source, line_starts, t.else_expr, out);
         }
         ExprKind::NullCoalesce(n) => {
-            collect_expr(source, n.left, out);
-            collect_expr(source, n.right, out);
+            collect_expr(source, line_starts, n.left, out);
+            collect_expr(source, line_starts, n.right, out);
         }
         ExprKind::Binary(b) => {
-            collect_expr(source, b.left, out);
-            collect_expr(source, b.right, out);
+            collect_expr(source, line_starts, b.left, out);
+            collect_expr(source, line_starts, b.right, out);
         }
-        ExprKind::Parenthesized(e) => collect_expr(source, e, out),
+        ExprKind::Parenthesized(e) => collect_expr(source, line_starts, e, out),
         ExprKind::Array(elements) => {
             for elem in elements.iter() {
                 if let Some(key) = &elem.key {
-                    collect_expr(source, key, out);
+                    collect_expr(source, line_starts, key, out);
                 }
-                collect_expr(source, &elem.value, out);
+                collect_expr(source, line_starts, &elem.value, out);
             }
         }
-        ExprKind::UnaryPrefix(u) => collect_expr(source, u.operand, out),
-        ExprKind::UnaryPostfix(u) => collect_expr(source, u.operand, out),
+        ExprKind::UnaryPrefix(u) => collect_expr(source, line_starts, u.operand, out),
+        ExprKind::UnaryPostfix(u) => collect_expr(source, line_starts, u.operand, out),
         ExprKind::Closure(c) => {
             for p in c.params.iter() {
                 if let Some(th) = &p.type_hint {
-                    push_type_hint(out, source, th);
+                    push_type_hint(out, source, line_starts, th);
                 }
-                push_param(out, source, p.name, TT_PARAMETER, MOD_DECLARATION);
+                push_param(
+                    out,
+                    source,
+                    line_starts,
+                    p.name,
+                    TT_PARAMETER,
+                    MOD_DECLARATION,
+                );
             }
             if let Some(rt) = &c.return_type {
-                push_type_hint(out, source, rt);
+                push_type_hint(out, source, line_starts, rt);
             }
-            collect_stmts(source, &c.body, out);
+            collect_stmts(source, line_starts, &c.body, out);
         }
         ExprKind::ArrowFunction(af) => {
             for p in af.params.iter() {
                 if let Some(th) = &p.type_hint {
-                    push_type_hint(out, source, th);
+                    push_type_hint(out, source, line_starts, th);
                 }
-                push_param(out, source, p.name, TT_PARAMETER, MOD_DECLARATION);
+                push_param(
+                    out,
+                    source,
+                    line_starts,
+                    p.name,
+                    TT_PARAMETER,
+                    MOD_DECLARATION,
+                );
             }
             if let Some(rt) = &af.return_type {
-                push_type_hint(out, source, rt);
+                push_type_hint(out, source, line_starts, rt);
             }
-            collect_expr(source, af.body, out);
+            collect_expr(source, line_starts, af.body, out);
         }
         // ── Variables ─────────────────────────────────────────────────────────
         ExprKind::Variable(_) => {
             let segment = &source[expr.span.start as usize..expr.span.end as usize];
             let len: u32 = segment.chars().map(|c| c.len_utf16() as u32).sum();
-            push_at(out, source, expr.span.start, len, TT_VARIABLE, 0);
+            push_at(
+                out,
+                source,
+                line_starts,
+                expr.span.start,
+                len,
+                TT_VARIABLE,
+                0,
+            );
         }
         _ => {}
     }

--- a/src/semantic_tokens.rs
+++ b/src/semantic_tokens.rs
@@ -9,7 +9,7 @@ use tower_lsp::lsp_types::{
     SemanticTokensLegend,
 };
 
-use crate::ast::{ParsedDoc, offset_to_position, str_offset};
+use crate::ast::{ParsedDoc, SourceView, str_offset};
 use crate::docblock::{docblock_before, parse_docblock};
 
 // Token type indices — order must match `legend()` vec order
@@ -62,22 +62,22 @@ pub fn legend() -> SemanticTokensLegend {
     }
 }
 
-pub fn semantic_tokens(source: &str, doc: &ParsedDoc) -> Vec<SemanticToken> {
-    let line_starts = doc.line_starts();
+pub fn semantic_tokens(_source: &str, doc: &ParsedDoc) -> Vec<SemanticToken> {
+    let sv = doc.view();
     let mut raw: Vec<RawToken> = Vec::new();
-    collect_comments(source, line_starts, &mut raw);
-    collect_stmts(source, line_starts, &doc.program().stmts, &mut raw);
+    collect_comments(sv, &mut raw);
+    collect_stmts(sv, &doc.program().stmts, &mut raw);
     raw.sort_by(|a, b| a.0.cmp(&b.0).then(a.1.cmp(&b.1)));
     delta_encode(raw)
 }
 
-/// Return semantic tokens restricted to the given source range.
+/// Return semantic tokens restricted to the given sv.source() range.
 /// Useful for editors that only request tokens for the visible viewport.
-pub fn semantic_tokens_range(source: &str, doc: &ParsedDoc, range: Range) -> Vec<SemanticToken> {
-    let line_starts = doc.line_starts();
+pub fn semantic_tokens_range(_source: &str, doc: &ParsedDoc, range: Range) -> Vec<SemanticToken> {
+    let sv = doc.view();
     let mut raw: Vec<RawToken> = Vec::new();
-    collect_comments(source, line_starts, &mut raw);
-    collect_stmts(source, line_starts, &doc.program().stmts, &mut raw);
+    collect_comments(sv, &mut raw);
+    collect_stmts(sv, &doc.program().stmts, &mut raw);
     raw.sort_by(|a, b| a.0.cmp(&b.0).then(a.1.cmp(&b.1)));
 
     let filtered: Vec<RawToken> = raw
@@ -162,30 +162,27 @@ pub fn compute_token_delta(
 
 fn push_at(
     out: &mut Vec<RawToken>,
-    source: &str,
-    line_starts: &[u32],
+    sv: SourceView<'_>,
     offset: u32,
     len: u32,
     token_type: u32,
     modifiers: u32,
 ) {
-    let pos = offset_to_position(source, line_starts, offset);
+    let pos = sv.position_of(offset);
     out.push((pos.line, pos.character, len, token_type, modifiers));
 }
 
 fn push_name(
     out: &mut Vec<RawToken>,
-    source: &str,
-    line_starts: &[u32],
+    sv: SourceView<'_>,
     name: &str,
     token_type: u32,
     modifiers: u32,
 ) {
-    let offset = str_offset(source, name);
+    let offset = str_offset(sv.source(), name);
     push_at(
         out,
-        source,
-        line_starts,
+        sv,
         offset,
         name.chars().map(|c| c.len_utf16() as u32).sum::<u32>(),
         token_type,
@@ -194,28 +191,26 @@ fn push_name(
 }
 
 /// Like `push_name` but also includes the leading `$` sigil when one immediately
-/// precedes the name in the source.  PHP parameter names in the AST are stored
+/// precedes the name in the sv.source().  PHP parameter names in the AST are stored
 /// without `$`, but the sigil is part of the syntax and must be highlighted
 /// consistently with variable-expression tokens which include it.
 fn push_param(
     out: &mut Vec<RawToken>,
-    source: &str,
-    line_starts: &[u32],
+    sv: SourceView<'_>,
     name: &str,
     token_type: u32,
     modifiers: u32,
 ) {
-    let name_offset = str_offset(source, name);
+    let name_offset = str_offset(sv.source(), name);
     let (offset, extra_len) =
-        if name_offset > 0 && source.as_bytes().get(name_offset as usize - 1) == Some(&b'$') {
+        if name_offset > 0 && sv.source().as_bytes().get(name_offset as usize - 1) == Some(&b'$') {
             (name_offset - 1, 1u32)
         } else {
             (name_offset, 0u32)
         };
     push_at(
         out,
-        source,
-        line_starts,
+        sv,
         offset,
         extra_len + name.chars().map(|c| c.len_utf16() as u32).sum::<u32>(),
         token_type,
@@ -223,17 +218,12 @@ fn push_param(
     );
 }
 
-fn push_attributes(
-    out: &mut Vec<RawToken>,
-    source: &str,
-    line_starts: &[u32],
-    attrs: &[Attribute<'_, '_>],
-) {
+fn push_attributes(out: &mut Vec<RawToken>, sv: SourceView<'_>, attrs: &[Attribute<'_, '_>]) {
     for attr in attrs.iter() {
         let span = attr.name.span();
-        let segment = &source[span.start as usize..span.end as usize];
+        let segment = &sv.source()[span.start as usize..span.end as usize];
         let len: u32 = segment.chars().map(|c| c.len_utf16() as u32).sum();
-        push_at(out, source, line_starts, span.start, len, TT_CLASS, 0);
+        push_at(out, sv, span.start, len, TT_CLASS, 0);
     }
 }
 
@@ -249,12 +239,12 @@ fn deprecated_mod(source: &str, node_start: u32) -> u32 {
         .unwrap_or(0)
 }
 
-/// Scan `source` for PHP comments (single-line `//` and `#`, multi-line `/* */`)
+/// Scan `sv.source()` for PHP comments (single-line `//` and `#`, multi-line `/* */`)
 /// and emit `TT_COMMENT` tokens.  Each physical line of a multi-line comment
 /// is emitted as a separate token because the LSP protocol requires tokens to
 /// fit on a single line.
-fn collect_comments(source: &str, line_starts: &[u32], out: &mut Vec<RawToken>) {
-    let bytes = source.as_bytes();
+fn collect_comments(sv: SourceView<'_>, out: &mut Vec<RawToken>) {
+    let bytes = sv.source().as_bytes();
     let len = bytes.len();
     let mut i = 0usize;
 
@@ -298,17 +288,9 @@ fn collect_comments(source: &str, line_starts: &[u32], out: &mut Vec<RawToken>) 
                     while i < len && bytes[i] != b'\n' {
                         i += 1;
                     }
-                    let text = &source[start..i];
+                    let text = &sv.source()[start..i];
                     let len_utf16: u32 = text.chars().map(|c| c.len_utf16() as u32).sum();
-                    push_at(
-                        out,
-                        source,
-                        line_starts,
-                        start as u32,
-                        len_utf16,
-                        TT_COMMENT,
-                        0,
-                    );
+                    push_at(out, sv, start as u32, len_utf16, TT_COMMENT, 0);
                 } else if bytes[i + 1] == b'*' {
                     // Multi-line comment: `/* ... */`
                     let start = i;
@@ -321,7 +303,7 @@ fn collect_comments(source: &str, line_starts: &[u32], out: &mut Vec<RawToken>) 
                         i += 2;
                     }
                     // Emit per-line so the LSP single-line constraint is met
-                    emit_multiline_comment(source, line_starts, start, i, out);
+                    emit_multiline_comment(sv, start, i, out);
                 } else {
                     i += 1;
                 }
@@ -333,17 +315,9 @@ fn collect_comments(source: &str, line_starts: &[u32], out: &mut Vec<RawToken>) 
                 while i < len && bytes[i] != b'\n' {
                     i += 1;
                 }
-                let text = &source[start..i];
+                let text = &sv.source()[start..i];
                 let len_utf16: u32 = text.chars().map(|c| c.len_utf16() as u32).sum();
-                push_at(
-                    out,
-                    source,
-                    line_starts,
-                    start as u32,
-                    len_utf16,
-                    TT_COMMENT,
-                    0,
-                );
+                push_at(out, sv, start as u32, len_utf16, TT_COMMENT, 0);
             }
             _ => {
                 i += 1;
@@ -353,32 +327,18 @@ fn collect_comments(source: &str, line_starts: &[u32], out: &mut Vec<RawToken>) 
 }
 
 /// Emit a `TT_COMMENT` raw token for each line within a block comment
-/// `source[start..end]`.  Multi-line tokens are not allowed by the LSP spec.
-fn emit_multiline_comment(
-    source: &str,
-    line_starts: &[u32],
-    start: usize,
-    end: usize,
-    out: &mut Vec<RawToken>,
-) {
-    let text = &source[start..end];
+/// `sv.source()[start..end]`.  Multi-line tokens are not allowed by the LSP spec.
+fn emit_multiline_comment(sv: SourceView<'_>, start: usize, end: usize, out: &mut Vec<RawToken>) {
+    let text = &sv.source()[start..end];
     let mut line_start = start;
     for (rel, ch) in text.char_indices() {
         if ch == '\n' {
             let line_end = start + rel; // byte index of newline
             if line_end > line_start {
-                let segment = &source[line_start..line_end];
+                let segment = &sv.source()[line_start..line_end];
                 let len_utf16: u32 = segment.chars().map(|c| c.len_utf16() as u32).sum();
                 if len_utf16 > 0 {
-                    push_at(
-                        out,
-                        source,
-                        line_starts,
-                        line_start as u32,
-                        len_utf16,
-                        TT_COMMENT,
-                        0,
-                    );
+                    push_at(out, sv, line_start as u32, len_utf16, TT_COMMENT, 0);
                 }
             }
             line_start = start + rel + 1; // byte after '\n'
@@ -386,18 +346,10 @@ fn emit_multiline_comment(
     }
     // Last (or only) line
     if line_start < end {
-        let segment = &source[line_start..end];
+        let segment = &sv.source()[line_start..end];
         let len_utf16: u32 = segment.chars().map(|c| c.len_utf16() as u32).sum();
         if len_utf16 > 0 {
-            push_at(
-                out,
-                source,
-                line_starts,
-                line_start as u32,
-                len_utf16,
-                TT_COMMENT,
-                0,
-            );
+            push_at(out, sv, line_start as u32, len_utf16, TT_COMMENT, 0);
         }
     }
 }
@@ -407,291 +359,240 @@ fn emit_multiline_comment(
 /// Keyword types (e.g. `int`, `string`, `void`, `null`) get one token at
 /// the keyword span.  Union/intersection/nullable are recursed into so
 /// every component is covered.
-fn push_type_hint(
-    out: &mut Vec<RawToken>,
-    source: &str,
-    line_starts: &[u32],
-    hint: &TypeHint<'_, '_>,
-) {
+fn push_type_hint(out: &mut Vec<RawToken>, sv: SourceView<'_>, hint: &TypeHint<'_, '_>) {
     match &hint.kind {
         TypeHintKind::Named(name) => {
             let span = name.span();
-            let segment = &source[span.start as usize..span.end as usize];
+            let segment = &sv.source()[span.start as usize..span.end as usize];
             let len: u32 = segment.chars().map(|c| c.len_utf16() as u32).sum();
-            push_at(out, source, line_starts, span.start, len, TT_TYPE, 0);
+            push_at(out, sv, span.start, len, TT_TYPE, 0);
         }
         TypeHintKind::Keyword(builtin, span) => {
             let text = builtin.as_str();
             let len_utf16: u32 = text.chars().map(|c| c.len_utf16() as u32).sum();
-            push_at(out, source, line_starts, span.start, len_utf16, TT_TYPE, 0);
+            push_at(out, sv, span.start, len_utf16, TT_TYPE, 0);
         }
         TypeHintKind::Nullable(inner) => {
-            push_type_hint(out, source, line_starts, inner);
+            push_type_hint(out, sv, inner);
         }
         TypeHintKind::Union(types) | TypeHintKind::Intersection(types) => {
             for t in types.iter() {
-                push_type_hint(out, source, line_starts, t);
+                push_type_hint(out, sv, t);
             }
         }
     }
 }
 
-fn collect_stmts(
-    source: &str,
-    line_starts: &[u32],
-    stmts: &[Stmt<'_, '_>],
-    out: &mut Vec<RawToken>,
-) {
+fn collect_stmts(sv: SourceView<'_>, stmts: &[Stmt<'_, '_>], out: &mut Vec<RawToken>) {
     for stmt in stmts {
-        collect_stmt(source, line_starts, stmt, out);
+        collect_stmt(sv, stmt, out);
     }
 }
 
-fn collect_stmt(source: &str, line_starts: &[u32], stmt: &Stmt<'_, '_>, out: &mut Vec<RawToken>) {
+fn collect_stmt(sv: SourceView<'_>, stmt: &Stmt<'_, '_>, out: &mut Vec<RawToken>) {
     match &stmt.kind {
         StmtKind::Function(f) => {
-            push_attributes(out, source, line_starts, &f.attributes);
-            let mods = MOD_DECLARATION | deprecated_mod(source, stmt.span.start);
-            push_name(out, source, line_starts, f.name, TT_FUNCTION, mods);
+            push_attributes(out, sv, &f.attributes);
+            let mods = MOD_DECLARATION | deprecated_mod(sv.source(), stmt.span.start);
+            push_name(out, sv, f.name, TT_FUNCTION, mods);
             for p in f.params.iter() {
-                push_attributes(out, source, line_starts, &p.attributes);
+                push_attributes(out, sv, &p.attributes);
                 if let Some(th) = &p.type_hint {
-                    push_type_hint(out, source, line_starts, th);
+                    push_type_hint(out, sv, th);
                 }
-                push_param(
-                    out,
-                    source,
-                    line_starts,
-                    p.name,
-                    TT_PARAMETER,
-                    MOD_DECLARATION,
-                );
+                push_param(out, sv, p.name, TT_PARAMETER, MOD_DECLARATION);
             }
             if let Some(rt) = &f.return_type {
-                push_type_hint(out, source, line_starts, rt);
+                push_type_hint(out, sv, rt);
             }
-            collect_stmts(source, line_starts, &f.body, out);
+            collect_stmts(sv, &f.body, out);
         }
         StmtKind::Class(c) => {
-            push_attributes(out, source, line_starts, &c.attributes);
+            push_attributes(out, sv, &c.attributes);
             if let Some(name) = c.name {
-                let mods = MOD_DECLARATION | deprecated_mod(source, stmt.span.start);
-                push_name(out, source, line_starts, name, TT_CLASS, mods);
+                let mods = MOD_DECLARATION | deprecated_mod(sv.source(), stmt.span.start);
+                push_name(out, sv, name, TT_CLASS, mods);
             }
             for member in c.members.iter() {
-                collect_class_member(source, line_starts, member, out);
+                collect_class_member(sv, member, out);
             }
         }
         StmtKind::Interface(i) => {
-            push_attributes(out, source, line_starts, &i.attributes);
-            let mods = MOD_DECLARATION | deprecated_mod(source, stmt.span.start);
-            push_name(out, source, line_starts, i.name, TT_INTERFACE, mods);
+            push_attributes(out, sv, &i.attributes);
+            let mods = MOD_DECLARATION | deprecated_mod(sv.source(), stmt.span.start);
+            push_name(out, sv, i.name, TT_INTERFACE, mods);
         }
         StmtKind::Trait(t) => {
-            push_attributes(out, source, line_starts, &t.attributes);
-            let mods = MOD_DECLARATION | deprecated_mod(source, stmt.span.start);
-            push_name(out, source, line_starts, t.name, TT_CLASS, mods);
+            push_attributes(out, sv, &t.attributes);
+            let mods = MOD_DECLARATION | deprecated_mod(sv.source(), stmt.span.start);
+            push_name(out, sv, t.name, TT_CLASS, mods);
             for member in t.members.iter() {
-                collect_class_member(source, line_starts, member, out);
+                collect_class_member(sv, member, out);
             }
         }
         StmtKind::Enum(e) => {
-            push_attributes(out, source, line_starts, &e.attributes);
-            let mods = MOD_DECLARATION | deprecated_mod(source, stmt.span.start);
-            push_name(out, source, line_starts, e.name, TT_CLASS, mods);
+            push_attributes(out, sv, &e.attributes);
+            let mods = MOD_DECLARATION | deprecated_mod(sv.source(), stmt.span.start);
+            push_name(out, sv, e.name, TT_CLASS, mods);
             for member in e.members.iter() {
                 if let EnumMemberKind::Method(m) = &member.kind {
-                    push_attributes(out, source, line_starts, &m.attributes);
-                    let mut mmods = MOD_DECLARATION | deprecated_mod(source, member.span.start);
+                    push_attributes(out, sv, &m.attributes);
+                    let mut mmods =
+                        MOD_DECLARATION | deprecated_mod(sv.source(), member.span.start);
                     if m.is_static {
                         mmods |= MOD_STATIC;
                     }
-                    push_name(out, source, line_starts, m.name, TT_METHOD, mmods);
+                    push_name(out, sv, m.name, TT_METHOD, mmods);
                     for p in m.params.iter() {
                         if let Some(th) = &p.type_hint {
-                            push_type_hint(out, source, line_starts, th);
+                            push_type_hint(out, sv, th);
                         }
-                        push_param(
-                            out,
-                            source,
-                            line_starts,
-                            p.name,
-                            TT_PARAMETER,
-                            MOD_DECLARATION,
-                        );
+                        push_param(out, sv, p.name, TT_PARAMETER, MOD_DECLARATION);
                     }
                     if let Some(rt) = &m.return_type {
-                        push_type_hint(out, source, line_starts, rt);
+                        push_type_hint(out, sv, rt);
                     }
                     if let Some(body) = &m.body {
-                        collect_stmts(source, line_starts, body, out);
+                        collect_stmts(sv, body, out);
                     }
                 }
             }
         }
         StmtKind::Namespace(ns) => {
             if let NamespaceBody::Braced(inner) = &ns.body {
-                collect_stmts(source, line_starts, inner, out);
+                collect_stmts(sv, inner, out);
             }
         }
         StmtKind::Use(_) => {}
-        StmtKind::Expression(e) => collect_expr(source, line_starts, e, out),
-        StmtKind::Return(Some(expr)) => collect_expr(source, line_starts, expr, out),
+        StmtKind::Expression(e) => collect_expr(sv, e, out),
+        StmtKind::Return(Some(expr)) => collect_expr(sv, expr, out),
         StmtKind::Return(None) => {}
         StmtKind::Echo(exprs) => {
             for expr in exprs.iter() {
-                collect_expr(source, line_starts, expr, out);
+                collect_expr(sv, expr, out);
             }
         }
         StmtKind::If(i) => {
-            collect_expr(source, line_starts, &i.condition, out);
-            collect_stmt(source, line_starts, i.then_branch, out);
+            collect_expr(sv, &i.condition, out);
+            collect_stmt(sv, i.then_branch, out);
             for ei in i.elseif_branches.iter() {
-                collect_expr(source, line_starts, &ei.condition, out);
-                collect_stmt(source, line_starts, &ei.body, out);
+                collect_expr(sv, &ei.condition, out);
+                collect_stmt(sv, &ei.body, out);
             }
             if let Some(e) = &i.else_branch {
-                collect_stmt(source, line_starts, e, out);
+                collect_stmt(sv, e, out);
             }
         }
         StmtKind::While(w) => {
-            collect_expr(source, line_starts, &w.condition, out);
-            collect_stmt(source, line_starts, w.body, out);
+            collect_expr(sv, &w.condition, out);
+            collect_stmt(sv, w.body, out);
         }
         StmtKind::For(f) => {
             for e in f.init.iter() {
-                collect_expr(source, line_starts, e, out);
+                collect_expr(sv, e, out);
             }
             for cond in f.condition.iter() {
-                collect_expr(source, line_starts, cond, out);
+                collect_expr(sv, cond, out);
             }
             for e in f.update.iter() {
-                collect_expr(source, line_starts, e, out);
+                collect_expr(sv, e, out);
             }
-            collect_stmt(source, line_starts, f.body, out);
+            collect_stmt(sv, f.body, out);
         }
         StmtKind::Foreach(f) => {
-            collect_expr(source, line_starts, &f.expr, out);
-            collect_stmt(source, line_starts, f.body, out);
+            collect_expr(sv, &f.expr, out);
+            collect_stmt(sv, f.body, out);
         }
         StmtKind::TryCatch(t) => {
-            collect_stmts(source, line_starts, &t.body, out);
+            collect_stmts(sv, &t.body, out);
             for catch in t.catches.iter() {
-                collect_stmts(source, line_starts, &catch.body, out);
+                collect_stmts(sv, &catch.body, out);
             }
             if let Some(finally) = &t.finally {
-                collect_stmts(source, line_starts, finally, out);
+                collect_stmts(sv, finally, out);
             }
         }
-        StmtKind::Block(stmts) => collect_stmts(source, line_starts, stmts, out),
+        StmtKind::Block(stmts) => collect_stmts(sv, stmts, out),
         _ => {}
     }
 }
 
 fn collect_class_member(
-    source: &str,
-    line_starts: &[u32],
+    sv: SourceView<'_>,
     member: &php_ast::ClassMember<'_, '_>,
     out: &mut Vec<RawToken>,
 ) {
     if let ClassMemberKind::Method(m) = &member.kind {
-        push_attributes(out, source, line_starts, &m.attributes);
-        let mut mods = MOD_DECLARATION | deprecated_mod(source, member.span.start);
+        push_attributes(out, sv, &m.attributes);
+        let mut mods = MOD_DECLARATION | deprecated_mod(sv.source(), member.span.start);
         if m.is_static {
             mods |= MOD_STATIC;
         }
         if m.is_abstract {
             mods |= MOD_ABSTRACT;
         }
-        push_name(out, source, line_starts, m.name, TT_METHOD, mods);
+        push_name(out, sv, m.name, TT_METHOD, mods);
         for p in m.params.iter() {
-            push_attributes(out, source, line_starts, &p.attributes);
+            push_attributes(out, sv, &p.attributes);
             if let Some(th) = &p.type_hint {
-                push_type_hint(out, source, line_starts, th);
+                push_type_hint(out, sv, th);
             }
-            push_param(
-                out,
-                source,
-                line_starts,
-                p.name,
-                TT_PARAMETER,
-                MOD_DECLARATION,
-            );
+            push_param(out, sv, p.name, TT_PARAMETER, MOD_DECLARATION);
         }
         if let Some(rt) = &m.return_type {
-            push_type_hint(out, source, line_starts, rt);
+            push_type_hint(out, sv, rt);
         }
         if let Some(body) = &m.body {
-            collect_stmts(source, line_starts, body, out);
+            collect_stmts(sv, body, out);
         }
     } else if let ClassMemberKind::Property(p) = &member.kind {
-        push_attributes(out, source, line_starts, &p.attributes);
+        push_attributes(out, sv, &p.attributes);
         if let Some(th) = &p.type_hint {
-            push_type_hint(out, source, line_starts, th);
+            push_type_hint(out, sv, th);
         }
-        push_name(
-            out,
-            source,
-            line_starts,
-            p.name,
-            TT_PROPERTY,
-            MOD_DECLARATION,
-        );
+        push_name(out, sv, p.name, TT_PROPERTY, MOD_DECLARATION);
     }
 }
 
-fn collect_expr(
-    source: &str,
-    line_starts: &[u32],
-    expr: &php_ast::Expr<'_, '_>,
-    out: &mut Vec<RawToken>,
-) {
+fn collect_expr(sv: SourceView<'_>, expr: &php_ast::Expr<'_, '_>, out: &mut Vec<RawToken>) {
     match &expr.kind {
         // ── Literals ──────────────────────────────────────────────────────────
         ExprKind::Int(_) | ExprKind::Float(_) => {
             let span_len = expr.span.end - expr.span.start;
-            push_at(
-                out,
-                source,
-                line_starts,
-                expr.span.start,
-                span_len,
-                TT_NUMBER,
-                0,
-            );
+            push_at(out, sv, expr.span.start, span_len, TT_NUMBER, 0);
         }
         ExprKind::String(_) | ExprKind::Nowdoc { .. } => {
-            let segment = &source[expr.span.start as usize..expr.span.end as usize];
+            let segment = &sv.source()[expr.span.start as usize..expr.span.end as usize];
             let len: u32 = segment.chars().map(|c| c.len_utf16() as u32).sum();
-            push_at(out, source, line_starts, expr.span.start, len, TT_STRING, 0);
+            push_at(out, sv, expr.span.start, len, TT_STRING, 0);
         }
         ExprKind::InterpolatedString(parts) | ExprKind::ShellExec(parts) => {
             // Emit the whole span as a string; embedded variables are not
             // re-coloured here to keep the implementation simple.
-            let segment = &source[expr.span.start as usize..expr.span.end as usize];
+            let segment = &sv.source()[expr.span.start as usize..expr.span.end as usize];
             let len: u32 = segment.chars().map(|c| c.len_utf16() as u32).sum();
-            push_at(out, source, line_starts, expr.span.start, len, TT_STRING, 0);
+            push_at(out, sv, expr.span.start, len, TT_STRING, 0);
             // Still recurse into embedded expressions so method/function calls
             // inside `"... {$obj->method()} ..."` get proper tokens.
             for part in parts.iter() {
                 if let php_ast::StringPart::Expr(inner) = part {
-                    collect_expr(source, line_starts, inner, out);
+                    collect_expr(sv, inner, out);
                 }
             }
         }
         ExprKind::Heredoc { parts, .. } => {
-            let segment = &source[expr.span.start as usize..expr.span.end as usize];
+            let segment = &sv.source()[expr.span.start as usize..expr.span.end as usize];
             let len: u32 = segment.chars().map(|c| c.len_utf16() as u32).sum();
-            push_at(out, source, line_starts, expr.span.start, len, TT_STRING, 0);
+            push_at(out, sv, expr.span.start, len, TT_STRING, 0);
             for part in parts.iter() {
                 if let php_ast::StringPart::Expr(inner) = part {
-                    collect_expr(source, line_starts, inner, out);
+                    collect_expr(sv, inner, out);
                 }
             }
         }
         ExprKind::New(n) => {
             for arg in n.args.iter() {
-                collect_expr(source, line_starts, &arg.value, out);
+                collect_expr(sv, &arg.value, out);
             }
         }
         // ── Calls ─────────────────────────────────────────────────────────────
@@ -700,28 +601,26 @@ fn collect_expr(
                 let name_str: &str = name;
                 push_at(
                     out,
-                    source,
-                    line_starts,
+                    sv,
                     f.name.span.start,
                     name_str.chars().map(|c| c.len_utf16() as u32).sum::<u32>(),
                     TT_FUNCTION,
                     0,
                 );
             } else {
-                collect_expr(source, line_starts, f.name, out);
+                collect_expr(sv, f.name, out);
             }
             for arg in f.args.iter() {
-                collect_expr(source, line_starts, &arg.value, out);
+                collect_expr(sv, &arg.value, out);
             }
         }
         ExprKind::MethodCall(m) => {
-            collect_expr(source, line_starts, m.object, out);
+            collect_expr(sv, m.object, out);
             if let ExprKind::Identifier(name) = &m.method.kind {
                 let name_str: &str = name;
                 push_at(
                     out,
-                    source,
-                    line_starts,
+                    sv,
                     m.method.span.start,
                     name_str.chars().map(|c| c.len_utf16() as u32).sum::<u32>(),
                     TT_METHOD,
@@ -729,17 +628,16 @@ fn collect_expr(
                 );
             }
             for arg in m.args.iter() {
-                collect_expr(source, line_starts, &arg.value, out);
+                collect_expr(sv, &arg.value, out);
             }
         }
         ExprKind::NullsafeMethodCall(m) => {
-            collect_expr(source, line_starts, m.object, out);
+            collect_expr(sv, m.object, out);
             if let ExprKind::Identifier(name) = &m.method.kind {
                 let name_str: &str = name;
                 push_at(
                     out,
-                    source,
-                    line_starts,
+                    sv,
                     m.method.span.start,
                     name_str.chars().map(|c| c.len_utf16() as u32).sum::<u32>(),
                     TT_METHOD,
@@ -747,91 +645,69 @@ fn collect_expr(
                 );
             }
             for arg in m.args.iter() {
-                collect_expr(source, line_starts, &arg.value, out);
+                collect_expr(sv, &arg.value, out);
             }
         }
         // ── Compound expressions ──────────────────────────────────────────────
         ExprKind::Assign(a) => {
-            collect_expr(source, line_starts, a.target, out);
-            collect_expr(source, line_starts, a.value, out);
+            collect_expr(sv, a.target, out);
+            collect_expr(sv, a.value, out);
         }
         ExprKind::Ternary(t) => {
-            collect_expr(source, line_starts, t.condition, out);
+            collect_expr(sv, t.condition, out);
             if let Some(then_expr) = t.then_expr {
-                collect_expr(source, line_starts, then_expr, out);
+                collect_expr(sv, then_expr, out);
             }
-            collect_expr(source, line_starts, t.else_expr, out);
+            collect_expr(sv, t.else_expr, out);
         }
         ExprKind::NullCoalesce(n) => {
-            collect_expr(source, line_starts, n.left, out);
-            collect_expr(source, line_starts, n.right, out);
+            collect_expr(sv, n.left, out);
+            collect_expr(sv, n.right, out);
         }
         ExprKind::Binary(b) => {
-            collect_expr(source, line_starts, b.left, out);
-            collect_expr(source, line_starts, b.right, out);
+            collect_expr(sv, b.left, out);
+            collect_expr(sv, b.right, out);
         }
-        ExprKind::Parenthesized(e) => collect_expr(source, line_starts, e, out),
+        ExprKind::Parenthesized(e) => collect_expr(sv, e, out),
         ExprKind::Array(elements) => {
             for elem in elements.iter() {
                 if let Some(key) = &elem.key {
-                    collect_expr(source, line_starts, key, out);
+                    collect_expr(sv, key, out);
                 }
-                collect_expr(source, line_starts, &elem.value, out);
+                collect_expr(sv, &elem.value, out);
             }
         }
-        ExprKind::UnaryPrefix(u) => collect_expr(source, line_starts, u.operand, out),
-        ExprKind::UnaryPostfix(u) => collect_expr(source, line_starts, u.operand, out),
+        ExprKind::UnaryPrefix(u) => collect_expr(sv, u.operand, out),
+        ExprKind::UnaryPostfix(u) => collect_expr(sv, u.operand, out),
         ExprKind::Closure(c) => {
             for p in c.params.iter() {
                 if let Some(th) = &p.type_hint {
-                    push_type_hint(out, source, line_starts, th);
+                    push_type_hint(out, sv, th);
                 }
-                push_param(
-                    out,
-                    source,
-                    line_starts,
-                    p.name,
-                    TT_PARAMETER,
-                    MOD_DECLARATION,
-                );
+                push_param(out, sv, p.name, TT_PARAMETER, MOD_DECLARATION);
             }
             if let Some(rt) = &c.return_type {
-                push_type_hint(out, source, line_starts, rt);
+                push_type_hint(out, sv, rt);
             }
-            collect_stmts(source, line_starts, &c.body, out);
+            collect_stmts(sv, &c.body, out);
         }
         ExprKind::ArrowFunction(af) => {
             for p in af.params.iter() {
                 if let Some(th) = &p.type_hint {
-                    push_type_hint(out, source, line_starts, th);
+                    push_type_hint(out, sv, th);
                 }
-                push_param(
-                    out,
-                    source,
-                    line_starts,
-                    p.name,
-                    TT_PARAMETER,
-                    MOD_DECLARATION,
-                );
+                push_param(out, sv, p.name, TT_PARAMETER, MOD_DECLARATION);
             }
             if let Some(rt) = &af.return_type {
-                push_type_hint(out, source, line_starts, rt);
+                push_type_hint(out, sv, rt);
             }
-            collect_expr(source, line_starts, af.body, out);
+            collect_expr(sv, af.body, out);
         }
         // ── Variables ─────────────────────────────────────────────────────────
         ExprKind::Variable(_) => {
-            let segment = &source[expr.span.start as usize..expr.span.end as usize];
+            let segment = &sv.source()[expr.span.start as usize..expr.span.end as usize];
             let len: u32 = segment.chars().map(|c| c.len_utf16() as u32).sum();
-            push_at(
-                out,
-                source,
-                line_starts,
-                expr.span.start,
-                len,
-                TT_VARIABLE,
-                0,
-            );
+            push_at(out, sv, expr.span.start, len, TT_VARIABLE, 0);
         }
         _ => {}
     }

--- a/src/symbols.rs
+++ b/src/symbols.rs
@@ -8,16 +8,16 @@ use tower_lsp::lsp_types::{
     WorkspaceSymbol,
 };
 
-use crate::ast::{ParsedDoc, name_range, offset_to_position};
+use crate::ast::{ParsedDoc, SourceView, name_range};
 use crate::docblock::{docblock_before, parse_docblock};
 use crate::util::fuzzy_camel_match;
 
-pub fn document_symbols(source: &str, doc: &ParsedDoc) -> Vec<DocumentSymbol> {
-    let line_starts = doc.line_starts();
-    symbols_from_statements(source, line_starts, &doc.program().stmts)
+pub fn document_symbols(_source: &str, doc: &ParsedDoc) -> Vec<DocumentSymbol> {
+    let sv = doc.view();
+    symbols_from_statements(sv, &doc.program().stmts)
 }
 
-/// Fill in the source range for a `WorkspaceSymbol` whose `location` carries only a URI
+/// Fill in the sv.source() range for a `WorkspaceSymbol` whose `location` carries only a URI
 /// (i.e. `OneOf::Right(WorkspaceLocation)`).  If the range is already present, or if the
 /// document cannot be found, the symbol is returned unchanged.
 pub fn resolve_workspace_symbol(
@@ -80,11 +80,9 @@ pub fn workspace_symbols(query: &str, docs: &[(Url, Arc<ParsedDoc>)]) -> Vec<Sym
     let (kind_filter, term) = parse_kind_filter(query);
     let mut results = Vec::new();
     for (uri, doc) in docs {
-        let source = doc.source();
-        let line_starts = doc.line_starts();
+        let sv = doc.view();
         collect_symbol_info(
-            source,
-            line_starts,
+            sv,
             &doc.program().stmts,
             term,
             kind_filter,
@@ -97,8 +95,7 @@ pub fn workspace_symbols(query: &str, docs: &[(Url, Arc<ParsedDoc>)]) -> Vec<Sym
 
 #[allow(deprecated)]
 fn collect_symbol_info(
-    source: &str,
-    line_starts: &[u32],
+    sv: SourceView<'_>,
     stmts: &[Stmt<'_, '_>],
     query: &str,
     kind_filter: Option<SymbolKind>,
@@ -117,7 +114,7 @@ fn collect_symbol_info(
                         kind: SymbolKind::FUNCTION,
                         location: Location {
                             uri: uri.clone(),
-                            range: name_range(source, line_starts, name),
+                            range: sv.name_range(name),
                         },
                         tags: None,
                         deprecated: None,
@@ -136,7 +133,7 @@ fn collect_symbol_info(
                         kind: SymbolKind::CLASS,
                         location: Location {
                             uri: uri.clone(),
-                            range: name_range(source, line_starts, name),
+                            range: sv.name_range(name),
                         },
                         tags: None,
                         deprecated: None,
@@ -153,7 +150,7 @@ fn collect_symbol_info(
                             kind: SymbolKind::METHOD,
                             location: Location {
                                 uri: uri.clone(),
-                                range: name_range(source, line_starts, m.name),
+                                range: sv.name_range(m.name),
                             },
                             tags: None,
                             deprecated: None,
@@ -173,7 +170,7 @@ fn collect_symbol_info(
                         kind: SymbolKind::INTERFACE,
                         location: Location {
                             uri: uri.clone(),
-                            range: name_range(source, line_starts, i.name),
+                            range: sv.name_range(i.name),
                         },
                         tags: None,
                         deprecated: None,
@@ -188,7 +185,7 @@ fn collect_symbol_info(
                         kind: SymbolKind::CLASS,
                         location: Location {
                             uri: uri.clone(),
-                            range: name_range(source, line_starts, t.name),
+                            range: sv.name_range(t.name),
                         },
                         tags: None,
                         deprecated: None,
@@ -203,7 +200,7 @@ fn collect_symbol_info(
                         kind: SymbolKind::ENUM,
                         location: Location {
                             uri: uri.clone(),
-                            range: name_range(source, line_starts, e.name),
+                            range: sv.name_range(e.name),
                         },
                         tags: None,
                         deprecated: None,
@@ -220,7 +217,7 @@ fn collect_symbol_info(
                             kind: SymbolKind::ENUM_MEMBER,
                             location: Location {
                                 uri: uri.clone(),
-                                range: name_range(source, line_starts, c.name),
+                                range: sv.name_range(c.name),
                             },
                             tags: None,
                             deprecated: None,
@@ -231,7 +228,7 @@ fn collect_symbol_info(
             }
             StmtKind::Namespace(ns) => {
                 if let NamespaceBody::Braced(inner) = &ns.body {
-                    collect_symbol_info(source, line_starts, inner, query, kind_filter, uri, out);
+                    collect_symbol_info(sv, inner, query, kind_filter, uri, out);
                 }
             }
             _ => {}
@@ -239,21 +236,17 @@ fn collect_symbol_info(
     }
 }
 
-fn symbols_from_statements(
-    source: &str,
-    line_starts: &[u32],
-    stmts: &[Stmt<'_, '_>],
-) -> Vec<DocumentSymbol> {
+fn symbols_from_statements(sv: SourceView<'_>, stmts: &[Stmt<'_, '_>]) -> Vec<DocumentSymbol> {
     let mut symbols = Vec::new();
     for stmt in stmts {
         match &stmt.kind {
             StmtKind::Namespace(ns) => {
                 if let NamespaceBody::Braced(inner) = &ns.body {
-                    symbols.extend(symbols_from_statements(source, line_starts, inner));
+                    symbols.extend(symbols_from_statements(sv, inner));
                 }
             }
             _ => {
-                if let Some(sym) = statement_to_symbol(source, line_starts, stmt) {
+                if let Some(sym) = statement_to_symbol(sv, stmt) {
                     symbols.push(sym);
                 }
             }
@@ -262,35 +255,31 @@ fn symbols_from_statements(
     symbols
 }
 
-fn stmt_range(source: &str, line_starts: &[u32], stmt: &Stmt<'_, '_>) -> Range {
-    let start = offset_to_position(source, line_starts, stmt.span.start);
-    let end = offset_to_position(source, line_starts, stmt.span.end);
+fn stmt_range(sv: SourceView<'_>, stmt: &Stmt<'_, '_>) -> Range {
+    let start = sv.position_of(stmt.span.start);
+    let end = sv.position_of(stmt.span.end);
     Range { start, end }
 }
 
-fn member_range(source: &str, line_starts: &[u32], member: &php_ast::ClassMember<'_, '_>) -> Range {
-    let start = offset_to_position(source, line_starts, member.span.start);
-    let end = offset_to_position(source, line_starts, member.span.end);
+fn member_range(sv: SourceView<'_>, member: &php_ast::ClassMember<'_, '_>) -> Range {
+    let start = sv.position_of(member.span.start);
+    let end = sv.position_of(member.span.end);
     Range { start, end }
 }
 
-fn param_range(source: &str, line_starts: &[u32], param: &php_ast::Param<'_, '_>) -> Range {
-    let start = offset_to_position(source, line_starts, param.span.start);
-    let end = offset_to_position(source, line_starts, param.span.end);
+fn param_range(sv: SourceView<'_>, param: &php_ast::Param<'_, '_>) -> Range {
+    let start = sv.position_of(param.span.start);
+    let end = sv.position_of(param.span.end);
     Range { start, end }
 }
 
-fn statement_to_symbol(
-    source: &str,
-    line_starts: &[u32],
-    stmt: &Stmt<'_, '_>,
-) -> Option<DocumentSymbol> {
+fn statement_to_symbol(sv: SourceView<'_>, stmt: &Stmt<'_, '_>) -> Option<DocumentSymbol> {
     match &stmt.kind {
         StmtKind::Function(f) => {
-            let range = stmt_range(source, line_starts, stmt);
-            let selection_range = name_range(source, line_starts, f.name);
+            let range = stmt_range(sv, stmt);
+            let selection_range = sv.name_range(f.name);
             let detail = Some(format_fn_signature(&f.params, f.return_type.as_ref()));
-            let is_deprecated = docblock_before(source, stmt.span.start)
+            let is_deprecated = docblock_before(sv.source(), stmt.span.start)
                 .filter(|raw| parse_docblock(raw).deprecated.is_some())
                 .map(|_| true);
 
@@ -298,8 +287,8 @@ fn statement_to_symbol(
                 .params
                 .iter()
                 .map(|p| {
-                    let prange = param_range(source, line_starts, p);
-                    let psel = name_range(source, line_starts, p.name);
+                    let prange = param_range(sv, p);
+                    let psel = sv.name_range(p.name);
                     DocumentSymbol {
                         name: format!("${}", p.name),
                         detail: None,
@@ -331,9 +320,9 @@ fn statement_to_symbol(
 
         StmtKind::Class(c) => {
             let name = c.name?;
-            let range = stmt_range(source, line_starts, stmt);
-            let selection_range = name_range(source, line_starts, name);
-            let class_deprecated = docblock_before(source, stmt.span.start)
+            let range = stmt_range(sv, stmt);
+            let selection_range = sv.name_range(name);
+            let class_deprecated = docblock_before(sv.source(), stmt.span.start)
                 .filter(|raw| parse_docblock(raw).deprecated.is_some())
                 .map(|_| true);
 
@@ -343,11 +332,11 @@ fn statement_to_symbol(
                 .flat_map(|member| -> Vec<DocumentSymbol> {
                     match &member.kind {
                         ClassMemberKind::Method(m) => {
-                            let mrange = member_range(source, line_starts, member);
-                            let msel = name_range(source, line_starts, m.name);
+                            let mrange = member_range(sv, member);
+                            let msel = sv.name_range(m.name);
                             let detail =
                                 Some(format_fn_signature(&m.params, m.return_type.as_ref()));
-                            let method_deprecated = docblock_before(source, member.span.start)
+                            let method_deprecated = docblock_before(sv.source(), member.span.start)
                                 .filter(|raw| parse_docblock(raw).deprecated.is_some())
                                 .map(|_| true);
                             vec![DocumentSymbol {
@@ -362,9 +351,9 @@ fn statement_to_symbol(
                             }]
                         }
                         ClassMemberKind::Property(p) => {
-                            let prange = member_range(source, line_starts, member);
-                            let psel = name_range(source, line_starts, p.name);
-                            let prop_deprecated = docblock_before(source, member.span.start)
+                            let prange = member_range(sv, member);
+                            let psel = sv.name_range(p.name);
+                            let prop_deprecated = docblock_before(sv.source(), member.span.start)
                                 .filter(|raw| parse_docblock(raw).deprecated.is_some())
                                 .map(|_| true);
                             vec![DocumentSymbol {
@@ -379,9 +368,9 @@ fn statement_to_symbol(
                             }]
                         }
                         ClassMemberKind::ClassConst(cc) => {
-                            let crange = member_range(source, line_starts, member);
-                            let csel = name_range(source, line_starts, cc.name);
-                            let const_deprecated = docblock_before(source, member.span.start)
+                            let crange = member_range(sv, member);
+                            let csel = sv.name_range(cc.name);
+                            let const_deprecated = docblock_before(sv.source(), member.span.start)
                                 .filter(|raw| parse_docblock(raw).deprecated.is_some())
                                 .map(|_| true);
                             vec![DocumentSymbol {
@@ -417,9 +406,9 @@ fn statement_to_symbol(
         }
 
         StmtKind::Interface(i) => {
-            let range = stmt_range(source, line_starts, stmt);
-            let selection_range = name_range(source, line_starts, i.name);
-            let iface_deprecated = docblock_before(source, stmt.span.start)
+            let range = stmt_range(sv, stmt);
+            let selection_range = sv.name_range(i.name);
+            let iface_deprecated = docblock_before(sv.source(), stmt.span.start)
                 .filter(|raw| parse_docblock(raw).deprecated.is_some())
                 .map(|_| true);
             let children: Vec<DocumentSymbol> = i
@@ -427,9 +416,9 @@ fn statement_to_symbol(
                 .iter()
                 .filter_map(|member| {
                     if let ClassMemberKind::ClassConst(cc) = &member.kind {
-                        let crange = member_range(source, line_starts, member);
-                        let csel = name_range(source, line_starts, cc.name);
-                        let const_deprecated = docblock_before(source, member.span.start)
+                        let crange = member_range(sv, member);
+                        let csel = sv.name_range(cc.name);
+                        let const_deprecated = docblock_before(sv.source(), member.span.start)
                             .filter(|raw| parse_docblock(raw).deprecated.is_some())
                             .map(|_| true);
                         Some(DocumentSymbol {
@@ -464,9 +453,9 @@ fn statement_to_symbol(
         }
 
         StmtKind::Trait(t) => {
-            let range = stmt_range(source, line_starts, stmt);
-            let selection_range = name_range(source, line_starts, t.name);
-            let trait_deprecated = docblock_before(source, stmt.span.start)
+            let range = stmt_range(sv, stmt);
+            let selection_range = sv.name_range(t.name);
+            let trait_deprecated = docblock_before(sv.source(), stmt.span.start)
                 .filter(|raw| parse_docblock(raw).deprecated.is_some())
                 .map(|_| true);
             let children: Vec<DocumentSymbol> = t
@@ -474,9 +463,9 @@ fn statement_to_symbol(
                 .iter()
                 .filter_map(|member| {
                     if let ClassMemberKind::Method(m) = &member.kind {
-                        let mrange = member_range(source, line_starts, member);
-                        let msel = name_range(source, line_starts, m.name);
-                        let method_deprecated = docblock_before(source, member.span.start)
+                        let mrange = member_range(sv, member);
+                        let msel = sv.name_range(m.name);
+                        let method_deprecated = docblock_before(sv.source(), member.span.start)
                             .filter(|raw| parse_docblock(raw).deprecated.is_some())
                             .map(|_| true);
                         Some(DocumentSymbol {
@@ -512,9 +501,9 @@ fn statement_to_symbol(
         }
 
         StmtKind::Enum(e) => {
-            let range = stmt_range(source, line_starts, stmt);
-            let selection_range = name_range(source, line_starts, e.name);
-            let enum_deprecated = docblock_before(source, stmt.span.start)
+            let range = stmt_range(sv, stmt);
+            let selection_range = sv.name_range(e.name);
+            let enum_deprecated = docblock_before(sv.source(), stmt.span.start)
                 .filter(|raw| parse_docblock(raw).deprecated.is_some())
                 .map(|_| true);
             let children: Vec<DocumentSymbol> = e
@@ -523,10 +512,10 @@ fn statement_to_symbol(
                 .filter_map(|member| match &member.kind {
                     EnumMemberKind::Case(c) => {
                         let crange = Range {
-                            start: offset_to_position(source, line_starts, member.span.start),
-                            end: offset_to_position(source, line_starts, member.span.end),
+                            start: sv.position_of(member.span.start),
+                            end: sv.position_of(member.span.end),
                         };
-                        let csel = name_range(source, line_starts, c.name);
+                        let csel = sv.name_range(c.name);
                         Some(DocumentSymbol {
                             name: c.name.to_string(),
                             detail: None,
@@ -540,11 +529,11 @@ fn statement_to_symbol(
                     }
                     EnumMemberKind::Method(m) => {
                         let mrange = Range {
-                            start: offset_to_position(source, line_starts, member.span.start),
-                            end: offset_to_position(source, line_starts, member.span.end),
+                            start: sv.position_of(member.span.start),
+                            end: sv.position_of(member.span.end),
                         };
-                        let msel = name_range(source, line_starts, m.name);
-                        let method_deprecated = docblock_before(source, member.span.start)
+                        let msel = sv.name_range(m.name);
+                        let method_deprecated = docblock_before(sv.source(), member.span.start)
                             .filter(|raw| parse_docblock(raw).deprecated.is_some())
                             .map(|_| true);
                         Some(DocumentSymbol {
@@ -611,8 +600,8 @@ fn format_fn_signature(
     format!("({}){}", params_str, ret_str)
 }
 
-fn _pos_from_offset(source: &str, line_starts: &[u32], offset: u32) -> Position {
-    offset_to_position(source, line_starts, offset)
+fn _pos_from_offset(sv: SourceView<'_>, offset: u32) -> Position {
+    sv.position_of(offset)
 }
 
 #[cfg(test)]

--- a/src/symbols.rs
+++ b/src/symbols.rs
@@ -13,7 +13,8 @@ use crate::docblock::{docblock_before, parse_docblock};
 use crate::util::fuzzy_camel_match;
 
 pub fn document_symbols(source: &str, doc: &ParsedDoc) -> Vec<DocumentSymbol> {
-    symbols_from_statements(source, &doc.program().stmts)
+    let line_starts = doc.line_starts();
+    symbols_from_statements(source, line_starts, &doc.program().stmts)
 }
 
 /// Fill in the source range for a `WorkspaceSymbol` whose `location` carries only a URI
@@ -30,7 +31,7 @@ pub fn resolve_workspace_symbol(
     };
     for (doc_uri, doc) in docs {
         if doc_uri == &uri {
-            let range = name_range(doc.source(), &symbol.name);
+            let range = name_range(doc.source(), doc.line_starts(), &symbol.name);
             symbol.location = OneOf::Left(Location { uri, range });
             break;
         }
@@ -80,8 +81,10 @@ pub fn workspace_symbols(query: &str, docs: &[(Url, Arc<ParsedDoc>)]) -> Vec<Sym
     let mut results = Vec::new();
     for (uri, doc) in docs {
         let source = doc.source();
+        let line_starts = doc.line_starts();
         collect_symbol_info(
             source,
+            line_starts,
             &doc.program().stmts,
             term,
             kind_filter,
@@ -95,6 +98,7 @@ pub fn workspace_symbols(query: &str, docs: &[(Url, Arc<ParsedDoc>)]) -> Vec<Sym
 #[allow(deprecated)]
 fn collect_symbol_info(
     source: &str,
+    line_starts: &[u32],
     stmts: &[Stmt<'_, '_>],
     query: &str,
     kind_filter: Option<SymbolKind>,
@@ -113,7 +117,7 @@ fn collect_symbol_info(
                         kind: SymbolKind::FUNCTION,
                         location: Location {
                             uri: uri.clone(),
-                            range: name_range(source, name),
+                            range: name_range(source, line_starts, name),
                         },
                         tags: None,
                         deprecated: None,
@@ -132,7 +136,7 @@ fn collect_symbol_info(
                         kind: SymbolKind::CLASS,
                         location: Location {
                             uri: uri.clone(),
-                            range: name_range(source, name),
+                            range: name_range(source, line_starts, name),
                         },
                         tags: None,
                         deprecated: None,
@@ -149,7 +153,7 @@ fn collect_symbol_info(
                             kind: SymbolKind::METHOD,
                             location: Location {
                                 uri: uri.clone(),
-                                range: name_range(source, m.name),
+                                range: name_range(source, line_starts, m.name),
                             },
                             tags: None,
                             deprecated: None,
@@ -169,7 +173,7 @@ fn collect_symbol_info(
                         kind: SymbolKind::INTERFACE,
                         location: Location {
                             uri: uri.clone(),
-                            range: name_range(source, i.name),
+                            range: name_range(source, line_starts, i.name),
                         },
                         tags: None,
                         deprecated: None,
@@ -184,7 +188,7 @@ fn collect_symbol_info(
                         kind: SymbolKind::CLASS,
                         location: Location {
                             uri: uri.clone(),
-                            range: name_range(source, t.name),
+                            range: name_range(source, line_starts, t.name),
                         },
                         tags: None,
                         deprecated: None,
@@ -199,7 +203,7 @@ fn collect_symbol_info(
                         kind: SymbolKind::ENUM,
                         location: Location {
                             uri: uri.clone(),
-                            range: name_range(source, e.name),
+                            range: name_range(source, line_starts, e.name),
                         },
                         tags: None,
                         deprecated: None,
@@ -216,7 +220,7 @@ fn collect_symbol_info(
                             kind: SymbolKind::ENUM_MEMBER,
                             location: Location {
                                 uri: uri.clone(),
-                                range: name_range(source, c.name),
+                                range: name_range(source, line_starts, c.name),
                             },
                             tags: None,
                             deprecated: None,
@@ -227,7 +231,7 @@ fn collect_symbol_info(
             }
             StmtKind::Namespace(ns) => {
                 if let NamespaceBody::Braced(inner) = &ns.body {
-                    collect_symbol_info(source, inner, query, kind_filter, uri, out);
+                    collect_symbol_info(source, line_starts, inner, query, kind_filter, uri, out);
                 }
             }
             _ => {}
@@ -235,17 +239,21 @@ fn collect_symbol_info(
     }
 }
 
-fn symbols_from_statements(source: &str, stmts: &[Stmt<'_, '_>]) -> Vec<DocumentSymbol> {
+fn symbols_from_statements(
+    source: &str,
+    line_starts: &[u32],
+    stmts: &[Stmt<'_, '_>],
+) -> Vec<DocumentSymbol> {
     let mut symbols = Vec::new();
     for stmt in stmts {
         match &stmt.kind {
             StmtKind::Namespace(ns) => {
                 if let NamespaceBody::Braced(inner) = &ns.body {
-                    symbols.extend(symbols_from_statements(source, inner));
+                    symbols.extend(symbols_from_statements(source, line_starts, inner));
                 }
             }
             _ => {
-                if let Some(sym) = statement_to_symbol(source, stmt) {
+                if let Some(sym) = statement_to_symbol(source, line_starts, stmt) {
                     symbols.push(sym);
                 }
             }
@@ -254,29 +262,33 @@ fn symbols_from_statements(source: &str, stmts: &[Stmt<'_, '_>]) -> Vec<Document
     symbols
 }
 
-fn stmt_range(source: &str, stmt: &Stmt<'_, '_>) -> Range {
-    let start = offset_to_position(source, stmt.span.start);
-    let end = offset_to_position(source, stmt.span.end);
+fn stmt_range(source: &str, line_starts: &[u32], stmt: &Stmt<'_, '_>) -> Range {
+    let start = offset_to_position(source, line_starts, stmt.span.start);
+    let end = offset_to_position(source, line_starts, stmt.span.end);
     Range { start, end }
 }
 
-fn member_range(source: &str, member: &php_ast::ClassMember<'_, '_>) -> Range {
-    let start = offset_to_position(source, member.span.start);
-    let end = offset_to_position(source, member.span.end);
+fn member_range(source: &str, line_starts: &[u32], member: &php_ast::ClassMember<'_, '_>) -> Range {
+    let start = offset_to_position(source, line_starts, member.span.start);
+    let end = offset_to_position(source, line_starts, member.span.end);
     Range { start, end }
 }
 
-fn param_range(source: &str, param: &php_ast::Param<'_, '_>) -> Range {
-    let start = offset_to_position(source, param.span.start);
-    let end = offset_to_position(source, param.span.end);
+fn param_range(source: &str, line_starts: &[u32], param: &php_ast::Param<'_, '_>) -> Range {
+    let start = offset_to_position(source, line_starts, param.span.start);
+    let end = offset_to_position(source, line_starts, param.span.end);
     Range { start, end }
 }
 
-fn statement_to_symbol(source: &str, stmt: &Stmt<'_, '_>) -> Option<DocumentSymbol> {
+fn statement_to_symbol(
+    source: &str,
+    line_starts: &[u32],
+    stmt: &Stmt<'_, '_>,
+) -> Option<DocumentSymbol> {
     match &stmt.kind {
         StmtKind::Function(f) => {
-            let range = stmt_range(source, stmt);
-            let selection_range = name_range(source, f.name);
+            let range = stmt_range(source, line_starts, stmt);
+            let selection_range = name_range(source, line_starts, f.name);
             let detail = Some(format_fn_signature(&f.params, f.return_type.as_ref()));
             let is_deprecated = docblock_before(source, stmt.span.start)
                 .filter(|raw| parse_docblock(raw).deprecated.is_some())
@@ -286,8 +298,8 @@ fn statement_to_symbol(source: &str, stmt: &Stmt<'_, '_>) -> Option<DocumentSymb
                 .params
                 .iter()
                 .map(|p| {
-                    let prange = param_range(source, p);
-                    let psel = name_range(source, p.name);
+                    let prange = param_range(source, line_starts, p);
+                    let psel = name_range(source, line_starts, p.name);
                     DocumentSymbol {
                         name: format!("${}", p.name),
                         detail: None,
@@ -319,8 +331,8 @@ fn statement_to_symbol(source: &str, stmt: &Stmt<'_, '_>) -> Option<DocumentSymb
 
         StmtKind::Class(c) => {
             let name = c.name?;
-            let range = stmt_range(source, stmt);
-            let selection_range = name_range(source, name);
+            let range = stmt_range(source, line_starts, stmt);
+            let selection_range = name_range(source, line_starts, name);
             let class_deprecated = docblock_before(source, stmt.span.start)
                 .filter(|raw| parse_docblock(raw).deprecated.is_some())
                 .map(|_| true);
@@ -331,8 +343,8 @@ fn statement_to_symbol(source: &str, stmt: &Stmt<'_, '_>) -> Option<DocumentSymb
                 .flat_map(|member| -> Vec<DocumentSymbol> {
                     match &member.kind {
                         ClassMemberKind::Method(m) => {
-                            let mrange = member_range(source, member);
-                            let msel = name_range(source, m.name);
+                            let mrange = member_range(source, line_starts, member);
+                            let msel = name_range(source, line_starts, m.name);
                             let detail =
                                 Some(format_fn_signature(&m.params, m.return_type.as_ref()));
                             let method_deprecated = docblock_before(source, member.span.start)
@@ -350,8 +362,8 @@ fn statement_to_symbol(source: &str, stmt: &Stmt<'_, '_>) -> Option<DocumentSymb
                             }]
                         }
                         ClassMemberKind::Property(p) => {
-                            let prange = member_range(source, member);
-                            let psel = name_range(source, p.name);
+                            let prange = member_range(source, line_starts, member);
+                            let psel = name_range(source, line_starts, p.name);
                             let prop_deprecated = docblock_before(source, member.span.start)
                                 .filter(|raw| parse_docblock(raw).deprecated.is_some())
                                 .map(|_| true);
@@ -367,8 +379,8 @@ fn statement_to_symbol(source: &str, stmt: &Stmt<'_, '_>) -> Option<DocumentSymb
                             }]
                         }
                         ClassMemberKind::ClassConst(cc) => {
-                            let crange = member_range(source, member);
-                            let csel = name_range(source, cc.name);
+                            let crange = member_range(source, line_starts, member);
+                            let csel = name_range(source, line_starts, cc.name);
                             let const_deprecated = docblock_before(source, member.span.start)
                                 .filter(|raw| parse_docblock(raw).deprecated.is_some())
                                 .map(|_| true);
@@ -405,8 +417,8 @@ fn statement_to_symbol(source: &str, stmt: &Stmt<'_, '_>) -> Option<DocumentSymb
         }
 
         StmtKind::Interface(i) => {
-            let range = stmt_range(source, stmt);
-            let selection_range = name_range(source, i.name);
+            let range = stmt_range(source, line_starts, stmt);
+            let selection_range = name_range(source, line_starts, i.name);
             let iface_deprecated = docblock_before(source, stmt.span.start)
                 .filter(|raw| parse_docblock(raw).deprecated.is_some())
                 .map(|_| true);
@@ -415,8 +427,8 @@ fn statement_to_symbol(source: &str, stmt: &Stmt<'_, '_>) -> Option<DocumentSymb
                 .iter()
                 .filter_map(|member| {
                     if let ClassMemberKind::ClassConst(cc) = &member.kind {
-                        let crange = member_range(source, member);
-                        let csel = name_range(source, cc.name);
+                        let crange = member_range(source, line_starts, member);
+                        let csel = name_range(source, line_starts, cc.name);
                         let const_deprecated = docblock_before(source, member.span.start)
                             .filter(|raw| parse_docblock(raw).deprecated.is_some())
                             .map(|_| true);
@@ -452,8 +464,8 @@ fn statement_to_symbol(source: &str, stmt: &Stmt<'_, '_>) -> Option<DocumentSymb
         }
 
         StmtKind::Trait(t) => {
-            let range = stmt_range(source, stmt);
-            let selection_range = name_range(source, t.name);
+            let range = stmt_range(source, line_starts, stmt);
+            let selection_range = name_range(source, line_starts, t.name);
             let trait_deprecated = docblock_before(source, stmt.span.start)
                 .filter(|raw| parse_docblock(raw).deprecated.is_some())
                 .map(|_| true);
@@ -462,8 +474,8 @@ fn statement_to_symbol(source: &str, stmt: &Stmt<'_, '_>) -> Option<DocumentSymb
                 .iter()
                 .filter_map(|member| {
                     if let ClassMemberKind::Method(m) = &member.kind {
-                        let mrange = member_range(source, member);
-                        let msel = name_range(source, m.name);
+                        let mrange = member_range(source, line_starts, member);
+                        let msel = name_range(source, line_starts, m.name);
                         let method_deprecated = docblock_before(source, member.span.start)
                             .filter(|raw| parse_docblock(raw).deprecated.is_some())
                             .map(|_| true);
@@ -500,8 +512,8 @@ fn statement_to_symbol(source: &str, stmt: &Stmt<'_, '_>) -> Option<DocumentSymb
         }
 
         StmtKind::Enum(e) => {
-            let range = stmt_range(source, stmt);
-            let selection_range = name_range(source, e.name);
+            let range = stmt_range(source, line_starts, stmt);
+            let selection_range = name_range(source, line_starts, e.name);
             let enum_deprecated = docblock_before(source, stmt.span.start)
                 .filter(|raw| parse_docblock(raw).deprecated.is_some())
                 .map(|_| true);
@@ -511,10 +523,10 @@ fn statement_to_symbol(source: &str, stmt: &Stmt<'_, '_>) -> Option<DocumentSymb
                 .filter_map(|member| match &member.kind {
                     EnumMemberKind::Case(c) => {
                         let crange = Range {
-                            start: offset_to_position(source, member.span.start),
-                            end: offset_to_position(source, member.span.end),
+                            start: offset_to_position(source, line_starts, member.span.start),
+                            end: offset_to_position(source, line_starts, member.span.end),
                         };
-                        let csel = name_range(source, c.name);
+                        let csel = name_range(source, line_starts, c.name);
                         Some(DocumentSymbol {
                             name: c.name.to_string(),
                             detail: None,
@@ -528,10 +540,10 @@ fn statement_to_symbol(source: &str, stmt: &Stmt<'_, '_>) -> Option<DocumentSymb
                     }
                     EnumMemberKind::Method(m) => {
                         let mrange = Range {
-                            start: offset_to_position(source, member.span.start),
-                            end: offset_to_position(source, member.span.end),
+                            start: offset_to_position(source, line_starts, member.span.start),
+                            end: offset_to_position(source, line_starts, member.span.end),
                         };
-                        let msel = name_range(source, m.name);
+                        let msel = name_range(source, line_starts, m.name);
                         let method_deprecated = docblock_before(source, member.span.start)
                             .filter(|raw| parse_docblock(raw).deprecated.is_some())
                             .map(|_| true);
@@ -599,8 +611,8 @@ fn format_fn_signature(
     format!("({}){}", params_str, ret_str)
 }
 
-fn _pos_from_offset(source: &str, offset: u32) -> Position {
-    offset_to_position(source, offset)
+fn _pos_from_offset(source: &str, line_starts: &[u32], offset: u32) -> Position {
+    offset_to_position(source, line_starts, offset)
 }
 
 #[cfg(test)]

--- a/src/type_action.rs
+++ b/src/type_action.rs
@@ -16,14 +16,23 @@ pub fn add_return_type_actions(
     range: Range,
     uri: &Url,
 ) -> Vec<CodeActionOrCommand> {
+    let line_starts = doc.line_starts();
     let mut out = Vec::new();
-    collect(&doc.program().stmts, source, range, uri, &mut out);
+    collect(
+        &doc.program().stmts,
+        source,
+        line_starts,
+        range,
+        uri,
+        &mut out,
+    );
     out
 }
 
 fn collect(
     stmts: &[Stmt<'_, '_>],
     source: &str,
+    line_starts: &[u32],
     range: Range,
     uri: &Url,
     out: &mut Vec<CodeActionOrCommand>,
@@ -31,17 +40,17 @@ fn collect(
     for stmt in stmts {
         match &stmt.kind {
             StmtKind::Function(f) => {
-                let fn_line = offset_to_position(source, stmt.span.start).line;
+                let fn_line = offset_to_position(source, line_starts, stmt.span.start).line;
                 if line_in_range(fn_line, range) && f.return_type.is_none() {
                     let returns_value = body_has_value_return(&f.body);
                     let type_str = if returns_value { "mixed" } else { "void" };
                     if let Some(insert) = find_close_paren_offset(source, stmt.span.start as usize)
                     {
-                        push_action(source, insert, type_str, uri, out);
+                        push_action(source, line_starts, insert, type_str, uri, out);
                     }
                 }
                 // Recurse into nested functions
-                collect_in_stmts(&f.body, source, range, uri, out);
+                collect_in_stmts(&f.body, source, line_starts, range, uri, out);
             }
             StmtKind::Class(c) => {
                 for member in c.members.iter() {
@@ -49,7 +58,8 @@ fn collect(
                         if m.name == "__construct" {
                             continue;
                         }
-                        let fn_line = offset_to_position(source, member.span.start).line;
+                        let fn_line =
+                            offset_to_position(source, line_starts, member.span.start).line;
                         if line_in_range(fn_line, range)
                             && m.return_type.is_none()
                             && let Some(body) = &m.body
@@ -61,7 +71,7 @@ fn collect(
                             } else {
                                 "void"
                             };
-                            push_action(source, insert, type_str, uri, out);
+                            push_action(source, line_starts, insert, type_str, uri, out);
                         }
                     }
                 }
@@ -69,7 +79,8 @@ fn collect(
             StmtKind::Trait(t) => {
                 for member in t.members.iter() {
                     if let ClassMemberKind::Method(m) = &member.kind
-                        && let fn_line = offset_to_position(source, member.span.start).line
+                        && let fn_line =
+                            offset_to_position(source, line_starts, member.span.start).line
                         && line_in_range(fn_line, range)
                         && m.return_type.is_none()
                         && let Some(body) = &m.body
@@ -81,14 +92,15 @@ fn collect(
                         } else {
                             "void"
                         };
-                        push_action(source, insert, type_str, uri, out);
+                        push_action(source, line_starts, insert, type_str, uri, out);
                     }
                 }
             }
             StmtKind::Enum(e) => {
                 for member in e.members.iter() {
                     if let EnumMemberKind::Method(m) = &member.kind
-                        && let fn_line = offset_to_position(source, member.span.start).line
+                        && let fn_line =
+                            offset_to_position(source, line_starts, member.span.start).line
                         && line_in_range(fn_line, range)
                         && m.return_type.is_none()
                         && let Some(body) = &m.body
@@ -100,13 +112,13 @@ fn collect(
                         } else {
                             "void"
                         };
-                        push_action(source, insert, type_str, uri, out);
+                        push_action(source, line_starts, insert, type_str, uri, out);
                     }
                 }
             }
             StmtKind::Namespace(ns) => {
                 if let NamespaceBody::Braced(inner) = &ns.body {
-                    collect(inner, source, range, uri, out);
+                    collect(inner, source, line_starts, range, uri, out);
                 }
             }
             _ => {}
@@ -117,11 +129,12 @@ fn collect(
 fn collect_in_stmts(
     stmts: &[Stmt<'_, '_>],
     source: &str,
+    line_starts: &[u32],
     range: Range,
     uri: &Url,
     out: &mut Vec<CodeActionOrCommand>,
 ) {
-    collect(stmts, source, range, uri, out);
+    collect(stmts, source, line_starts, range, uri, out);
 }
 
 fn line_in_range(line: u32, range: Range) -> bool {
@@ -224,12 +237,13 @@ fn find_close_paren_offset(source: &str, from: usize) -> Option<usize> {
 
 fn push_action(
     source: &str,
+    line_starts: &[u32],
     after_close_paren: usize,
     type_str: &str,
     uri: &Url,
     out: &mut Vec<CodeActionOrCommand>,
 ) {
-    let pos = offset_to_position(source, after_close_paren as u32);
+    let pos = offset_to_position(source, line_starts, after_close_paren as u32);
     let insert_pos = Position {
         line: pos.line,
         character: pos.character,

--- a/src/type_action.rs
+++ b/src/type_action.rs
@@ -6,33 +6,25 @@ use tower_lsp::lsp_types::{
     CodeAction, CodeActionKind, CodeActionOrCommand, Position, Range, TextEdit, Url, WorkspaceEdit,
 };
 
-use crate::ast::{ParsedDoc, offset_to_position};
+use crate::ast::{ParsedDoc, SourceView};
 
 /// Return "Add return type" code actions for any function/method within `range`
 /// that has no return type annotation and a concrete body.
 pub fn add_return_type_actions(
-    source: &str,
+    _source: &str,
     doc: &ParsedDoc,
     range: Range,
     uri: &Url,
 ) -> Vec<CodeActionOrCommand> {
-    let line_starts = doc.line_starts();
+    let sv = doc.view();
     let mut out = Vec::new();
-    collect(
-        &doc.program().stmts,
-        source,
-        line_starts,
-        range,
-        uri,
-        &mut out,
-    );
+    collect(&doc.program().stmts, sv, range, uri, &mut out);
     out
 }
 
 fn collect(
     stmts: &[Stmt<'_, '_>],
-    source: &str,
-    line_starts: &[u32],
+    sv: SourceView<'_>,
     range: Range,
     uri: &Url,
     out: &mut Vec<CodeActionOrCommand>,
@@ -40,17 +32,18 @@ fn collect(
     for stmt in stmts {
         match &stmt.kind {
             StmtKind::Function(f) => {
-                let fn_line = offset_to_position(source, line_starts, stmt.span.start).line;
+                let fn_line = sv.position_of(stmt.span.start).line;
                 if line_in_range(fn_line, range) && f.return_type.is_none() {
                     let returns_value = body_has_value_return(&f.body);
                     let type_str = if returns_value { "mixed" } else { "void" };
-                    if let Some(insert) = find_close_paren_offset(source, stmt.span.start as usize)
+                    if let Some(insert) =
+                        find_close_paren_offset(sv.source(), stmt.span.start as usize)
                     {
-                        push_action(source, line_starts, insert, type_str, uri, out);
+                        push_action(sv, insert, type_str, uri, out);
                     }
                 }
                 // Recurse into nested functions
-                collect_in_stmts(&f.body, source, line_starts, range, uri, out);
+                collect_in_stmts(&f.body, sv, range, uri, out);
             }
             StmtKind::Class(c) => {
                 for member in c.members.iter() {
@@ -58,20 +51,19 @@ fn collect(
                         if m.name == "__construct" {
                             continue;
                         }
-                        let fn_line =
-                            offset_to_position(source, line_starts, member.span.start).line;
+                        let fn_line = sv.position_of(member.span.start).line;
                         if line_in_range(fn_line, range)
                             && m.return_type.is_none()
                             && let Some(body) = &m.body
                             && let Some(insert) =
-                                find_close_paren_offset(source, member.span.start as usize)
+                                find_close_paren_offset(sv.source(), member.span.start as usize)
                         {
                             let type_str = if body_has_value_return(body) {
                                 "mixed"
                             } else {
                                 "void"
                             };
-                            push_action(source, line_starts, insert, type_str, uri, out);
+                            push_action(sv, insert, type_str, uri, out);
                         }
                     }
                 }
@@ -79,46 +71,44 @@ fn collect(
             StmtKind::Trait(t) => {
                 for member in t.members.iter() {
                     if let ClassMemberKind::Method(m) = &member.kind
-                        && let fn_line =
-                            offset_to_position(source, line_starts, member.span.start).line
+                        && let fn_line = sv.position_of(member.span.start).line
                         && line_in_range(fn_line, range)
                         && m.return_type.is_none()
                         && let Some(body) = &m.body
                         && let Some(insert) =
-                            find_close_paren_offset(source, member.span.start as usize)
+                            find_close_paren_offset(sv.source(), member.span.start as usize)
                     {
                         let type_str = if body_has_value_return(body) {
                             "mixed"
                         } else {
                             "void"
                         };
-                        push_action(source, line_starts, insert, type_str, uri, out);
+                        push_action(sv, insert, type_str, uri, out);
                     }
                 }
             }
             StmtKind::Enum(e) => {
                 for member in e.members.iter() {
                     if let EnumMemberKind::Method(m) = &member.kind
-                        && let fn_line =
-                            offset_to_position(source, line_starts, member.span.start).line
+                        && let fn_line = sv.position_of(member.span.start).line
                         && line_in_range(fn_line, range)
                         && m.return_type.is_none()
                         && let Some(body) = &m.body
                         && let Some(insert) =
-                            find_close_paren_offset(source, member.span.start as usize)
+                            find_close_paren_offset(sv.source(), member.span.start as usize)
                     {
                         let type_str = if body_has_value_return(body) {
                             "mixed"
                         } else {
                             "void"
                         };
-                        push_action(source, line_starts, insert, type_str, uri, out);
+                        push_action(sv, insert, type_str, uri, out);
                     }
                 }
             }
             StmtKind::Namespace(ns) => {
                 if let NamespaceBody::Braced(inner) = &ns.body {
-                    collect(inner, source, line_starts, range, uri, out);
+                    collect(inner, sv, range, uri, out);
                 }
             }
             _ => {}
@@ -128,13 +118,12 @@ fn collect(
 
 fn collect_in_stmts(
     stmts: &[Stmt<'_, '_>],
-    source: &str,
-    line_starts: &[u32],
+    sv: SourceView<'_>,
     range: Range,
     uri: &Url,
     out: &mut Vec<CodeActionOrCommand>,
 ) {
-    collect(stmts, source, line_starts, range, uri, out);
+    collect(stmts, sv, range, uri, out);
 }
 
 fn line_in_range(line: u32, range: Range) -> bool {
@@ -180,7 +169,7 @@ fn stmt_has_value_return(stmt: &Stmt<'_, '_>) -> bool {
     }
 }
 
-/// Scan `source` starting at `from` (byte offset) and return the byte offset
+/// Scan `sv.source()` starting at `from` (byte offset) and return the byte offset
 /// immediately after the `)` that closes the first `(...)` group encountered.
 /// Skips single- and double-quoted string literals.
 fn find_close_paren_offset(source: &str, from: usize) -> Option<usize> {
@@ -236,14 +225,13 @@ fn find_close_paren_offset(source: &str, from: usize) -> Option<usize> {
 }
 
 fn push_action(
-    source: &str,
-    line_starts: &[u32],
+    sv: SourceView<'_>,
     after_close_paren: usize,
     type_str: &str,
     uri: &Url,
     out: &mut Vec<CodeActionOrCommand>,
 ) {
-    let pos = offset_to_position(source, line_starts, after_close_paren as u32);
+    let pos = sv.position_of(after_close_paren as u32);
     let insert_pos = Position {
         line: pos.line,
         character: pos.character,

--- a/src/type_definition.rs
+++ b/src/type_definition.rs
@@ -31,8 +31,13 @@ pub fn goto_type_definition(
 
     for (uri, other_doc) in all_docs {
         let other_source = other_doc.source();
-        if let Some(range) = find_class_range(other_source, &other_doc.program().stmts, &class_name)
-        {
+        let other_line_starts = other_doc.line_starts();
+        if let Some(range) = find_class_range(
+            other_source,
+            other_line_starts,
+            &other_doc.program().stmts,
+            &class_name,
+        ) {
             return Some(Location {
                 uri: uri.clone(),
                 range,
@@ -69,27 +74,33 @@ fn param_type_for(stmts: &[Stmt<'_, '_>], word: &str) -> Option<String> {
 }
 
 /// Find the range of the class or interface declaration named `name`.
-fn find_class_range(source: &str, stmts: &[Stmt<'_, '_>], name: &str) -> Option<Range> {
+fn find_class_range(
+    source: &str,
+    line_starts: &[u32],
+    stmts: &[Stmt<'_, '_>],
+    name: &str,
+) -> Option<Range> {
     for stmt in stmts {
         match &stmt.kind {
             StmtKind::Class(c) if c.name == Some(name) => {
                 return Some(name_range(
                     source,
+                    line_starts,
                     c.name.expect("match guard ensures Some"),
                 ));
             }
             StmtKind::Interface(i) if i.name == name => {
-                return Some(name_range(source, i.name));
+                return Some(name_range(source, line_starts, i.name));
             }
             StmtKind::Trait(t) if t.name == name => {
-                return Some(name_range(source, t.name));
+                return Some(name_range(source, line_starts, t.name));
             }
             StmtKind::Enum(e) if e.name == name => {
-                return Some(name_range(source, e.name));
+                return Some(name_range(source, line_starts, e.name));
             }
             StmtKind::Namespace(ns) => {
                 if let NamespaceBody::Braced(inner) = &ns.body
-                    && let Some(r) = find_class_range(source, inner, name)
+                    && let Some(r) = find_class_range(source, line_starts, inner, name)
                 {
                     return Some(r);
                 }
@@ -100,8 +111,13 @@ fn find_class_range(source: &str, stmts: &[Stmt<'_, '_>], name: &str) -> Option<
     None
 }
 
-fn _offset_to_position_range(source: &str, name_str: &str, _name: &str) -> Range {
-    let start = offset_to_position(source, 0);
+fn _offset_to_position_range(
+    source: &str,
+    line_starts: &[u32],
+    name_str: &str,
+    _name: &str,
+) -> Range {
+    let start = offset_to_position(source, line_starts, 0);
     Range {
         start,
         end: Position {

--- a/src/type_definition.rs
+++ b/src/type_definition.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use php_ast::{NamespaceBody, Stmt, StmtKind};
 use tower_lsp::lsp_types::{Location, Position, Range, Url};
 
-use crate::ast::{ParsedDoc, format_type_hint, name_range, offset_to_position};
+use crate::ast::{ParsedDoc, SourceView, format_type_hint};
 use crate::type_map::TypeMap;
 use crate::util::word_at;
 
@@ -30,14 +30,8 @@ pub fn goto_type_definition(
     };
 
     for (uri, other_doc) in all_docs {
-        let other_source = other_doc.source();
-        let other_line_starts = other_doc.line_starts();
-        if let Some(range) = find_class_range(
-            other_source,
-            other_line_starts,
-            &other_doc.program().stmts,
-            &class_name,
-        ) {
+        let other_sv = other_doc.view();
+        if let Some(range) = find_class_range(other_sv, &other_doc.program().stmts, &class_name) {
             return Some(Location {
                 uri: uri.clone(),
                 range,
@@ -74,33 +68,24 @@ fn param_type_for(stmts: &[Stmt<'_, '_>], word: &str) -> Option<String> {
 }
 
 /// Find the range of the class or interface declaration named `name`.
-fn find_class_range(
-    source: &str,
-    line_starts: &[u32],
-    stmts: &[Stmt<'_, '_>],
-    name: &str,
-) -> Option<Range> {
+fn find_class_range(sv: SourceView<'_>, stmts: &[Stmt<'_, '_>], name: &str) -> Option<Range> {
     for stmt in stmts {
         match &stmt.kind {
             StmtKind::Class(c) if c.name == Some(name) => {
-                return Some(name_range(
-                    source,
-                    line_starts,
-                    c.name.expect("match guard ensures Some"),
-                ));
+                return Some(sv.name_range(c.name.expect("match guard ensures Some")));
             }
             StmtKind::Interface(i) if i.name == name => {
-                return Some(name_range(source, line_starts, i.name));
+                return Some(sv.name_range(i.name));
             }
             StmtKind::Trait(t) if t.name == name => {
-                return Some(name_range(source, line_starts, t.name));
+                return Some(sv.name_range(t.name));
             }
             StmtKind::Enum(e) if e.name == name => {
-                return Some(name_range(source, line_starts, e.name));
+                return Some(sv.name_range(e.name));
             }
             StmtKind::Namespace(ns) => {
                 if let NamespaceBody::Braced(inner) = &ns.body
-                    && let Some(r) = find_class_range(source, line_starts, inner, name)
+                    && let Some(r) = find_class_range(sv, inner, name)
                 {
                     return Some(r);
                 }
@@ -111,13 +96,8 @@ fn find_class_range(
     None
 }
 
-fn _offset_to_position_range(
-    source: &str,
-    line_starts: &[u32],
-    name_str: &str,
-    _name: &str,
-) -> Range {
-    let start = offset_to_position(source, line_starts, 0);
+fn _offset_to_position_range(sv: SourceView<'_>, name_str: &str, _name: &str) -> Range {
+    let start = sv.position_of(0);
     Range {
         start,
         end: Position {

--- a/src/type_hierarchy.rs
+++ b/src/type_hierarchy.rs
@@ -17,7 +17,10 @@ pub fn prepare_type_hierarchy(
     let word = word_at(source, position)?;
     for (uri, doc) in all_docs {
         let doc_source = doc.source();
-        if let Some(item) = find_type_item(doc_source, &doc.program().stmts, &word, uri) {
+        let line_starts = doc.line_starts();
+        if let Some(item) =
+            find_type_item(doc_source, line_starts, &doc.program().stmts, &word, uri)
+        {
             return Some(item);
         }
     }
@@ -26,6 +29,7 @@ pub fn prepare_type_hierarchy(
 
 fn find_type_item(
     source: &str,
+    line_starts: &[u32],
     stmts: &[Stmt<'_, '_>],
     word: &str,
     uri: &Url,
@@ -34,20 +38,38 @@ fn find_type_item(
         match &stmt.kind {
             StmtKind::Class(c) if c.name == Some(word) => {
                 let name = c.name.expect("match guard ensures Some");
-                return Some(make_item(source, name, SymbolKind::CLASS, uri));
+                return Some(make_item(source, line_starts, name, SymbolKind::CLASS, uri));
             }
             StmtKind::Interface(i) if i.name == word => {
-                return Some(make_item(source, i.name, SymbolKind::INTERFACE, uri));
+                return Some(make_item(
+                    source,
+                    line_starts,
+                    i.name,
+                    SymbolKind::INTERFACE,
+                    uri,
+                ));
             }
             StmtKind::Trait(t) if t.name == word => {
-                return Some(make_item(source, t.name, SymbolKind::CLASS, uri));
+                return Some(make_item(
+                    source,
+                    line_starts,
+                    t.name,
+                    SymbolKind::CLASS,
+                    uri,
+                ));
             }
             StmtKind::Enum(e) if e.name == word => {
-                return Some(make_item(source, e.name, SymbolKind::ENUM, uri));
+                return Some(make_item(
+                    source,
+                    line_starts,
+                    e.name,
+                    SymbolKind::ENUM,
+                    uri,
+                ));
             }
             StmtKind::Namespace(ns) => {
                 if let NamespaceBody::Braced(inner) = &ns.body
-                    && let Some(item) = find_type_item(source, inner, word, uri)
+                    && let Some(item) = find_type_item(source, line_starts, inner, word, uri)
                 {
                     return Some(item);
                 }
@@ -58,8 +80,14 @@ fn find_type_item(
     None
 }
 
-fn make_item(source: &str, name: &str, kind: SymbolKind, uri: &Url) -> TypeHierarchyItem {
-    let range = name_range(source, name);
+fn make_item(
+    source: &str,
+    line_starts: &[u32],
+    name: &str,
+    kind: SymbolKind,
+    uri: &Url,
+) -> TypeHierarchyItem {
+    let range = name_range(source, line_starts, name);
     TypeHierarchyItem {
         name: name.to_string(),
         kind,
@@ -88,7 +116,10 @@ pub fn supertypes_of(
     for name in super_names {
         for (uri, doc) in all_docs {
             let doc_source = doc.source();
-            if let Some(super_item) = find_type_item(doc_source, &doc.program().stmts, &name, uri) {
+            let line_starts = doc.line_starts();
+            if let Some(super_item) =
+                find_type_item(doc_source, line_starts, &doc.program().stmts, &name, uri)
+            {
                 result.push(super_item);
                 break;
             }
@@ -137,8 +168,10 @@ pub fn subtypes_of(
     let mut result = Vec::new();
     for (uri, doc) in all_docs {
         let doc_source = doc.source();
+        let line_starts = doc.line_starts();
         collect_subtypes(
             doc_source,
+            line_starts,
             &doc.program().stmts,
             &item.name,
             uri,
@@ -150,6 +183,7 @@ pub fn subtypes_of(
 
 fn collect_subtypes(
     source: &str,
+    line_starts: &[u32],
     stmts: &[Stmt<'_, '_>],
     parent_name: &str,
     uri: &Url,
@@ -179,7 +213,7 @@ fn collect_subtypes(
                 if (extends_match || implements_match || trait_use_match)
                     && let Some(name) = c.name
                 {
-                    out.push(make_item(source, name, SymbolKind::CLASS, uri));
+                    out.push(make_item(source, line_starts, name, SymbolKind::CLASS, uri));
                 }
             }
             StmtKind::Interface(i) => {
@@ -188,7 +222,13 @@ fn collect_subtypes(
                     .iter()
                     .any(|p| p.to_string_repr().as_ref() == parent_name);
                 if extends_match {
-                    out.push(make_item(source, i.name, SymbolKind::INTERFACE, uri));
+                    out.push(make_item(
+                        source,
+                        line_starts,
+                        i.name,
+                        SymbolKind::INTERFACE,
+                        uri,
+                    ));
                 }
             }
             StmtKind::Enum(e) => {
@@ -197,12 +237,18 @@ fn collect_subtypes(
                     .iter()
                     .any(|i| i.to_string_repr().as_ref() == parent_name);
                 if implements_match {
-                    out.push(make_item(source, e.name, SymbolKind::ENUM, uri));
+                    out.push(make_item(
+                        source,
+                        line_starts,
+                        e.name,
+                        SymbolKind::ENUM,
+                        uri,
+                    ));
                 }
             }
             StmtKind::Namespace(ns) => {
                 if let NamespaceBody::Braced(inner) = &ns.body {
-                    collect_subtypes(source, inner, parent_name, uri, out);
+                    collect_subtypes(source, line_starts, inner, parent_name, uri, out);
                 }
             }
             _ => {}

--- a/src/type_hierarchy.rs
+++ b/src/type_hierarchy.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use php_ast::{ClassMemberKind, NamespaceBody, Stmt, StmtKind};
 use tower_lsp::lsp_types::{Position, SymbolKind, TypeHierarchyItem, Url};
 
-use crate::ast::{ParsedDoc, name_range};
+use crate::ast::{ParsedDoc, SourceView};
 use crate::util::word_at;
 
 // ── Prepare ───────────────────────────────────────────────────────────────────
@@ -16,11 +16,8 @@ pub fn prepare_type_hierarchy(
 ) -> Option<TypeHierarchyItem> {
     let word = word_at(source, position)?;
     for (uri, doc) in all_docs {
-        let doc_source = doc.source();
-        let line_starts = doc.line_starts();
-        if let Some(item) =
-            find_type_item(doc_source, line_starts, &doc.program().stmts, &word, uri)
-        {
+        let sv = doc.view();
+        if let Some(item) = find_type_item(sv, &doc.program().stmts, &word, uri) {
             return Some(item);
         }
     }
@@ -28,8 +25,7 @@ pub fn prepare_type_hierarchy(
 }
 
 fn find_type_item(
-    source: &str,
-    line_starts: &[u32],
+    sv: SourceView<'_>,
     stmts: &[Stmt<'_, '_>],
     word: &str,
     uri: &Url,
@@ -38,38 +34,20 @@ fn find_type_item(
         match &stmt.kind {
             StmtKind::Class(c) if c.name == Some(word) => {
                 let name = c.name.expect("match guard ensures Some");
-                return Some(make_item(source, line_starts, name, SymbolKind::CLASS, uri));
+                return Some(make_item(sv, name, SymbolKind::CLASS, uri));
             }
             StmtKind::Interface(i) if i.name == word => {
-                return Some(make_item(
-                    source,
-                    line_starts,
-                    i.name,
-                    SymbolKind::INTERFACE,
-                    uri,
-                ));
+                return Some(make_item(sv, i.name, SymbolKind::INTERFACE, uri));
             }
             StmtKind::Trait(t) if t.name == word => {
-                return Some(make_item(
-                    source,
-                    line_starts,
-                    t.name,
-                    SymbolKind::CLASS,
-                    uri,
-                ));
+                return Some(make_item(sv, t.name, SymbolKind::CLASS, uri));
             }
             StmtKind::Enum(e) if e.name == word => {
-                return Some(make_item(
-                    source,
-                    line_starts,
-                    e.name,
-                    SymbolKind::ENUM,
-                    uri,
-                ));
+                return Some(make_item(sv, e.name, SymbolKind::ENUM, uri));
             }
             StmtKind::Namespace(ns) => {
                 if let NamespaceBody::Braced(inner) = &ns.body
-                    && let Some(item) = find_type_item(source, line_starts, inner, word, uri)
+                    && let Some(item) = find_type_item(sv, inner, word, uri)
                 {
                     return Some(item);
                 }
@@ -80,14 +58,8 @@ fn find_type_item(
     None
 }
 
-fn make_item(
-    source: &str,
-    line_starts: &[u32],
-    name: &str,
-    kind: SymbolKind,
-    uri: &Url,
-) -> TypeHierarchyItem {
-    let range = name_range(source, line_starts, name);
+fn make_item(sv: SourceView<'_>, name: &str, kind: SymbolKind, uri: &Url) -> TypeHierarchyItem {
+    let range = sv.name_range(name);
     TypeHierarchyItem {
         name: name.to_string(),
         kind,
@@ -115,11 +87,8 @@ pub fn supertypes_of(
     let mut result = Vec::new();
     for name in super_names {
         for (uri, doc) in all_docs {
-            let doc_source = doc.source();
-            let line_starts = doc.line_starts();
-            if let Some(super_item) =
-                find_type_item(doc_source, line_starts, &doc.program().stmts, &name, uri)
-            {
+            let sv = doc.view();
+            if let Some(super_item) = find_type_item(sv, &doc.program().stmts, &name, uri) {
                 result.push(super_item);
                 break;
             }
@@ -167,23 +136,14 @@ pub fn subtypes_of(
 ) -> Vec<TypeHierarchyItem> {
     let mut result = Vec::new();
     for (uri, doc) in all_docs {
-        let doc_source = doc.source();
-        let line_starts = doc.line_starts();
-        collect_subtypes(
-            doc_source,
-            line_starts,
-            &doc.program().stmts,
-            &item.name,
-            uri,
-            &mut result,
-        );
+        let sv = doc.view();
+        collect_subtypes(sv, &doc.program().stmts, &item.name, uri, &mut result);
     }
     result
 }
 
 fn collect_subtypes(
-    source: &str,
-    line_starts: &[u32],
+    sv: SourceView<'_>,
     stmts: &[Stmt<'_, '_>],
     parent_name: &str,
     uri: &Url,
@@ -213,7 +173,7 @@ fn collect_subtypes(
                 if (extends_match || implements_match || trait_use_match)
                     && let Some(name) = c.name
                 {
-                    out.push(make_item(source, line_starts, name, SymbolKind::CLASS, uri));
+                    out.push(make_item(sv, name, SymbolKind::CLASS, uri));
                 }
             }
             StmtKind::Interface(i) => {
@@ -222,13 +182,7 @@ fn collect_subtypes(
                     .iter()
                     .any(|p| p.to_string_repr().as_ref() == parent_name);
                 if extends_match {
-                    out.push(make_item(
-                        source,
-                        line_starts,
-                        i.name,
-                        SymbolKind::INTERFACE,
-                        uri,
-                    ));
+                    out.push(make_item(sv, i.name, SymbolKind::INTERFACE, uri));
                 }
             }
             StmtKind::Enum(e) => {
@@ -237,18 +191,12 @@ fn collect_subtypes(
                     .iter()
                     .any(|i| i.to_string_repr().as_ref() == parent_name);
                 if implements_match {
-                    out.push(make_item(
-                        source,
-                        line_starts,
-                        e.name,
-                        SymbolKind::ENUM,
-                        uri,
-                    ));
+                    out.push(make_item(sv, e.name, SymbolKind::ENUM, uri));
                 }
             }
             StmtKind::Namespace(ns) => {
                 if let NamespaceBody::Braced(inner) = &ns.body {
-                    collect_subtypes(source, line_starts, inner, parent_name, uri, out);
+                    collect_subtypes(sv, inner, parent_name, uri, out);
                 }
             }
             _ => {}

--- a/src/type_map.rs
+++ b/src/type_map.rs
@@ -891,29 +891,35 @@ fn mixin_classes_in_stmts(source: &str, stmts: &[Stmt<'_, '_>], class_name: &str
 
 /// Return the name of the class whose body contains `position`, or `None`.
 pub fn enclosing_class_at(source: &str, doc: &ParsedDoc, position: Position) -> Option<String> {
-    enclosing_class_in_stmts(source, &doc.program().stmts, position)
+    let line_starts = doc.line_starts();
+    enclosing_class_in_stmts(source, line_starts, &doc.program().stmts, position)
 }
 
-fn enclosing_class_in_stmts(source: &str, stmts: &[Stmt<'_, '_>], pos: Position) -> Option<String> {
+fn enclosing_class_in_stmts(
+    source: &str,
+    line_starts: &[u32],
+    stmts: &[Stmt<'_, '_>],
+    pos: Position,
+) -> Option<String> {
     for stmt in stmts {
         match &stmt.kind {
             StmtKind::Class(c) => {
-                let start = offset_to_position(source, stmt.span.start).line;
-                let end = offset_to_position(source, stmt.span.end).line;
+                let start = offset_to_position(source, line_starts, stmt.span.start).line;
+                let end = offset_to_position(source, line_starts, stmt.span.end).line;
                 if pos.line >= start && pos.line <= end {
                     return c.name.map(|n| n.to_string());
                 }
             }
             StmtKind::Enum(e) => {
-                let start = offset_to_position(source, stmt.span.start).line;
-                let end = offset_to_position(source, stmt.span.end).line;
+                let start = offset_to_position(source, line_starts, stmt.span.start).line;
+                let end = offset_to_position(source, line_starts, stmt.span.end).line;
                 if pos.line >= start && pos.line <= end {
                     return Some(e.name.to_string());
                 }
             }
             StmtKind::Namespace(ns) => {
                 if let NamespaceBody::Braced(inner) = &ns.body
-                    && let Some(found) = enclosing_class_in_stmts(source, inner, pos)
+                    && let Some(found) = enclosing_class_in_stmts(source, line_starts, inner, pos)
                 {
                     return Some(found);
                 }

--- a/src/type_map.rs
+++ b/src/type_map.rs
@@ -9,7 +9,7 @@ use php_ast::{
 };
 use tower_lsp::lsp_types::Position;
 
-use crate::ast::{ParsedDoc, offset_to_position};
+use crate::ast::{ParsedDoc, SourceView};
 use crate::docblock::{docblock_before, parse_docblock};
 use crate::phpstorm_meta::PhpStormMeta;
 
@@ -890,36 +890,35 @@ fn mixin_classes_in_stmts(source: &str, stmts: &[Stmt<'_, '_>], class_name: &str
 }
 
 /// Return the name of the class whose body contains `position`, or `None`.
-pub fn enclosing_class_at(source: &str, doc: &ParsedDoc, position: Position) -> Option<String> {
-    let line_starts = doc.line_starts();
-    enclosing_class_in_stmts(source, line_starts, &doc.program().stmts, position)
+pub fn enclosing_class_at(_source: &str, doc: &ParsedDoc, position: Position) -> Option<String> {
+    let sv = doc.view();
+    enclosing_class_in_stmts(sv, &doc.program().stmts, position)
 }
 
 fn enclosing_class_in_stmts(
-    source: &str,
-    line_starts: &[u32],
+    sv: SourceView<'_>,
     stmts: &[Stmt<'_, '_>],
     pos: Position,
 ) -> Option<String> {
     for stmt in stmts {
         match &stmt.kind {
             StmtKind::Class(c) => {
-                let start = offset_to_position(source, line_starts, stmt.span.start).line;
-                let end = offset_to_position(source, line_starts, stmt.span.end).line;
+                let start = sv.position_of(stmt.span.start).line;
+                let end = sv.position_of(stmt.span.end).line;
                 if pos.line >= start && pos.line <= end {
                     return c.name.map(|n| n.to_string());
                 }
             }
             StmtKind::Enum(e) => {
-                let start = offset_to_position(source, line_starts, stmt.span.start).line;
-                let end = offset_to_position(source, line_starts, stmt.span.end).line;
+                let start = sv.position_of(stmt.span.start).line;
+                let end = sv.position_of(stmt.span.end).line;
                 if pos.line >= start && pos.line <= end {
                     return Some(e.name.to_string());
                 }
             }
             StmtKind::Namespace(ns) => {
                 if let NamespaceBody::Braced(inner) = &ns.body
-                    && let Some(found) = enclosing_class_in_stmts(source, line_starts, inner, pos)
+                    && let Some(found) = enclosing_class_in_stmts(sv, inner, pos)
                 {
                     return Some(found);
                 }


### PR DESCRIPTION
## Summary

- Add `line_starts: Vec<u32>` to `ParsedDoc`, built once during `parse()` by scanning for `\n` positions (~200 bytes for a 200-line file)
- Replace the linear scan in `offset_to_position` with a `partition_point` binary search: O(log n) line lookup instead of O(file_size)
- Thread `line_starts: &[u32]` through all inner functions that call `offset_to_position`, `span_to_range`, or `name_range`

## Motivation

Every call to `offset_to_position` previously scanned `source[..offset]` from the beginning, counting `\n` bytes and finding the last newline. For a 500-line file with 300 semantic tokens, that's ~7.5 MB of source scanning per request. The cost scales with both file size and token count.

The fix pays one O(n) scan at parse time and converts every subsequent position lookup to O(log lines + line_length).

## Trade-offs

- One extra allocation per `ParsedDoc` (~200 bytes at 10k files = ~2 MB total, negligible)
- One extra O(n) byte scan at parse time (cheap compared to parsing itself)
- Column computation is still O(line_length) — only the line lookup is accelerated
- ~40 inner function signatures gained a `line_starts: &[u32]` parameter

## Test plan

- [ ] `cargo test` — all 784 tests pass
- [ ] Existing `offset_to_position` unit tests in `ast.rs` cover LF, CRLF, multibyte UTF-16, and start-of-file edge cases