### PR TITLE
perf/feat: slim FileIndex and configurable maxIndexedFiles limit

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -18,8 +18,8 @@ use crate::autoload::Psr4Map;
 use crate::call_hierarchy::{incoming_calls, outgoing_calls, prepare_call_hierarchy};
 use crate::code_lens::code_lenses;
 use crate::completion::{CompletionCtx, filtered_completions_at};
-use crate::declaration::goto_declaration;
-use crate::definition::{find_declaration_range, goto_definition};
+use crate::declaration::{goto_declaration, goto_declaration_from_index};
+use crate::definition::{find_declaration_range, find_in_indexes, goto_definition};
 use crate::diagnostics::parse_document;
 use crate::document_highlight::document_highlights;
 use crate::document_link::document_links;
@@ -31,9 +31,9 @@ use crate::file_rename::{use_edits_for_delete, use_edits_for_rename};
 use crate::folding::folding_ranges;
 use crate::formatting::{format_document, format_range};
 use crate::generate_action::{generate_constructor_actions, generate_getters_setters_actions};
-use crate::hover::{docs_for_symbol, hover_info, signature_for_symbol};
+use crate::hover::{docs_for_symbol_from_index, hover_info, signature_for_symbol_from_index};
 use crate::implement_action::implement_missing_actions;
-use crate::implementation::goto_implementation;
+use crate::implementation::{find_implementations, find_implementations_from_index};
 use crate::inlay_hints::inlay_hints;
 use crate::inline_action::inline_variable_actions;
 use crate::inline_value::inline_values_in_range;
@@ -54,10 +54,12 @@ use crate::semantic_tokens::{
     compute_token_delta, legend, semantic_tokens, semantic_tokens_range, token_hash,
 };
 use crate::signature_help::signature_help;
-use crate::symbols::{document_symbols, resolve_workspace_symbol, workspace_symbols};
+use crate::symbols::{document_symbols, resolve_workspace_symbol, workspace_symbols_from_index};
 use crate::type_action::add_return_type_actions;
-use crate::type_definition::goto_type_definition;
-use crate::type_hierarchy::{prepare_type_hierarchy, subtypes_of, supertypes_of};
+use crate::type_definition::{goto_type_definition, goto_type_definition_from_index};
+use crate::type_hierarchy::{
+    prepare_type_hierarchy_from_index, subtypes_of_from_index, supertypes_of_from_index,
+};
 use crate::use_import::{build_use_import_edit, find_fqn_for_class};
 use crate::util::word_at;
 
