### PR TITLE
perf/test: slim FileIndex + E2E coverage improvements

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1830,13 +1830,11 @@ impl LanguageServer for Backend {
             uri,
             params.range,
         ));
-        let mut all_docs_impl = vec![(uri.clone(), Arc::clone(&doc))];
-        all_docs_impl.extend(other_docs.iter().cloned());
         actions.extend(defer_actions(
             implement_missing_actions(
                 &source,
                 &doc,
-                &all_docs_impl,
+                &self.docs.doc_with_others(uri, Arc::clone(&doc)),
                 params.range,
                 uri,
                 &self.file_imports(uri),
@@ -1923,11 +1921,15 @@ impl LanguageServer for Backend {
         let candidates: Vec<CodeActionOrCommand> = match kind_tag.as_str() {
             "phpdoc" => phpdoc_actions(&uri, &doc, &source, range),
             "implement" => {
-                let other_docs = self.docs.other_docs(&uri);
                 let imports = self.file_imports(&uri);
-                let mut all_docs_impl = vec![(uri.clone(), Arc::clone(&doc))];
-                all_docs_impl.extend(other_docs.iter().cloned());
-                implement_missing_actions(&source, &doc, &all_docs_impl, range, &uri, &imports)
+                implement_missing_actions(
+                    &source,
+                    &doc,
+                    &self.docs.doc_with_others(&uri, Arc::clone(&doc)),
+                    range,
+                    &uri,
+                    &imports,
+                )
             }
             "constructor" => generate_constructor_actions(&source, &doc, range, &uri),
             "getters_setters" => generate_getters_setters_actions(&source, &doc, range, &uri),

--- a/src/declaration.rs
+++ b/src/declaration.rs
@@ -328,8 +328,6 @@ mod tests {
 
     #[test]
     fn from_index_finds_abstract_method() {
-        // abstract speak() is in animal.php; concrete speak() is in cat.php.
-        // Cursor in cat.php source must resolve to the abstract declaration.
         let (animal_uri, animal_idx) = make_index(
             "/animal.php",
             "<?php\nabstract class Animal {\n    abstract public function speak(): string;\n}",

--- a/src/document_store.rs
+++ b/src/document_store.rs
@@ -270,6 +270,14 @@ impl DocumentStore {
             .collect()
     }
 
+    /// Returns `(uri, doc)` first, followed by all other open files.
+    /// Use this when the callee requires the primary document to be the first entry.
+    pub fn doc_with_others(&self, uri: &Url, doc: Arc<ParsedDoc>) -> Vec<(Url, Arc<ParsedDoc>)> {
+        let mut result = vec![(uri.clone(), doc)];
+        result.extend(self.other_docs(uri));
+        result
+    }
+
     /// Returns `(uri, doc)` for open files excluding `uri`.
     pub fn other_docs(&self, uri: &Url) -> Vec<(Url, Arc<ParsedDoc>)> {
         self.map


### PR DESCRIPTION
## Summary

- Introduces a slim `FileIndex` for background files (~10× memory reduction vs `ParsedDoc`)
- Adds `_from_index` code paths to `declaration`, `implementation`, `type_definition`, and `type_hierarchy` so cross-file navigation works without a full AST in memory
- Adds broad E2E test coverage for LSP handlers (call hierarchy, type hierarchy, workspace symbols, completion resolve, inlay hint resolve, semantic tokens, and more)
- Strengthens previously weak assertions: call hierarchy tests now verify caller/callee names; `completion_resolve` no longer silently falls back to a random item
- Extracts `DocumentStore::doc_with_others` to eliminate a duplicated `vec![(uri, doc)] + extend` pattern in `code_action` and `execute_command`

## Test plan

- [ ] `cargo test` passes
- [ ] `definition_cross_file_uses_find_in_indexes` — cross-file goto-definition via `FileIndex`
- [ ] `call_hierarchy_incoming_calls_finds_caller` — asserts caller name `"caller"` in response
- [ ] `call_hierarchy_outgoing_calls_finds_callee` — asserts callee name `"inner"` in response
- [ ] `completion_resolve_returns_item` — asserts `resolveMe` is present before resolving
- [ ] Smoke tests for type hierarchy, workspace symbols, semantic tokens, inlay hints, formatting, code actions, moniker, pull diagnostics