### PR TITLE
fix(walk): ClassConstAccess span covers member name, not whole expression

### DIFF
--- a/src/references.rs
+++ b/src/references.rs
@@ -562,6 +562,57 @@ mod tests {
     }
 
     #[test]
+    fn class_const_access_span_covers_only_member_name() {
+        // Searching for the constant name `ACTIVE` in `Status::ACTIVE` must highlight
+        // only `ACTIVE`, not the whole `Status::ACTIVE` expression.
+        // Line 0: <?php
+        // Line 1: $x = Status::ACTIVE;
+        let src = "<?php\n$x = Status::ACTIVE;";
+        let docs = vec![doc("/a.php", src)];
+        let refs = find_references("ACTIVE", &docs, false, None);
+        assert_eq!(refs.len(), 1, "expected 1 reference, got: {:?}", refs);
+        // The range must span exactly "ACTIVE" (6 chars), starting after "Status::".
+        let r = &refs[0].range;
+        assert_eq!(r.start.line, 1);
+        let span_len = r.end.character - r.start.character;
+        assert_eq!(
+            span_len, 6,
+            "range must cover only 'ACTIVE' (6 chars), got {} chars at {:?}",
+            span_len, r
+        );
+        // "$x = Status::" is 13 chars; "ACTIVE" starts at character 13.
+        assert_eq!(
+            r.start.character, 13,
+            "range must start at 'ACTIVE', not at 'Status'"
+        );
+    }
+
+    #[test]
+    fn class_const_access_no_duplicate_when_name_equals_class() {
+        // Edge case: enum case named the same as the enum itself — `Status::Status`.
+        // Searching for `Status` must not produce a duplicate span from the member match.
+        // Line 0: <?php
+        // Line 1: $x = Status::Status;
+        let src = "<?php\n$x = Status::Status;";
+        let docs = vec![doc("/a.php", src)];
+        let refs = find_references("Status", &docs, false, None);
+        // Both the class part (`Status`) and the member part (`Status`) are at different
+        // byte offsets after the fix, so dedup is not needed — but we must not get
+        // duplicate positions.
+        let positions: Vec<_> = refs
+            .iter()
+            .map(|r| (r.range.start.line, r.range.start.character))
+            .collect();
+        let unique: std::collections::HashSet<_> = positions.iter().collect();
+        assert_eq!(
+            positions.len(),
+            unique.len(),
+            "duplicate positions found for Status::Status: {:?}",
+            refs
+        );
+    }
+
+    #[test]
     fn finds_reference_inside_enum_method_body() {
         // A function call inside an enum method body should be found by find_references.
         let src = "<?php\nfunction helper() {}\nenum Status {\n    public function label(): string { return helper(); }\n}";

--- a/src/references.rs
+++ b/src/references.rs
@@ -567,47 +567,48 @@ mod tests {
         // only `ACTIVE`, not the whole `Status::ACTIVE` expression.
         // Line 0: <?php
         // Line 1: $x = Status::ACTIVE;
+        //                       ^ character 13
         let src = "<?php\n$x = Status::ACTIVE;";
         let docs = vec![doc("/a.php", src)];
         let refs = find_references("ACTIVE", &docs, false, None);
         assert_eq!(refs.len(), 1, "expected 1 reference, got: {:?}", refs);
-        // The range must span exactly "ACTIVE" (6 chars), starting after "Status::".
         let r = &refs[0].range;
-        assert_eq!(r.start.line, 1);
-        let span_len = r.end.character - r.start.character;
-        assert_eq!(
-            span_len, 6,
-            "range must cover only 'ACTIVE' (6 chars), got {} chars at {:?}",
-            span_len, r
-        );
+        assert_eq!(r.start.line, 1, "reference must be on line 1");
         // "$x = Status::" is 13 chars; "ACTIVE" starts at character 13.
+        // Before the fix this was 5 (the start of "Status"), not 13.
         assert_eq!(
             r.start.character, 13,
-            "range must start at 'ACTIVE', not at 'Status'"
+            "range must start at 'ACTIVE' (char 13), not at 'Status' (char 5); got {:?}",
+            r
         );
     }
 
     #[test]
     fn class_const_access_no_duplicate_when_name_equals_class() {
         // Edge case: enum case named the same as the enum itself — `Status::Status`.
-        // Searching for `Status` must not produce a duplicate span from the member match.
+        // The general walker finds two distinct references:
+        //   - the class-side `Status` at character 5  ($x = [S]tatus::Status)
+        //   - the member-side `Status` at character 13 ($x = Status::[S]tatus)
+        // Before the fix, both pushed a span starting at character 5, producing a duplicate.
         // Line 0: <?php
         // Line 1: $x = Status::Status;
+        //              ^    char 5 (class)
+        //                       ^ char 13 (member)
         let src = "<?php\n$x = Status::Status;";
         let docs = vec![doc("/a.php", src)];
         let refs = find_references("Status", &docs, false, None);
-        // Both the class part (`Status`) and the member part (`Status`) are at different
-        // byte offsets after the fix, so dedup is not needed — but we must not get
-        // duplicate positions.
-        let positions: Vec<_> = refs
-            .iter()
-            .map(|r| (r.range.start.line, r.range.start.character))
-            .collect();
-        let unique: std::collections::HashSet<_> = positions.iter().collect();
         assert_eq!(
-            positions.len(),
-            unique.len(),
-            "duplicate positions found for Status::Status: {:?}",
+            refs.len(),
+            2,
+            "expected exactly 2 refs (class side + member side), got: {:?}",
+            refs
+        );
+        let mut chars: Vec<u32> = refs.iter().map(|r| r.range.start.character).collect();
+        chars.sort_unstable();
+        assert_eq!(
+            chars,
+            vec![5, 13],
+            "class-side ref must be at char 5 and member-side at char 13, got: {:?}",
             refs
         );
     }

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -956,7 +956,7 @@ pub fn refs_in_expr(source: &str, expr: &Expr<'_, '_>, word: &str, out: &mut Vec
         ExprKind::ClassConstAccess(c) => {
             refs_in_expr(source, c.class, word, out);
             if c.member.name_str() == Some(word) {
-                out.push(expr.span);
+                out.push(c.member.span);
             }
         }
         ExprKind::Closure(c) => refs_in_stmts(source, &c.body, word, out),


### PR DESCRIPTION
Fixes #167.

## Problem

`refs_in_expr` in `src/walk.rs` pushed `expr.span` (the span of the entire `Foo::BAR` expression) when the constant member name matched the search word. This meant:

- Searching for `ACTIVE` in `Status::ACTIVE` highlighted `Status::ACTIVE` starting at `S`, instead of highlighting only `ACTIVE`
- When the class and constant share the same name (e.g. `Status::Status` for a backed enum case), both the class-side recursion and the member check produced spans with the same start byte offset, requiring the dedup added in #166 to mask the symptom

## Fix

One-line change: `out.push(expr.span)` → `out.push(c.member.span)`, consistent with how `StaticMethodCall` already uses `s.method.span`.

## Tests

Two new tests in `src/references.rs`:
- `class_const_access_span_covers_only_member_name` — verifies the highlighted range starts at the constant name, not the class name
- `class_const_access_no_duplicate_when_name_equals_class` — verifies no duplicate positions for the `Status::Status` edge case