### PR TITLE
fix(walk): guard function_refs_in_expr against double-push on plain callee

### DIFF
--- a/src/walk.rs
+++ b/src/walk.rs
@@ -1078,13 +1078,16 @@ fn function_refs_in_expr(expr: &Expr<'_, '_>, name: &str, out: &mut Vec<Span>) {
     match &expr.kind {
         // The core match: a free function call whose callee is a bare identifier.
         ExprKind::FunctionCall(f) => {
-            if let ExprKind::Identifier(id) = &f.name.kind
-                && id.as_str() == name
-            {
-                out.push(f.name.span);
+            if let ExprKind::Identifier(id) = &f.name.kind {
+                if id.as_str() == name {
+                    out.push(f.name.span);
+                }
+                // Plain identifier callee already handled above — do not recurse
+                // into it, or adding an Identifier arm later would double-push.
+            } else {
+                // Dynamic callee: $fn(), get_fn()(), etc.
+                function_refs_in_expr(f.name, name, out);
             }
-            // Still recurse into args and a dynamic callee.
-            function_refs_in_expr(f.name, name, out);
             for a in f.args.iter() {
                 function_refs_in_expr(&a.value, name, out);
             }


### PR DESCRIPTION
Closes #168

## What

For a plain identifier callee like `foo()`, `function_refs_in_expr` was:
1. Explicitly pushing the callee span when the name matched **(A)**
2. Then **unconditionally** recursing into `f.name` **(B)**

Today (B) is a no-op because there is no `Identifier` arm in `function_refs_in_expr`. But adding one for any reason would cause every plain function call to appear twice in `textDocument/references` results.

## Fix

Guard the recursion so it only fires for dynamic callees (`$fn()`, `get_fn()()`, etc.), matching the pattern used in `method_refs_in_expr`.

## Test plan

The existing `references_finds_all_usages_of_function` integration test asserts exactly 3 results (1 declaration + 2 call sites) and would catch any double-push regression.