@@ -780,15 +782,15 @@ impl LanguageServer for Backend {
                     if let Ok(path) = change.uri.to_file_path()
                         && let Ok(text) = tokio::fs::read_to_string(&path).await
                     {
-                        self.docs.index(change.uri.clone(), &text);
-                        if let Some(d) = self.docs.get_doc(&change.uri) {
-                            self.codebase.remove_file_definitions(change.uri.as_str());
-                            self.collect_definitions_for(&change.uri, &d);
-                            self.codebase.finalize();
-                            if self.ref_index_ready.load(Ordering::Acquire) {
-                                index_file_references(&change.uri, &d, &self.codebase);
-                            }
+                        // Parse first to collect into codebase, then index (which drops ParsedDoc).
+                        let (doc, _diags) = parse_document(&text);
+                        self.codebase.remove_file_definitions(change.uri.as_str());
+                        self.collect_definitions_for(&change.uri, &doc);
+                        self.codebase.finalize();
+                        if self.ref_index_ready.load(Ordering::Acquire) {
+                            index_file_references(&change.uri, &doc, &self.codebase);
                         }
+                        self.docs.index(change.uri.clone(), &text);
                     }
                 }
                 FileChangeType::DELETED => {
@@ -847,14 +849,14 @@ impl LanguageServer for Backend {
         }
         // Strip trailing ':' from named-argument labels (e.g. "param:") before lookup.
         let name = item.label.trim_end_matches(':');
-        let all_docs = self.docs.all_docs();
+        let all_indexes = self.docs.all_indexes();
         if item.detail.is_none()
-            && let Some(sig) = signature_for_symbol(name, &all_docs)
+            && let Some(sig) = signature_for_symbol_from_index(name, &all_indexes)
         {
             item.detail = Some(sig);
         }
         if item.documentation.is_none()
-            && let Some(md) = docs_for_symbol(name, &all_docs)
+            && let Some(md) = docs_for_symbol_from_index(name, &all_indexes)
         {
             item.documentation = Some(Documentation::MarkupContent(MarkupContent {
                 kind: MarkupKind::Markdown,
@@ -875,10 +877,16 @@ impl LanguageServer for Backend {
             Some(d) => d,
             None => return Ok(None),
         };
-        let other_docs = self.docs.other_docs(uri);
-
-        // Primary lookup: search all indexed documents
-        if let Some(loc) = goto_definition(uri, &source, &doc, &other_docs, position) {
+        // Search current file's ParsedDoc first (fast), then fall back to index search.
+        let empty_other_docs: Vec<(Url, Arc<ParsedDoc>)> = vec![];
+        if let Some(loc) = goto_definition(uri, &source, &doc, &empty_other_docs, position) {
+            return Ok(Some(GotoDefinitionResponse::Scalar(loc)));
+        }
+        // Cross-file: use FileIndex (no disk I/O for background files).
+        let other_indexes = self.docs.other_indexes(uri);
+        if let Some(word) = crate::util::word_at(&source, position)
+            && let Some(loc) = find_in_indexes(&word, &other_indexes)
+        {
             return Ok(Some(GotoDefinitionResponse::Scalar(loc)));
         }
 
@@ -911,7 +919,7 @@ impl LanguageServer for Backend {
         } else {
             symbol_kind_at(&source, position, &word)
         };
-        let all_docs = self.docs.all_docs();
+        let all_docs = self.docs.all_docs_for_scan();
         let include_declaration = params.context.include_declaration;
 
         // Fast path: use the pre-computed reference index once it is ready.
@@ -962,10 +970,10 @@ impl LanguageServer for Backend {
                 position,
             )))
         } else if is_after_arrow(&source, position) {
-            let all_docs = self.docs.all_docs();
+            let all_docs = self.docs.all_docs_for_scan();
             Ok(Some(rename_property(&word, &params.new_name, &all_docs)))
         } else {
-            let all_docs = self.docs.all_docs();
+            let all_docs = self.docs.all_docs_for_scan();
             Ok(Some(rename(&word, &params.new_name, &all_docs)))
         }
     }
@@ -1042,8 +1050,8 @@ impl LanguageServer for Backend {
             .and_then(|v| v.as_str())
             .map(str::to_string);
         if let Some(name) = func_name {
-            let all_docs = self.docs.all_docs();
-            if let Some(md) = docs_for_symbol(&name, &all_docs) {
+            let all_indexes = self.docs.all_indexes();
+            if let Some(md) = docs_for_symbol_from_index(&name, &all_indexes) {
                 item.tooltip = Some(InlayHintTooltip::MarkupContent(MarkupContent {
                     kind: MarkupKind::Markdown,
                     value: md,
@@ -1057,8 +1065,8 @@ impl LanguageServer for Backend {
         &self,
         params: WorkspaceSymbolParams,
     ) -> Result<Option<Vec<SymbolInformation>>> {
-        let docs = self.docs.all_docs();
-        let results = workspace_symbols(&params.query, &docs);
+        let indexes = self.docs.all_indexes();
+        let results = workspace_symbols_from_index(&params.query, &indexes);
         Ok(if results.is_empty() {
             None
         } else {
@@ -1067,6 +1075,7 @@ impl LanguageServer for Backend {
     }
 
     async fn symbol_resolve(&self, params: WorkspaceSymbol) -> Result<WorkspaceSymbol> {
+        // For resolve, we need the full range from the ParsedDoc of open files.
         let docs = self.docs.all_docs();
         Ok(resolve_workspace_symbol(params, &docs))
     }
@@ -1174,7 +1183,7 @@ impl LanguageServer for Backend {
             Some(w) => w,
             None => return Ok(None),
         };
-        let all_docs = self.docs.all_docs();
+        let all_docs = self.docs.all_docs_for_scan();
         Ok(prepare_call_hierarchy(&word, &all_docs).map(|item| vec![item]))
     }
 
@@ -1182,7 +1191,7 @@ impl LanguageServer for Backend {
         &self,
         params: CallHierarchyIncomingCallsParams,
     ) -> Result<Option<Vec<CallHierarchyIncomingCall>>> {
-        let all_docs = self.docs.all_docs();
+        let all_docs = self.docs.all_docs_for_scan();
         let calls = incoming_calls(&params.item, &all_docs);
         Ok(if calls.is_empty() { None } else { Some(calls) })
     }
@@ -1191,7 +1200,7 @@ impl LanguageServer for Backend {
         &self,
         params: CallHierarchyOutgoingCallsParams,
     ) -> Result<Option<Vec<CallHierarchyOutgoingCall>>> {
-        let all_docs = self.docs.all_docs();
+        let all_docs = self.docs.all_docs_for_scan();
         let calls = outgoing_calls(&params.item, &all_docs);
         Ok(if calls.is_empty() { None } else { Some(calls) })
     }
@@ -1246,9 +1255,17 @@ impl LanguageServer for Backend {
         let uri = &params.text_document_position_params.text_document.uri;
         let position = params.text_document_position_params.position;
         let source = self.docs.get(uri).unwrap_or_default();
-        let all_docs = self.docs.all_docs();
         let imports = self.file_imports(uri);
-        let locs = goto_implementation(&source, &all_docs, position, &imports);
+        let word = crate::util::word_at(&source, position).unwrap_or_default();
+        let fqn = imports.get(&word).map(|s| s.as_str());
+        // First pass: open-file ParsedDocs give accurate character positions.
+        let open_docs = self.docs.all_docs();
+        let mut locs = find_implementations(&word, fqn, &open_docs);
+        if locs.is_empty() {
+            // Second pass: background files via FileIndex (line-only positions).
+            let all_indexes = self.docs.all_indexes();
+            locs = find_implementations_from_index(&word, fqn, &all_indexes);
+        }
         if locs.is_empty() {
             Ok(None)
         } else {
@@ -1263,8 +1280,15 @@ impl LanguageServer for Backend {
         let uri = &params.text_document_position_params.text_document.uri;
         let position = params.text_document_position_params.position;
         let source = self.docs.get(uri).unwrap_or_default();
-        let all_docs = self.docs.all_docs();
-        Ok(goto_declaration(&source, &all_docs, position).map(GotoDefinitionResponse::Scalar))
+        // First pass: open-file ParsedDocs give accurate character positions.
+        let open_docs = self.docs.all_docs();
+        if let Some(loc) = goto_declaration(&source, &open_docs, position) {
+            return Ok(Some(GotoDefinitionResponse::Scalar(loc)));
+        }
+        // Second pass: background files via FileIndex (line-only positions).
+        let all_indexes = self.docs.all_indexes();
+        Ok(goto_declaration_from_index(&source, &all_indexes, position)
+            .map(GotoDefinitionResponse::Scalar))
     }
 
     async fn goto_type_definition(
@@ -1278,9 +1302,17 @@ impl LanguageServer for Backend {
             Some(d) => d,
             None => return Ok(None),
         };
-        let all_docs = self.docs.all_docs();
-        Ok(goto_type_definition(&source, &doc, &all_docs, position)
-            .map(GotoDefinitionResponse::Scalar))
+        // First pass: open-file ParsedDocs give accurate character positions.
+        let open_docs = self.docs.all_docs();
+        if let Some(loc) = goto_type_definition(&source, &doc, &open_docs, position) {
+            return Ok(Some(GotoDefinitionResponse::Scalar(loc)));
+        }
+        // Second pass: background files via FileIndex (line-only positions).
+        let all_indexes = self.docs.all_indexes();
+        Ok(
+            goto_type_definition_from_index(&source, &doc, &all_indexes, position)
+                .map(GotoDefinitionResponse::Scalar),
+        )
     }
 
     async fn prepare_type_hierarchy(
@@ -1290,16 +1322,19 @@ impl LanguageServer for Backend {
         let uri = &params.text_document_position_params.text_document.uri;
         let position = params.text_document_position_params.position;
         let source = self.docs.get(uri).unwrap_or_default();
-        let all_docs = self.docs.all_docs();
-        Ok(prepare_type_hierarchy(&source, &all_docs, position).map(|item| vec![item]))
+        let all_indexes = self.docs.all_indexes();
+        Ok(
+            prepare_type_hierarchy_from_index(&source, &all_indexes, position)
+                .map(|item| vec![item]),
+        )
     }
 
     async fn supertypes(
         &self,
         params: TypeHierarchySupertypesParams,
     ) -> Result<Option<Vec<TypeHierarchyItem>>> {
-        let all_docs = self.docs.all_docs();
-        let result = supertypes_of(&params.item, &all_docs);
+        let all_indexes = self.docs.all_indexes();
+        let result = supertypes_of_from_index(&params.item, &all_indexes);
         Ok(if result.is_empty() {
             None
         } else {
@@ -1311,8 +1346,8 @@ impl LanguageServer for Backend {
         &self,
         params: TypeHierarchySubtypesParams,
     ) -> Result<Option<Vec<TypeHierarchyItem>>> {
-        let all_docs = self.docs.all_docs();
-        let result = subtypes_of(&params.item, &all_docs);
+        let all_indexes = self.docs.all_indexes();
+        let result = subtypes_of_from_index(&params.item, &all_indexes);
         Ok(if result.is_empty() {
             None
         } else {
@@ -1326,7 +1361,7 @@ impl LanguageServer for Backend {
             Some(d) => d,
             None => return Ok(None),
         };
-        let all_docs = self.docs.all_docs();
+        let all_docs = self.docs.all_docs_for_scan();
         let lenses = code_lenses(uri, &doc, &all_docs);
         Ok(if lenses.is_empty() {
             None
@@ -1424,7 +1459,7 @@ impl LanguageServer for Backend {
 
     async fn will_rename_files(&self, params: RenameFilesParams) -> Result<Option<WorkspaceEdit>> {
         let psr4 = self.psr4.read().unwrap();
-        let all_docs = self.docs.all_docs();
+        let all_docs = self.docs.all_docs_for_scan();
         let mut merged_changes: std::collections::HashMap<
             tower_lsp::lsp_types::Url,
             Vec<tower_lsp::lsp_types::TextEdit>,
@@ -1563,7 +1598,7 @@ impl LanguageServer for Backend {
     /// `use` import referencing its PSR-4 class name.
     async fn will_delete_files(&self, params: DeleteFilesParams) -> Result<Option<WorkspaceEdit>> {
         let psr4 = self.psr4.read().unwrap();
-        let all_docs = self.docs.all_docs();
+        let all_docs = self.docs.all_docs_for_scan();
         let mut merged_changes: std::collections::HashMap<Url, Vec<TextEdit>> =
             std::collections::HashMap::new();
 
@@ -2384,10 +2419,11 @@ async fn scan_workspace(
                 return;
             };
             tokio::task::spawn_blocking(move || {
+                // Parse once: collect into codebase, then let docs.index()
+                // extract the FileIndex and drop the ParsedDoc.
+                let (doc, _diags) = parse_document(&text);
+                collect_into_codebase(&codebase, &uri, &doc);
                 docs.index(uri.clone(), &text);
-                if let Some(d) = docs.get_doc(&uri) {
-                    collect_into_codebase(&codebase, &uri, &d);
-                }
                 count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             })
             .await
@@ -2417,7 +2453,7 @@ async fn build_reference_index(
     // semantic_diagnostics calls that reset the finalized flag via
     // remove_file_definitions(), causing method-inheritance lookups to
     // transiently return None and silently drop those references from the index.
-    let all_docs = docs.all_docs();
+    let all_docs = docs.all_docs_for_scan();
     let parallelism = std::thread::available_parallelism()
         .map(|n| n.get())
         .unwrap_or(4);

--- a/src/declaration.rs
+++ b/src/declaration.rs
@@ -144,6 +144,87 @@ fn find_any_declaration(
     None
 }
 
+/// Find abstract or interface declaration using `FileIndex` entries.
+pub fn goto_declaration_from_index(
+    source: &str,
+    indexes: &[(
+        tower_lsp::lsp_types::Url,
+        std::sync::Arc<crate::file_index::FileIndex>,
+    )],
+    position: tower_lsp::lsp_types::Position,
+) -> Option<Location> {
+    use crate::file_index::ClassKind;
+    use crate::util::word_at;
+    let word = word_at(source, position)?;
+
+    let line_range = |line: u32| -> tower_lsp::lsp_types::Range {
+        let p = tower_lsp::lsp_types::Position { line, character: 0 };
+        tower_lsp::lsp_types::Range { start: p, end: p }
+    };
+
+    // First pass: abstract/interface declarations.
+    for (uri, idx) in indexes {
+        for cls in &idx.classes {
+            if cls.kind == ClassKind::Interface {
+                // Interface itself.
+                if cls.name == word {
+                    return Some(Location {
+                        uri: uri.clone(),
+                        range: line_range(cls.start_line),
+                    });
+                }
+                // Abstract method in interface.
+                for m in &cls.methods {
+                    if m.name == word {
+                        return Some(Location {
+                            uri: uri.clone(),
+                            range: line_range(m.start_line),
+                        });
+                    }
+                }
+            } else if cls.is_abstract {
+                for m in &cls.methods {
+                    if m.is_abstract && m.name == word {
+                        return Some(Location {
+                            uri: uri.clone(),
+                            range: line_range(m.start_line),
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    // Second pass: any declaration.
+    for (uri, idx) in indexes {
+        for f in &idx.functions {
+            if f.name == word {
+                return Some(Location {
+                    uri: uri.clone(),
+                    range: line_range(f.start_line),
+                });
+            }
+        }
+        for cls in &idx.classes {
+            if cls.name == word {
+                return Some(Location {
+                    uri: uri.clone(),
+                    range: line_range(cls.start_line),
+                });
+            }
+            for m in &cls.methods {
+                if m.name == word {
+                    return Some(Location {
+                        uri: uri.clone(),
+                        range: line_range(m.start_line),
+                    });
+                }
+            }
+        }
+    }
+    None
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/definition.rs
+++ b/src/definition.rs
@@ -126,6 +126,117 @@ fn scan_statements(sv: SourceView<'_>, stmts: &[Stmt<'_, '_>], word: &str) -> Op
     None
 }
 
+/// Find a class/function declaration by name in a slice of `FileIndex` entries.
+/// Returns the URI and a line-level `Range`.
+pub fn find_in_indexes(
+    name: &str,
+    indexes: &[(
+        tower_lsp::lsp_types::Url,
+        std::sync::Arc<crate::file_index::FileIndex>,
+    )],
+) -> Option<Location> {
+    let bare = name.strip_prefix('$').unwrap_or(name);
+    for (uri, idx) in indexes {
+        // Check top-level functions.
+        for f in &idx.functions {
+            if f.name == bare || f.name == name {
+                let pos = tower_lsp::lsp_types::Position {
+                    line: f.start_line,
+                    character: 0,
+                };
+                return Some(Location {
+                    uri: uri.clone(),
+                    range: Range {
+                        start: pos,
+                        end: pos,
+                    },
+                });
+            }
+        }
+        // Check classes / interfaces / traits / enums and their members.
+        for cls in &idx.classes {
+            if cls.name == bare || cls.name == name {
+                let pos = tower_lsp::lsp_types::Position {
+                    line: cls.start_line,
+                    character: 0,
+                };
+                return Some(Location {
+                    uri: uri.clone(),
+                    range: Range {
+                        start: pos,
+                        end: pos,
+                    },
+                });
+            }
+            // Methods.
+            for m in &cls.methods {
+                if m.name == name {
+                    let pos = tower_lsp::lsp_types::Position {
+                        line: m.start_line,
+                        character: 0,
+                    };
+                    return Some(Location {
+                        uri: uri.clone(),
+                        range: Range {
+                            start: pos,
+                            end: pos,
+                        },
+                    });
+                }
+            }
+            // Properties (stored without `$`).
+            for p in &cls.properties {
+                if p.name == bare {
+                    let pos = tower_lsp::lsp_types::Position {
+                        line: cls.start_line,
+                        character: 0,
+                    };
+                    return Some(Location {
+                        uri: uri.clone(),
+                        range: Range {
+                            start: pos,
+                            end: pos,
+                        },
+                    });
+                }
+            }
+            // Class constants.
+            for cc in &cls.constants {
+                if cc.as_str() == name {
+                    let pos = tower_lsp::lsp_types::Position {
+                        line: cls.start_line,
+                        character: 0,
+                    };
+                    return Some(Location {
+                        uri: uri.clone(),
+                        range: Range {
+                            start: pos,
+                            end: pos,
+                        },
+                    });
+                }
+            }
+            // Enum cases.
+            for case in &cls.cases {
+                if case.as_str() == name {
+                    let pos = tower_lsp::lsp_types::Position {
+                        line: cls.start_line,
+                        character: 0,
+                    };
+                    return Some(Location {
+                        uri: uri.clone(),
+                        range: Range {
+                            start: pos,
+                            end: pos,
+                        },
+                    });
+                }
+            }
+        }
+    }
+    None
+}
+
 fn _name_range_from_offset(sv: SourceView<'_>, name: &str) -> Range {
     let start_offset = str_offset(sv.source(), name);
     let start = sv.position_of(start_offset);

--- a/src/document_store.rs
+++ b/src/document_store.rs
@@ -7,6 +7,7 @@ use tower_lsp::lsp_types::{Diagnostic, SemanticToken, Url};
 
 use crate::ast::ParsedDoc;
 use crate::diagnostics::parse_document;
+use crate::file_index::FileIndex;
 
 /// Default limit used in tests so eviction can be exercised without many files.
 #[cfg(test)]
@@ -18,7 +19,10 @@ pub(crate) const DEFAULT_MAX_INDEXED: usize = 1_000;
 struct Document {
     /// `Some` when the file is open in the editor; `None` for workspace-indexed files.
     text: Option<String>,
-    doc: Arc<ParsedDoc>,
+    /// `Some` for open files; `None` for background-indexed files (they use `index` instead).
+    doc: Option<Arc<ParsedDoc>>,
+    /// Always present; compact symbol index extracted after parsing.
+    index: Arc<FileIndex>,
     diagnostics: Vec<Diagnostic>,
     /// Semantic diagnostics computed by `did_open`/`did_change`.
     /// Stored separately so callers like `code_action` can read them without
@@ -82,7 +86,8 @@ impl DocumentStore {
     pub fn set_text(&self, uri: Url, text: String) -> u64 {
         let mut entry = self.map.entry(uri).or_insert_with(|| Document {
             text: None,
-            doc: Arc::new(ParsedDoc::default()),
+            doc: None,
+            index: Arc::new(FileIndex::default()),
             diagnostics: vec![],
             sem_diagnostics: vec![],
             text_version: 0,
@@ -104,7 +109,8 @@ impl DocumentStore {
         if let Some(mut entry) = self.map.get_mut(uri)
             && entry.text_version == version
         {
-            entry.doc = Arc::new(doc);
+            entry.index = Arc::new(FileIndex::extract(uri, &doc));
+            entry.doc = Some(Arc::new(doc));
             entry.diagnostics = diagnostics;
             return true;
         }
@@ -114,6 +120,8 @@ impl DocumentStore {
     pub fn close(&self, uri: &Url) {
         if let Some(mut entry) = self.map.get_mut(uri) {
             entry.text = None;
+            // Drop the full ParsedDoc for closed files — the FileIndex is retained.
+            entry.doc = None;
             entry.text_version += 1;
             let mut q = self.indexed_order.lock().unwrap();
             if !q.contains(uri) {
@@ -132,12 +140,20 @@ impl DocumentStore {
         {
             return;
         }
-        let (doc, diagnostics) = parse_document(text);
+        // Parse → extract compact index → drop ParsedDoc + text immediately.
+        let (index, diagnostics) = {
+            let (doc, diagnostics) = parse_document(text);
+            let idx = FileIndex::extract(&uri, &doc);
+            // `doc` is dropped here — arena freed / returned to pool.
+            (Arc::new(idx), diagnostics)
+        };
+
         self.map.insert(
             uri.clone(),
             Document {
                 text: None,
-                doc: Arc::new(doc),
+                doc: None,
+                index,
                 diagnostics,
                 sem_diagnostics: vec![],
                 text_version: 0,
@@ -196,9 +212,15 @@ impl DocumentStore {
         self.map.get(uri).and_then(|d| d.text.clone())
     }
 
-    /// Returns the parsed document (cheap Arc clone). Always present once indexed.
+    /// Returns the parsed document (cheap Arc clone).
+    /// Only `Some` for files currently open in the editor.
     pub fn get_doc(&self, uri: &Url) -> Option<Arc<ParsedDoc>> {
-        self.map.get(uri).map(|d| d.doc.clone())
+        self.map.get(uri).and_then(|d| d.doc.clone())
+    }
+
+    /// Returns the compact symbol index for a file.
+    pub fn get_index(&self, uri: &Url) -> Option<Arc<FileIndex>> {
+        self.map.get(uri).map(|d| d.index.clone())
     }
 
     pub fn get_diagnostics(&self, uri: &Url) -> Option<Vec<Diagnostic>> {
@@ -220,10 +242,14 @@ impl DocumentStore {
             .unwrap_or_default()
     }
 
+    /// Returns `(uri, doc)` for files currently open in the editor.
+    ///
+    /// Background-indexed files no longer retain a `ParsedDoc`; use
+    /// [`all_docs_for_scan`] when you need to traverse every file's AST.
     pub fn all_docs(&self) -> Vec<(Url, Arc<ParsedDoc>)> {
         self.map
             .iter()
-            .map(|e| (e.key().clone(), e.value().doc.clone()))
+            .filter_map(|e| e.value().doc.as_ref().map(|d| (e.key().clone(), d.clone())))
             .collect()
     }
 
@@ -243,13 +269,81 @@ impl DocumentStore {
             .collect()
     }
 
+    /// Returns `(uri, doc)` for open files excluding `uri`.
     pub fn other_docs(&self, uri: &Url) -> Vec<(Url, Arc<ParsedDoc>)> {
         self.map
             .iter()
             .filter(|e| e.key() != uri)
-            .map(|e| (e.key().clone(), e.value().doc.clone()))
+            .filter_map(|e| e.value().doc.as_ref().map(|d| (e.key().clone(), d.clone())))
             .collect()
     }
+
+    /// Returns the compact symbol index for every indexed file.
+    pub fn all_indexes(&self) -> Vec<(Url, Arc<FileIndex>)> {
+        self.map
+            .iter()
+            .map(|e| (e.key().clone(), e.value().index.clone()))
+            .collect()
+    }
+
+    /// Returns indexes for every file except `uri`.
+    pub fn other_indexes(&self, uri: &Url) -> Vec<(Url, Arc<FileIndex>)> {
+        self.map
+            .iter()
+            .filter(|e| e.key() != uri)
+            .map(|e| (e.key().clone(), e.value().index.clone()))
+            .collect()
+    }
+
+    /// Returns parsed documents for every file, suitable for full-scan operations
+    /// (find-references, rename, call_hierarchy, code_lens).
+    ///
+    /// - For open files: returns the in-memory `ParsedDoc` (cheap Arc clone).
+    /// - For background-indexed files: re-reads the file from disk and parses it.
+    ///   The resulting `ParsedDoc` is **not** stored — callers hold it temporarily.
+    pub fn all_docs_for_scan(&self) -> Vec<(Url, Arc<ParsedDoc>)> {
+        let mut result = Vec::new();
+        for entry in self.map.iter() {
+            let uri = entry.key().clone();
+            if let Some(doc) = entry.value().doc.as_ref() {
+                // Open file: use in-memory doc.
+                result.push((uri, doc.clone()));
+            } else {
+                // Background file: read from disk.
+                if let Some(doc) = read_and_parse_from_disk(&uri) {
+                    result.push((uri, Arc::new(doc)));
+                }
+            }
+        }
+        result
+    }
+
+    /// Same as `all_docs_for_scan` but excludes `uri`.
+    pub fn other_docs_for_scan(&self, uri: &Url) -> Vec<(Url, Arc<ParsedDoc>)> {
+        let mut result = Vec::new();
+        for entry in self.map.iter() {
+            let entry_uri = entry.key().clone();
+            if &entry_uri == uri {
+                continue;
+            }
+            if let Some(doc) = entry.value().doc.as_ref() {
+                result.push((entry_uri, doc.clone()));
+            } else {
+                if let Some(doc) = read_and_parse_from_disk(&entry_uri) {
+                    result.push((entry_uri, Arc::new(doc)));
+                }
+            }
+        }
+        result
+    }
+}
+
+/// Read a file from disk and parse it. Returns `None` if the file cannot be read.
+fn read_and_parse_from_disk(uri: &Url) -> Option<ParsedDoc> {
+    let path = uri.to_file_path().ok()?;
+    let text = std::fs::read_to_string(&path).ok()?;
+    let (doc, _) = parse_document(&text);
+    Some(doc)
 }
 
 #[cfg(test)]
@@ -289,7 +383,7 @@ mod tests {
     }
 
     #[test]
-    fn close_clears_text_but_keeps_doc() {
+    fn close_clears_text_but_keeps_index() {
         let store = DocumentStore::new();
         open(
             &store,
@@ -298,7 +392,9 @@ mod tests {
         );
         store.close(&uri("/a.php"));
         assert!(store.get(&uri("/a.php")).is_none());
-        assert!(store.get_doc(&uri("/a.php")).is_some());
+        // After close, ParsedDoc is gone but FileIndex is retained.
+        assert!(store.get_doc(&uri("/a.php")).is_none());
+        assert!(store.get_index(&uri("/a.php")).is_some());
     }
 
     #[test]
@@ -308,11 +404,13 @@ mod tests {
     }
 
     #[test]
-    fn index_stores_doc_without_text() {
+    fn index_stores_index_without_doc() {
         let store = DocumentStore::new();
         store.index(uri("/lib.php"), "<?php\nfunction lib_fn() {}");
         assert!(store.get(&uri("/lib.php")).is_none());
-        assert!(store.get_doc(&uri("/lib.php")).is_some());
+        // Background-indexed files have no ParsedDoc, only FileIndex.
+        assert!(store.get_doc(&uri("/lib.php")).is_none());
+        assert!(store.get_index(&uri("/lib.php")).is_some());
     }
 
     #[test]
@@ -328,15 +426,32 @@ mod tests {
         let store = DocumentStore::new();
         store.index(uri("/lib.php"), "<?php");
         store.remove(&uri("/lib.php"));
-        assert!(store.get_doc(&uri("/lib.php")).is_none());
+        assert!(store.get_index(&uri("/lib.php")).is_none());
     }
 
     #[test]
-    fn all_docs_includes_indexed_files() {
+    fn all_docs_only_includes_open_files() {
         let store = DocumentStore::new();
         open(&store, uri("/a.php"), "<?php\nfunction a() {}".to_string());
         store.index(uri("/b.php"), "<?php\nfunction b() {}");
-        assert_eq!(store.all_docs().len(), 2);
+        // only open files have docs
+        assert_eq!(store.all_docs().len(), 1);
+    }
+
+    #[test]
+    fn all_indexes_includes_all_files() {
+        let store = DocumentStore::new();
+        open(&store, uri("/a.php"), "<?php\nfunction a() {}".to_string());
+        store.index(uri("/b.php"), "<?php\nfunction b() {}");
+        assert_eq!(store.all_indexes().len(), 2);
+    }
+
+    #[test]
+    fn other_indexes_excludes_current_uri() {
+        let store = DocumentStore::new();
+        open(&store, uri("/a.php"), "<?php\nfunction a() {}".to_string());
+        open(&store, uri("/b.php"), "<?php\nfunction b() {}".to_string());
+        assert_eq!(store.other_indexes(&uri("/a.php")).len(), 1);
     }
 
     #[test]
@@ -368,16 +483,16 @@ mod tests {
         store.index(uri("/overflow.php"), "<?php");
 
         assert_eq!(
-            store.all_docs().len(),
+            store.all_indexes().len(),
             DEFAULT_MAX_INDEXED,
             "map must not exceed DEFAULT_MAX_INDEXED after overflow"
         );
         assert!(
-            store.get_doc(&uri("/overflow.php")).is_some(),
+            store.get_index(&uri("/overflow.php")).is_some(),
             "newly indexed file must be present"
         );
         assert!(
-            store.get_doc(&uri("/0.php")).is_none(),
+            store.get_index(&uri("/0.php")).is_none(),
             "oldest file must have been evicted"
         );
     }
@@ -385,13 +500,7 @@ mod tests {
     #[test]
     fn eviction_skips_open_files_and_evicts_next_indexed() {
         // Regression test for the bug where an open file at the front of the
-        // eviction queue caused the loop to exit without evicting anything:
-        //
-        //   order.len() was DEFAULT_MAX_INDEXED+1 → pop open file → order.len() drops
-        //   to DEFAULT_MAX_INDEXED → while condition false → loop exits → no eviction.
-        //
-        // After the fix the loop tracks `need_to_evict` independently of
-        // order.len(), so it keeps looking until it finds an indexed file.
+        // eviction queue caused the loop to exit without evicting anything.
         let store = DocumentStore::new();
 
         // Index DEFAULT_MAX_INDEXED files; /0.php will be the oldest in the queue.
@@ -408,24 +517,24 @@ mod tests {
 
         // The open file must still be present.
         assert!(
-            store.get_doc(&uri("/0.php")).is_some(),
+            store.get_index(&uri("/0.php")).is_some(),
             "/0.php is open and must not be evicted"
         );
         // The overflow file must have been indexed.
         assert!(
-            store.get_doc(&uri("/overflow.php")).is_some(),
+            store.get_index(&uri("/overflow.php")).is_some(),
             "overflow file must be present"
         );
         // The eviction must have brought the map back to DEFAULT_MAX_INDEXED total
-        // entries: /0.php (open) + the remaining indexed files + /overflow.php.
+        // entries.
         assert_eq!(
-            store.all_docs().len(),
+            store.all_indexes().len(),
             DEFAULT_MAX_INDEXED,
             "total docs must equal DEFAULT_MAX_INDEXED after eviction"
         );
         // /1.php should have been evicted (oldest indexed-only file after /0.php).
         assert!(
-            store.get_doc(&uri("/1.php")).is_none(),
+            store.get_index(&uri("/1.php")).is_none(),
             "/1.php must have been evicted as the oldest indexed-only file"
         );
     }
@@ -456,5 +565,23 @@ mod tests {
             len_after_first, len_after_second,
             "second close must not add a duplicate entry to indexed_order"
         );
+    }
+
+    #[test]
+    fn index_populates_file_index_with_symbols() {
+        let store = DocumentStore::new();
+        store.index(uri("/a.php"), "<?php\nfunction hello() {}");
+        let idx = store.get_index(&uri("/a.php")).unwrap();
+        assert_eq!(idx.functions.len(), 1);
+        assert_eq!(idx.functions[0].name, "hello");
+    }
+
+    #[test]
+    fn open_populates_file_index_with_symbols() {
+        let store = DocumentStore::new();
+        open(&store, uri("/a.php"), "<?php\nclass Foo {}".to_string());
+        let idx = store.get_index(&uri("/a.php")).unwrap();
+        assert_eq!(idx.classes.len(), 1);
+        assert_eq!(idx.classes[0].name, "Foo");
     }
 }

--- a/src/file_index.rs
+++ b/src/file_index.rs
@@ -1,0 +1,583 @@
+/// Compact symbol index extracted from a parsed PHP file.
+///
+/// A `FileIndex` captures only the declaration-level information needed for
+/// cross-file features (go-to-definition, workspace symbols, hover signatures,
+/// find-implementations, etc.).  It is ~2 KB per file compared to ~100 KB for
+/// a full `ParsedDoc`, allowing the LSP to keep thousands of background files
+/// in memory without exhausting RAM.
+///
+/// Call [`FileIndex::extract`] right after parsing; the `ParsedDoc` (and its
+/// bumpalo arena) can be dropped immediately after extraction.
+use php_ast::{ClassMemberKind, EnumMemberKind, NamespaceBody, Stmt, StmtKind};
+use tower_lsp::lsp_types::Url;
+
+use crate::ast::{ParsedDoc, format_type_hint};
+use crate::docblock::docblock_before;
+
+// ── Public types ──────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Default)]
+pub struct FileIndex {
+    pub namespace: Option<String>,
+    pub functions: Vec<FunctionDef>,
+    pub classes: Vec<ClassDef>,
+    pub constants: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct FunctionDef {
+    pub name: String,
+    /// Fully-qualified name: `\Namespace\function_name` or just `function_name`.
+    pub fqn: String,
+    pub params: Vec<ParamDef>,
+    pub return_type: Option<String>,
+    /// Raw docblock text (the `/** … */` comment before the declaration).
+    pub doc: Option<String>,
+    pub start_line: u32,
+}
+
+#[derive(Debug, Clone)]
+pub struct ParamDef {
+    pub name: String,
+    pub type_hint: Option<String>,
+    pub has_default: bool,
+    pub variadic: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct ClassDef {
+    pub name: String,
+    /// Fully-qualified name.
+    pub fqn: String,
+    pub kind: ClassKind,
+    pub is_abstract: bool,
+    /// `extends` clause as written in source (may be short name or FQN).
+    pub parent: Option<String>,
+    pub implements: Vec<String>,
+    pub traits: Vec<String>,
+    pub methods: Vec<MethodDef>,
+    pub properties: Vec<PropertyDef>,
+    pub constants: Vec<String>,
+    /// Enum case names (only populated for `ClassKind::Enum`).
+    pub cases: Vec<String>,
+    pub start_line: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ClassKind {
+    Class,
+    Interface,
+    Trait,
+    Enum,
+}
+
+#[derive(Debug, Clone)]
+pub struct MethodDef {
+    pub name: String,
+    pub is_static: bool,
+    pub is_abstract: bool,
+    pub visibility: Visibility,
+    pub params: Vec<ParamDef>,
+    pub return_type: Option<String>,
+    pub doc: Option<String>,
+    pub start_line: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Visibility {
+    Public,
+    Protected,
+    Private,
+}
+
+#[derive(Debug, Clone)]
+pub struct PropertyDef {
+    pub name: String,
+    pub is_static: bool,
+    pub type_hint: Option<String>,
+    pub visibility: Visibility,
+}
+
+// ── Extract ───────────────────────────────────────────────────────────────────
+
+impl FileIndex {
+    /// Walk `doc.program().stmts` once and build a compact symbol index.
+    ///
+    /// The `_uri` parameter is accepted for future use (e.g. logging) but is
+    /// not currently used.
+    pub fn extract(_uri: &Url, doc: &ParsedDoc) -> Self {
+        let source = doc.source();
+        let view = doc.view();
+        let mut index = FileIndex::default();
+        collect_stmts(source, &view, &doc.program().stmts, None, &mut index);
+        index
+    }
+}
+
+// ── Internal helpers ──────────────────────────────────────────────────────────
+
+fn fqn(namespace: Option<&str>, name: &str) -> String {
+    match namespace {
+        Some(ns) if !ns.is_empty() => format!("{}\\{}", ns, name),
+        _ => name.to_string(),
+    }
+}
+
+fn collect_stmts(
+    source: &str,
+    view: &crate::ast::SourceView<'_>,
+    stmts: &[Stmt<'_, '_>],
+    namespace: Option<&str>,
+    index: &mut FileIndex,
+) {
+    // Track the current namespace for unbraced `namespace Foo;` statements.
+    let mut cur_ns: Option<String> = namespace.map(str::to_string);
+
+    for stmt in stmts {
+        match &stmt.kind {
+            // ── Namespace ────────────────────────────────────────────────────
+            StmtKind::Namespace(ns) => {
+                let ns_name = ns.name.as_ref().map(|n| n.to_string_repr().to_string());
+
+                match &ns.body {
+                    NamespaceBody::Braced(inner) => {
+                        // Braced namespace: recurse with its name as context.
+                        let ns_str = ns_name.as_deref();
+                        // Update the top-level namespace if not already set.
+                        if index.namespace.is_none() {
+                            index.namespace = ns_name.clone();
+                        }
+                        collect_stmts(source, view, inner, ns_str, index);
+                    }
+                    NamespaceBody::Simple => {
+                        // Unbraced namespace: all following stmts belong to it.
+                        if index.namespace.is_none() {
+                            index.namespace = ns_name.clone();
+                        }
+                        cur_ns = ns_name;
+                    }
+                }
+            }
+
+            // ── Top-level function ───────────────────────────────────────────
+            StmtKind::Function(f) => {
+                let doc_text = docblock_before(source, stmt.span.start);
+                let start_line = view.position_of(stmt.span.start).line;
+                let ns = cur_ns.as_deref();
+                index.functions.push(FunctionDef {
+                    name: f.name.to_string(),
+                    fqn: fqn(ns, f.name),
+                    params: extract_params(&f.params),
+                    return_type: f.return_type.as_ref().map(format_type_hint),
+                    doc: doc_text,
+                    start_line,
+                });
+            }
+
+            // ── Class ────────────────────────────────────────────────────────
+            StmtKind::Class(c) => {
+                let Some(class_name) = c.name else { continue };
+                let start_line = view.position_of(stmt.span.start).line;
+                let ns = cur_ns.as_deref();
+
+                let mut class_def = ClassDef {
+                    name: class_name.to_string(),
+                    fqn: fqn(ns, class_name),
+                    kind: ClassKind::Class,
+                    is_abstract: c.modifiers.is_abstract,
+                    parent: c.extends.as_ref().map(|e| e.to_string_repr().into_owned()),
+                    implements: c
+                        .implements
+                        .iter()
+                        .map(|i| i.to_string_repr().into_owned())
+                        .collect(),
+                    traits: Vec::new(),
+                    methods: Vec::new(),
+                    properties: Vec::new(),
+                    constants: Vec::new(),
+                    cases: Vec::new(),
+                    start_line,
+                };
+
+                for member in c.members.iter() {
+                    match &member.kind {
+                        ClassMemberKind::Method(m) => {
+                            let mdoc = docblock_before(source, member.span.start);
+                            let mstart = view.position_of(member.span.start).line;
+                            let vis = method_visibility(m.visibility);
+                            let method_params = extract_params(&m.params);
+                            // Constructor-promoted params → also add as PropertyDef.
+                            for ast_param in m.params.iter() {
+                                if ast_param.visibility.is_some() {
+                                    let pvis = method_visibility(ast_param.visibility);
+                                    class_def.properties.push(PropertyDef {
+                                        name: ast_param.name.to_string(),
+                                        is_static: false,
+                                        type_hint: ast_param
+                                            .type_hint
+                                            .as_ref()
+                                            .map(format_type_hint),
+                                        visibility: pvis,
+                                    });
+                                }
+                            }
+                            class_def.methods.push(MethodDef {
+                                name: m.name.to_string(),
+                                is_static: m.is_static,
+                                is_abstract: m.is_abstract,
+                                visibility: vis,
+                                params: method_params,
+                                return_type: m.return_type.as_ref().map(format_type_hint),
+                                doc: mdoc,
+                                start_line: mstart,
+                            });
+                        }
+                        ClassMemberKind::Property(p) => {
+                            let vis = method_visibility(p.visibility);
+                            class_def.properties.push(PropertyDef {
+                                name: p.name.to_string(),
+                                is_static: p.is_static,
+                                type_hint: p.type_hint.as_ref().map(format_type_hint),
+                                visibility: vis,
+                            });
+                        }
+                        ClassMemberKind::ClassConst(cc) => {
+                            class_def.constants.push(cc.name.to_string());
+                        }
+                        ClassMemberKind::TraitUse(tu) => {
+                            for t in tu.traits.iter() {
+                                class_def.traits.push(t.to_string_repr().into_owned());
+                            }
+                        }
+                    }
+                }
+                index.classes.push(class_def);
+            }
+
+            // ── Interface ────────────────────────────────────────────────────
+            StmtKind::Interface(i) => {
+                let start_line = view.position_of(stmt.span.start).line;
+                let ns = cur_ns.as_deref();
+
+                let mut iface_def = ClassDef {
+                    name: i.name.to_string(),
+                    fqn: fqn(ns, i.name),
+                    kind: ClassKind::Interface,
+                    is_abstract: true,
+                    parent: None,
+                    implements: i
+                        .extends
+                        .iter()
+                        .map(|e| e.to_string_repr().into_owned())
+                        .collect(),
+                    traits: Vec::new(),
+                    methods: Vec::new(),
+                    properties: Vec::new(),
+                    constants: Vec::new(),
+                    cases: Vec::new(),
+                    start_line,
+                };
+
+                for member in i.members.iter() {
+                    match &member.kind {
+                        ClassMemberKind::Method(m) => {
+                            let mdoc = docblock_before(source, member.span.start);
+                            let mstart = view.position_of(member.span.start).line;
+                            iface_def.methods.push(MethodDef {
+                                name: m.name.to_string(),
+                                is_static: m.is_static,
+                                is_abstract: true,
+                                visibility: Visibility::Public,
+                                params: extract_params(&m.params),
+                                return_type: m.return_type.as_ref().map(format_type_hint),
+                                doc: mdoc,
+                                start_line: mstart,
+                            });
+                        }
+                        ClassMemberKind::ClassConst(cc) => {
+                            iface_def.constants.push(cc.name.to_string());
+                        }
+                        _ => {}
+                    }
+                }
+                index.classes.push(iface_def);
+            }
+
+            // ── Trait ────────────────────────────────────────────────────────
+            StmtKind::Trait(t) => {
+                let start_line = view.position_of(stmt.span.start).line;
+                let ns = cur_ns.as_deref();
+
+                let mut trait_def = ClassDef {
+                    name: t.name.to_string(),
+                    fqn: fqn(ns, t.name),
+                    kind: ClassKind::Trait,
+                    is_abstract: false,
+                    parent: None,
+                    implements: Vec::new(),
+                    traits: Vec::new(),
+                    methods: Vec::new(),
+                    properties: Vec::new(),
+                    constants: Vec::new(),
+                    cases: Vec::new(),
+                    start_line,
+                };
+
+                for member in t.members.iter() {
+                    match &member.kind {
+                        ClassMemberKind::Method(m) => {
+                            let mdoc = docblock_before(source, member.span.start);
+                            let mstart = view.position_of(member.span.start).line;
+                            let vis = method_visibility(m.visibility);
+                            trait_def.methods.push(MethodDef {
+                                name: m.name.to_string(),
+                                is_static: m.is_static,
+                                is_abstract: m.is_abstract,
+                                visibility: vis,
+                                params: extract_params(&m.params),
+                                return_type: m.return_type.as_ref().map(format_type_hint),
+                                doc: mdoc,
+                                start_line: mstart,
+                            });
+                        }
+                        ClassMemberKind::Property(p) => {
+                            let vis = method_visibility(p.visibility);
+                            trait_def.properties.push(PropertyDef {
+                                name: p.name.to_string(),
+                                is_static: p.is_static,
+                                type_hint: p.type_hint.as_ref().map(format_type_hint),
+                                visibility: vis,
+                            });
+                        }
+                        ClassMemberKind::ClassConst(cc) => {
+                            trait_def.constants.push(cc.name.to_string());
+                        }
+                        ClassMemberKind::TraitUse(tu) => {
+                            for tr in tu.traits.iter() {
+                                trait_def.traits.push(tr.to_string_repr().into_owned());
+                            }
+                        }
+                    }
+                }
+                index.classes.push(trait_def);
+            }
+
+            // ── Enum ─────────────────────────────────────────────────────────
+            StmtKind::Enum(e) => {
+                let start_line = view.position_of(stmt.span.start).line;
+                let ns = cur_ns.as_deref();
+
+                let mut enum_def = ClassDef {
+                    name: e.name.to_string(),
+                    fqn: fqn(ns, e.name),
+                    kind: ClassKind::Enum,
+                    is_abstract: false,
+                    parent: None,
+                    implements: e
+                        .implements
+                        .iter()
+                        .map(|i| i.to_string_repr().into_owned())
+                        .collect(),
+                    traits: Vec::new(),
+                    methods: Vec::new(),
+                    properties: Vec::new(),
+                    constants: Vec::new(),
+                    cases: Vec::new(),
+                    start_line,
+                };
+
+                for member in e.members.iter() {
+                    match &member.kind {
+                        EnumMemberKind::Case(c) => {
+                            enum_def.cases.push(c.name.to_string());
+                        }
+                        EnumMemberKind::Method(m) => {
+                            let mdoc = docblock_before(source, member.span.start);
+                            let mstart = view.position_of(member.span.start).line;
+                            let vis = method_visibility(m.visibility);
+                            enum_def.methods.push(MethodDef {
+                                name: m.name.to_string(),
+                                is_static: m.is_static,
+                                is_abstract: m.is_abstract,
+                                visibility: vis,
+                                params: extract_params(&m.params),
+                                return_type: m.return_type.as_ref().map(format_type_hint),
+                                doc: mdoc,
+                                start_line: mstart,
+                            });
+                        }
+                        EnumMemberKind::ClassConst(cc) => {
+                            enum_def.constants.push(cc.name.to_string());
+                        }
+                        _ => {}
+                    }
+                }
+                index.classes.push(enum_def);
+            }
+
+            // ── Top-level const ──────────────────────────────────────────────
+            StmtKind::Const(consts) => {
+                for c in consts.iter() {
+                    index.constants.push(c.name.to_string());
+                }
+            }
+
+            _ => {}
+        }
+    }
+}
+
+fn extract_params<'a, 'b>(params: &[php_ast::Param<'a, 'b>]) -> Vec<ParamDef> {
+    params
+        .iter()
+        .map(|p| ParamDef {
+            name: p.name.to_string(),
+            type_hint: p.type_hint.as_ref().map(format_type_hint),
+            has_default: p.default.is_some(),
+            variadic: p.variadic,
+        })
+        .collect()
+}
+
+fn method_visibility(vis: Option<php_ast::Visibility>) -> Visibility {
+    match vis {
+        Some(php_ast::Visibility::Protected) => Visibility::Protected,
+        Some(php_ast::Visibility::Private) => Visibility::Private,
+        _ => Visibility::Public,
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn uri() -> Url {
+        Url::parse("file:///test.php").unwrap()
+    }
+
+    #[test]
+    fn extracts_class_and_method() {
+        let src = "<?php\nclass Greeter {\n    public function greet(string $name): string {}\n}";
+        let doc = ParsedDoc::parse(src.to_string());
+        let idx = FileIndex::extract(&uri(), &doc);
+        assert_eq!(idx.classes.len(), 1);
+        let cls = &idx.classes[0];
+        assert_eq!(cls.name, "Greeter");
+        assert_eq!(cls.kind, ClassKind::Class);
+        assert_eq!(cls.start_line, 1);
+        assert_eq!(cls.methods.len(), 1);
+        let method = &cls.methods[0];
+        assert_eq!(method.name, "greet");
+        assert_eq!(method.return_type.as_deref(), Some("string"));
+        assert_eq!(method.params.len(), 1);
+        assert_eq!(method.params[0].name, "name");
+        assert_eq!(method.params[0].type_hint.as_deref(), Some("string"));
+    }
+
+    #[test]
+    fn extracts_function() {
+        let src = "<?php\nfunction add(int $a, int $b): int {}";
+        let doc = ParsedDoc::parse(src.to_string());
+        let idx = FileIndex::extract(&uri(), &doc);
+        assert_eq!(idx.functions.len(), 1);
+        let f = &idx.functions[0];
+        assert_eq!(f.name, "add");
+        assert_eq!(f.return_type.as_deref(), Some("int"));
+        assert_eq!(f.params.len(), 2);
+    }
+
+    #[test]
+    fn extracts_namespace() {
+        let src = "<?php\nnamespace App\\Services;\nclass Mailer {}";
+        let doc = ParsedDoc::parse(src.to_string());
+        let idx = FileIndex::extract(&uri(), &doc);
+        assert_eq!(idx.namespace.as_deref(), Some("App\\Services"));
+        assert_eq!(idx.classes[0].fqn, "App\\Services\\Mailer");
+    }
+
+    #[test]
+    fn extracts_braced_namespace() {
+        let src = "<?php\nnamespace App\\Models {\n    class User {}\n}";
+        let doc = ParsedDoc::parse(src.to_string());
+        let idx = FileIndex::extract(&uri(), &doc);
+        assert_eq!(idx.namespace.as_deref(), Some("App\\Models"));
+        assert_eq!(idx.classes[0].fqn, "App\\Models\\User");
+    }
+
+    #[test]
+    fn extracts_interface() {
+        let src = "<?php\ninterface Countable {\n    public function count(): int;\n}";
+        let doc = ParsedDoc::parse(src.to_string());
+        let idx = FileIndex::extract(&uri(), &doc);
+        assert_eq!(idx.classes.len(), 1);
+        assert_eq!(idx.classes[0].kind, ClassKind::Interface);
+        assert_eq!(idx.classes[0].methods[0].name, "count");
+        assert!(idx.classes[0].methods[0].is_abstract);
+    }
+
+    #[test]
+    fn extracts_trait() {
+        let src = "<?php\ntrait Loggable {\n    public function log(): void {}\n}";
+        let doc = ParsedDoc::parse(src.to_string());
+        let idx = FileIndex::extract(&uri(), &doc);
+        assert_eq!(idx.classes[0].kind, ClassKind::Trait);
+        assert_eq!(idx.classes[0].methods[0].name, "log");
+    }
+
+    #[test]
+    fn extracts_enum_cases() {
+        let src = "<?php\nenum Status { case Active; case Inactive; }";
+        let doc = ParsedDoc::parse(src.to_string());
+        let idx = FileIndex::extract(&uri(), &doc);
+        assert_eq!(idx.classes[0].kind, ClassKind::Enum);
+        assert!(idx.classes[0].cases.contains(&"Active".to_string()));
+        assert!(idx.classes[0].cases.contains(&"Inactive".to_string()));
+    }
+
+    #[test]
+    fn extracts_class_properties_and_constants() {
+        let src = "<?php\nclass Config {\n    public string $host;\n    const VERSION = '1.0';\n}";
+        let doc = ParsedDoc::parse(src.to_string());
+        let idx = FileIndex::extract(&uri(), &doc);
+        let cls = &idx.classes[0];
+        assert_eq!(cls.properties.len(), 1);
+        assert_eq!(cls.properties[0].name, "host");
+        assert_eq!(cls.constants, vec!["VERSION"]);
+    }
+
+    #[test]
+    fn extracts_trait_use() {
+        let src = "<?php\ntrait T {}\nclass MyClass { use T; }";
+        let doc = ParsedDoc::parse(src.to_string());
+        let idx = FileIndex::extract(&uri(), &doc);
+        let cls = idx.classes.iter().find(|c| c.name == "MyClass").unwrap();
+        assert!(cls.traits.contains(&"T".to_string()));
+    }
+
+    #[test]
+    fn extracts_class_implements_and_extends() {
+        let src = "<?php\nclass Dog extends Animal implements Pet, Movable {}";
+        let doc = ParsedDoc::parse(src.to_string());
+        let idx = FileIndex::extract(&uri(), &doc);
+        let cls = &idx.classes[0];
+        assert_eq!(cls.parent.as_deref(), Some("Animal"));
+        assert!(cls.implements.contains(&"Pet".to_string()));
+        assert!(cls.implements.contains(&"Movable".to_string()));
+    }
+
+    #[test]
+    fn constructor_promoted_params_become_properties() {
+        let src = "<?php\nclass User {\n    public function __construct(public string $name) {}\n}";
+        let doc = ParsedDoc::parse(src.to_string());
+        let idx = FileIndex::extract(&uri(), &doc);
+        let cls = &idx.classes[0];
+        // Should have a property from the promoted param.
+        assert!(
+            cls.properties.iter().any(|p| p.name == "name"),
+            "expected promoted property 'name', got: {:?}",
+            cls.properties.iter().map(|p| &p.name).collect::<Vec<_>>()
+        );
+    }
+}

--- a/src/hover.rs
+++ b/src/hover.rs
@@ -518,6 +518,136 @@ pub(crate) fn format_params_str(params: &[Param<'_, '_>]) -> String {
     format_params(params)
 }
 
+// ── Index-based variants ──────────────────────────────────────────────────────
+
+/// Return a function/method signature string from a `FileIndex` slice.
+/// Falls back to built-in doc URL for built-in functions.
+pub fn signature_for_symbol_from_index(
+    name: &str,
+    indexes: &[(
+        tower_lsp::lsp_types::Url,
+        std::sync::Arc<crate::file_index::FileIndex>,
+    )],
+) -> Option<String> {
+    for (_, idx) in indexes {
+        for f in &idx.functions {
+            if f.name == name {
+                let params_str = f
+                    .params
+                    .iter()
+                    .map(|p| {
+                        let mut s = String::new();
+                        if p.variadic {
+                            s.push_str("...");
+                        }
+                        if let Some(t) = &p.type_hint {
+                            s.push_str(&format!("{} ", t));
+                        }
+                        s.push_str(&format!("${}", p.name));
+                        s
+                    })
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                let ret = f
+                    .return_type
+                    .as_deref()
+                    .map(|r| format!(": {}", r))
+                    .unwrap_or_default();
+                return Some(format!("function {}({}){}", name, params_str, ret));
+            }
+        }
+        for cls in &idx.classes {
+            for m in &cls.methods {
+                if m.name == name {
+                    let params_str = m
+                        .params
+                        .iter()
+                        .map(|p| {
+                            let mut s = String::new();
+                            if p.variadic {
+                                s.push_str("...");
+                            }
+                            if let Some(t) = &p.type_hint {
+                                s.push_str(&format!("{} ", t));
+                            }
+                            s.push_str(&format!("${}", p.name));
+                            s
+                        })
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    let ret = m
+                        .return_type
+                        .as_deref()
+                        .map(|r| format!(": {}", r))
+                        .unwrap_or_default();
+                    return Some(format!("function {}({}){}", name, params_str, ret));
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Return hover documentation for a symbol from a `FileIndex` slice.
+pub fn docs_for_symbol_from_index(
+    name: &str,
+    indexes: &[(
+        tower_lsp::lsp_types::Url,
+        std::sync::Arc<crate::file_index::FileIndex>,
+    )],
+) -> Option<String> {
+    if let Some(sig) = signature_for_symbol_from_index(name, indexes) {
+        let mut value = wrap_php(&sig);
+        // Look for docblock text in the index.
+        for (_, idx) in indexes {
+            for f in &idx.functions {
+                if f.name == name {
+                    if let Some(raw) = &f.doc {
+                        let db = crate::docblock::parse_docblock(raw);
+                        let md = db.to_markdown();
+                        if !md.is_empty() {
+                            value.push_str("\n\n---\n\n");
+                            value.push_str(&md);
+                        }
+                    }
+                    break;
+                }
+            }
+            for cls in &idx.classes {
+                for m in &cls.methods {
+                    if m.name == name {
+                        if let Some(raw) = &m.doc {
+                            let db = crate::docblock::parse_docblock(raw);
+                            let md = db.to_markdown();
+                            if !md.is_empty() {
+                                value.push_str("\n\n---\n\n");
+                                value.push_str(&md);
+                            }
+                        }
+                        break;
+                    }
+                }
+            }
+        }
+        if is_php_builtin(name) {
+            value.push_str(&format!(
+                "\n\n[php.net documentation]({})",
+                php_doc_url(name)
+            ));
+        }
+        return Some(value);
+    }
+    // Fallback: built-in.
+    if is_php_builtin(name) {
+        return Some(format!(
+            "```php\nfunction {}()\n```\n\n[php.net documentation]({})",
+            name,
+            php_doc_url(name)
+        ));
+    }
+    None
+}
+
 /// Return the plain-text signature for a symbol (function or method) found in
 /// any of the supplied documents, or `None` if not found.
 ///

--- a/src/implementation.rs
+++ b/src/implementation.rs
@@ -66,6 +66,45 @@ pub fn goto_implementation(
     find_implementations(&word, fqn, all_docs)
 }
 
+/// Find implementations using `FileIndex` entries (memory-efficient cross-file search).
+pub fn find_implementations_from_index(
+    word: &str,
+    fqn: Option<&str>,
+    indexes: &[(
+        tower_lsp::lsp_types::Url,
+        std::sync::Arc<crate::file_index::FileIndex>,
+    )],
+) -> Vec<Location> {
+    let mut locations = Vec::new();
+    for (uri, idx) in indexes {
+        for cls in &idx.classes {
+            let extends_match = cls
+                .parent
+                .as_deref()
+                .map(|p| name_matches(p, word, fqn))
+                .unwrap_or(false);
+            let implements_match = cls
+                .implements
+                .iter()
+                .any(|iface| name_matches(iface, word, fqn));
+            if extends_match || implements_match {
+                let pos = tower_lsp::lsp_types::Position {
+                    line: cls.start_line,
+                    character: 0,
+                };
+                locations.push(Location {
+                    uri: uri.clone(),
+                    range: tower_lsp::lsp_types::Range {
+                        start: pos,
+                        end: pos,
+                    },
+                });
+            }
+        }
+    }
+    locations
+}
+
 fn collect_implementations(
     stmts: &[Stmt<'_, '_>],
     word: &str,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,9 @@ pub mod type_map;
 pub mod util;
 pub mod walk;
 
+// Public module: compact symbol index for background-indexed files.
+pub mod file_index;
+
 // Private modules needed transitively by the public ones.
 mod autoload;
 mod backend;

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ mod document_store;
 mod extract_action;
 mod extract_constant_action;
 mod extract_method_action;
+mod file_index;
 mod file_rename;
 mod folding;
 mod formatting;

--- a/src/symbols.rs
+++ b/src/symbols.rs
@@ -604,6 +604,107 @@ fn _pos_from_offset(sv: SourceView<'_>, offset: u32) -> Position {
     sv.position_of(offset)
 }
 
+// ── Index-based variants ──────────────────────────────────────────────────────
+
+/// `workspace_symbols` variant that queries `FileIndex` entries instead of
+/// full `ParsedDoc` ASTs.  Used by the backend for cross-file symbol search
+/// when background files only retain a compact index.
+#[allow(deprecated)]
+pub fn workspace_symbols_from_index(
+    query: &str,
+    indexes: &[(Url, Arc<crate::file_index::FileIndex>)],
+) -> Vec<SymbolInformation> {
+    use crate::file_index::ClassKind;
+    use crate::util::fuzzy_camel_match;
+
+    let (kind_filter, term) = parse_kind_filter(query);
+    let matches_kind = |k: SymbolKind| kind_filter.is_none_or(|f| f == k);
+
+    let line_range = |line: u32| -> Range {
+        let pos = Position { line, character: 0 };
+        Range {
+            start: pos,
+            end: pos,
+        }
+    };
+
+    let mut results = Vec::new();
+    for (uri, idx) in indexes {
+        if matches_kind(SymbolKind::FUNCTION) {
+            for f in &idx.functions {
+                if fuzzy_camel_match(term, &f.name) {
+                    results.push(SymbolInformation {
+                        name: f.name.clone(),
+                        kind: SymbolKind::FUNCTION,
+                        location: Location {
+                            uri: uri.clone(),
+                            range: line_range(f.start_line),
+                        },
+                        tags: None,
+                        deprecated: None,
+                        container_name: None,
+                    });
+                }
+            }
+        }
+        for cls in &idx.classes {
+            let class_kind = match cls.kind {
+                ClassKind::Class | ClassKind::Trait => SymbolKind::CLASS,
+                ClassKind::Interface => SymbolKind::INTERFACE,
+                ClassKind::Enum => SymbolKind::ENUM,
+            };
+            if matches_kind(class_kind) && fuzzy_camel_match(term, &cls.name) {
+                results.push(SymbolInformation {
+                    name: cls.name.clone(),
+                    kind: class_kind,
+                    location: Location {
+                        uri: uri.clone(),
+                        range: line_range(cls.start_line),
+                    },
+                    tags: None,
+                    deprecated: None,
+                    container_name: None,
+                });
+            }
+            if matches_kind(SymbolKind::METHOD) {
+                for m in &cls.methods {
+                    if fuzzy_camel_match(term, &m.name) {
+                        results.push(SymbolInformation {
+                            name: m.name.clone(),
+                            kind: SymbolKind::METHOD,
+                            location: Location {
+                                uri: uri.clone(),
+                                range: line_range(m.start_line),
+                            },
+                            tags: None,
+                            deprecated: None,
+                            container_name: Some(cls.name.clone()),
+                        });
+                    }
+                }
+            }
+            if matches_kind(SymbolKind::ENUM_MEMBER) && cls.kind == ClassKind::Enum {
+                for case in &cls.cases {
+                    if fuzzy_camel_match(term, case) {
+                        results.push(SymbolInformation {
+                            name: case.clone(),
+                            kind: SymbolKind::ENUM_MEMBER,
+                            location: Location {
+                                uri: uri.clone(),
+                                range: line_range(cls.start_line),
+                            },
+                            tags: None,
+                            deprecated: None,
+                            container_name: Some(cls.name.clone()),
+                        });
+                    }
+                }
+            }
+        }
+    }
+    results
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/type_definition.rs
+++ b/src/type_definition.rs
@@ -96,6 +96,44 @@ fn find_class_range(sv: SourceView<'_>, stmts: &[Stmt<'_, '_>], name: &str) -> O
     None
 }
 
+/// Find a type definition using `FileIndex` entries.
+pub fn goto_type_definition_from_index(
+    source: &str,
+    doc: &ParsedDoc,
+    indexes: &[(Url, std::sync::Arc<crate::file_index::FileIndex>)],
+    position: Position,
+) -> Option<Location> {
+    use crate::util::word_at;
+    let word = word_at(source, position)?;
+
+    let type_map = TypeMap::from_doc(doc);
+    let class_name = if word.starts_with('$') {
+        type_map.get(&word)?.to_string()
+    } else {
+        param_type_for(&doc.program().stmts, &word)?
+    };
+
+    let line_range = |line: u32| -> Range {
+        let p = Position { line, character: 0 };
+        Range { start: p, end: p }
+    };
+
+    for (uri, idx) in indexes {
+        for cls in &idx.classes {
+            // Match by short name (last segment after `\`).
+            let short = cls.name.rsplit('\\').next().unwrap_or(&cls.name);
+            let cn_short = class_name.rsplit('\\').next().unwrap_or(&class_name);
+            if cls.name == class_name || short == cn_short {
+                return Some(Location {
+                    uri: uri.clone(),
+                    range: line_range(cls.start_line),
+                });
+            }
+        }
+    }
+    None
+}
+
 fn _offset_to_position_range(sv: SourceView<'_>, name_str: &str, _name: &str) -> Range {
     let start = sv.position_of(0);
     Range {

--- a/src/type_hierarchy.rs
+++ b/src/type_hierarchy.rs
@@ -204,6 +204,122 @@ fn collect_subtypes(
     }
 }
 
+// ── Index-based variants ──────────────────────────────────────────────────────
+
+fn line_range(line: u32) -> tower_lsp::lsp_types::Range {
+    let pos = Position { line, character: 0 };
+    tower_lsp::lsp_types::Range {
+        start: pos,
+        end: pos,
+    }
+}
+
+fn make_item_from_index(
+    name: &str,
+    kind: SymbolKind,
+    uri: &Url,
+    start_line: u32,
+) -> TypeHierarchyItem {
+    let range = line_range(start_line);
+    TypeHierarchyItem {
+        name: name.to_string(),
+        kind,
+        tags: None,
+        detail: None,
+        uri: uri.clone(),
+        range,
+        selection_range: range,
+        data: None,
+    }
+}
+
+/// Prepare type hierarchy from a FileIndex slice.
+pub fn prepare_type_hierarchy_from_index(
+    source: &str,
+    indexes: &[(Url, std::sync::Arc<crate::file_index::FileIndex>)],
+    position: Position,
+) -> Option<TypeHierarchyItem> {
+    use crate::file_index::ClassKind;
+    use crate::util::word_at;
+    let word = word_at(source, position)?;
+    for (uri, idx) in indexes {
+        for cls in &idx.classes {
+            if cls.name == word {
+                let kind = match cls.kind {
+                    ClassKind::Class | ClassKind::Trait => SymbolKind::CLASS,
+                    ClassKind::Interface => SymbolKind::INTERFACE,
+                    ClassKind::Enum => SymbolKind::ENUM,
+                };
+                return Some(make_item_from_index(&cls.name, kind, uri, cls.start_line));
+            }
+        }
+    }
+    None
+}
+
+/// Supertypes from FileIndex.
+pub fn supertypes_of_from_index(
+    item: &TypeHierarchyItem,
+    indexes: &[(Url, std::sync::Arc<crate::file_index::FileIndex>)],
+) -> Vec<TypeHierarchyItem> {
+    use crate::file_index::ClassKind;
+    let mut super_names: Vec<String> = Vec::new();
+
+    for (_, idx) in indexes {
+        for cls in &idx.classes {
+            if cls.name == item.name {
+                if let Some(p) = &cls.parent {
+                    super_names.push(p.clone());
+                }
+                for iface in &cls.implements {
+                    super_names.push(iface.clone());
+                }
+            }
+        }
+    }
+
+    let mut result = Vec::new();
+    for name in super_names {
+        for (uri, idx) in indexes {
+            if let Some(cls) = idx.classes.iter().find(|c| c.name == name) {
+                let kind = match cls.kind {
+                    ClassKind::Class | ClassKind::Trait => SymbolKind::CLASS,
+                    ClassKind::Interface => SymbolKind::INTERFACE,
+                    ClassKind::Enum => SymbolKind::ENUM,
+                };
+                result.push(make_item_from_index(&cls.name, kind, uri, cls.start_line));
+                break;
+            }
+        }
+    }
+    result
+}
+
+/// Subtypes from FileIndex.
+pub fn subtypes_of_from_index(
+    item: &TypeHierarchyItem,
+    indexes: &[(Url, std::sync::Arc<crate::file_index::FileIndex>)],
+) -> Vec<TypeHierarchyItem> {
+    use crate::file_index::ClassKind;
+    let mut result = Vec::new();
+    for (uri, idx) in indexes {
+        for cls in &idx.classes {
+            let extends_match = cls.parent.as_deref() == Some(&item.name as &str);
+            let implements_match = cls.implements.iter().any(|i| i == &item.name);
+            let trait_use_match = cls.traits.iter().any(|t| t == &item.name);
+            if extends_match || implements_match || trait_use_match {
+                let kind = match cls.kind {
+                    ClassKind::Class | ClassKind::Trait => SymbolKind::CLASS,
+                    ClassKind::Interface => SymbolKind::INTERFACE,
+                    ClassKind::Enum => SymbolKind::ENUM,
+                };
+                result.push(make_item_from_index(&cls.name, kind, uri, cls.start_line));
+            }
+        }
+    }
+    result
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary

- Introduces a slim `FileIndex` struct to replace `ParsedDoc` for background (non-open) files, reducing per-file memory from ~100 KB to ~2–10 KB (~10× reduction)
- Adds a configurable `maxIndexedFiles` limit (default 1 000) via `initializationOptions`

## Implementation notes

**`FileIndex`** extracts only the symbols needed for cross-file features (functions, classes, interfaces, traits, enums, properties, methods, constants, constructor-promoted properties) from the AST, then discards the arena-allocated `ParsedDoc`. Open files (with active text) continue to use full `ParsedDoc` for all LSP features.

**Eviction** — when the indexed file count exceeds `maxIndexedFiles`, the oldest entries are evicted from the LRU queue, skipping any file that has since been opened. The limit is set once during `initialize()`, before the workspace scan begins.

**Known limitations**
- `FileIndex.namespace` records only the first namespace declaration in a file; multi-namespace files (rare in practice) store all symbol FQNs correctly but the top-level field is incomplete
- `VecDeque::contains()` in the close path is O(n); acceptable for typical workspace sizes but degrades at very large file counts

## Configuration

```json
{
  "initializationOptions": {
    "maxIndexedFiles": 1000
  }
}
```

## Test plan

- [ ] Open a large PHP project and verify memory usage is significantly lower than before
- [ ] Set `maxIndexedFiles` in `initializationOptions` and confirm indexing stops at the configured limit
- [ ] Verify LSP features (hover, go-to-definition, references, symbols) still work correctly on indexed files
- [ ] Verify LRU eviction correctly skips open files and continues evicting background files
- [ ] Verify that opening a previously evicted file re-indexes it correctly