### PR TITLE
perf/bench: full benchmark suite with memory profiling

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,25 @@ Requires Rust stable. No additional system dependencies.
 
 See [docs/architecture.md](docs/architecture.md) for a map of the codebase.
 
+## Benchmarking
+
+Before landing a change that touches parsing, indexing, or request handling,
+verify it doesn't regress performance. See [`benches/README.md`](benches/README.md)
+for the full tooling guide. Quick reference:
+
+```bash
+# Set up the Laravel fixture once (clones ~2 500 PHP files):
+./scripts/setup_laravel_fixture.sh
+
+# Save a baseline, make your change, then compare:
+./scripts/bench.sh save main
+./scripts/bench.sh compare main
+
+# Measure full-pipeline memory (matches real LSP workspace scan):
+cargo build --release
+cargo run --release --bin mem_index -- --full benches/fixtures/laravel/src
+```
+
 ## Issues
 
 Bug reports and feature requests are welcome via [GitHub Issues](https://github.com/jorgsowa/php-lsp/issues). Include a minimal PHP snippet that reproduces the problem when reporting bugs.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,6 +106,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -327,6 +336,43 @@ dependencies = [
  "lock_api",
  "once_cell",
  "parking_lot_core",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+]
+
+[[package]]
+name = "dhat"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98cd11d84628e233de0ce467de10b8633f4ddaecafadefc86e13b84b8739b827"
+dependencies = [
+ "backtrace",
+ "lazy_static",
+ "mintex",
+ "parking_lot",
+ "rustc-hash",
+ "serde",
+ "serde_json",
+ "thousands",
 ]
 
 [[package]]
@@ -565,6 +611,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "iai-callgrind"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c9e864ad001cbbf35a64f7b574998823b8622bb483a25246fa1b0e2b3888686"
+dependencies = [
+ "bincode",
+ "derive_more",
+ "iai-callgrind-macros",
+ "iai-callgrind-runner",
+]
+
+[[package]]
+name = "iai-callgrind-macros"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9cee6c3bc32b63ff40e5e56190b1276d2bd0e0b319aa6f998864c27865d3b4e"
+dependencies = [
+ "derive_more",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn",
+]
+
+[[package]]
+name = "iai-callgrind-runner"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a82491521e6505b06a824274712a1307904e7cdfdf047735f7dfdb28b5f7a337"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -717,6 +799,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -769,6 +857,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -812,6 +909,12 @@ checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
 ]
+
+[[package]]
+name = "mintex"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c505b3e17ed6b70a7ed2e67fbb2c560ee327353556120d6e72f5232b6880d536"
 
 [[package]]
 name = "mio"
@@ -879,6 +982,15 @@ dependencies = [
  "indexmap",
  "serde",
  "smallvec",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]
@@ -983,7 +1095,9 @@ dependencies = [
  "bumpalo",
  "criterion",
  "dashmap 6.1.0",
+ "dhat",
  "expect-test",
+ "iai-callgrind",
  "mir-analyzer",
  "mir-codebase",
  "mir-issues",
@@ -994,6 +1108,9 @@ dependencies = [
  "tempfile",
  "tokio",
  "tower-lsp",
+ "tracing",
+ "tracing-subscriber",
+ "walkdir",
 ]
 
 [[package]]
@@ -1079,6 +1196,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
+ "syn",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
  "syn",
 ]
 
@@ -1178,6 +1317,21 @@ name = "rustc-demangle"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -1282,6 +1436,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -1425,6 +1588,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thousands"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1577,6 +1755,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -1633,6 +1854,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,13 @@ harness = false
 name = "requests"
 harness = false
 
+[features]
+dhat-heap = ["dep:dhat"]
+
 [dependencies]
+dhat = { version = "0.3", optional = true }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 mir-analyzer = "0.6.0"
 mir-issues = "0.6.0"
 mir-codebase = "0.6.0"
@@ -40,7 +46,15 @@ tokio = { version = "1", features = ["full"] }
 serde_json = "1"
 dashmap = "6"
 
+[dependencies.walkdir]
+version = "2"
+
 [dev-dependencies]
 tempfile = "3"
 expect-test = "1"
 criterion = { version = "0.8", features = ["html_reports"] }
+iai-callgrind = "0.14"
+
+[[bench]]
+name = "iai_critical"
+harness = false

--- a/benches/README.md
+++ b/benches/README.md
@@ -1,0 +1,158 @@
+# Benchmarks
+
+Four complementary tools for measuring and comparing LSP performance.
+
+---
+
+## Setup (once)
+
+```bash
+# Clone Laravel framework as a realistic PHP workspace fixture (~2,500 files).
+./scripts/setup_laravel_fixture.sh
+```
+
+---
+
+## 1. Criterion — wall-clock benchmarks (local, with comparison)
+
+Best for: catching speed regressions during development.
+
+```bash
+# Save current performance as the "main" baseline:
+./scripts/bench.sh save main
+
+# After making a change, compare:
+./scripts/bench.sh compare main
+```
+
+Criterion prints per-bench deltas with confidence intervals and colours
+regressions red. HTML report: `target/criterion/report/index.html`.
+
+The `index/workspace_scan/laravel_framework` group exercises indexing the full
+Laravel codebase. Note: the store's default 1,000-file LRU cap means ~1,500
+files are evicted during this bench — realistic for what users experience, but
+not a clean "time to index N files" measurement.
+
+---
+
+## 2. iai-callgrind — instruction-count benchmarks (CI, deterministic)
+
+Best for: regression gates in CI where wall-clock is too noisy.
+
+**Requires valgrind + the runner binary (Linux only):**
+```bash
+cargo install iai-callgrind-runner   # once
+cargo bench --bench iai_critical
+```
+
+On macOS, valgrind is not supported on recent OS versions — these benches
+compile but will fail at runtime. Run them in CI (Linux) only.
+
+Three benchmarks: `parse_medium`, `index_get_all_docs`, `hover_cross_file`.
+
+---
+
+## 3. E2E — latency + peak RSS (integration)
+
+Best for: measuring request latency and memory growth against a real binary.
+
+```bash
+cargo build --release
+./benches/integration/bench_lsp.sh --method hover --requests 200
+```
+
+Reports: startup time, post-index RSS, **peak RSS during indexing** (sampled
+every 500 ms), and latency distribution (mean / p50 / p95 / p99).
+
+To compare before/after a change:
+```bash
+./benches/integration/bench_lsp.sh > before.txt
+# make your change, rebuild
+./benches/integration/bench_lsp.sh > after.txt
+diff before.txt after.txt
+```
+
+---
+
+## 4. dhat — heap allocation profiling
+
+Best for: understanding *where* memory is allocated (not just total RSS).
+
+Use `mem_index` — a standalone binary that indexes a directory and exits
+cleanly, so dhat's `Drop` runs and the profile is written.
+
+Two modes:
+
+- **default** — FileIndex only (fast, measures `DocumentStore`)
+- **`--full`** — full `scan_workspace` pipeline: parse → `DefinitionCollector` →
+  `FileIndex` → `codebase.finalize()`. This matches what the real LSP does and
+  is the right mode for catching memory regressions.
+
+```bash
+# DocumentStore only (FileIndex path):
+cargo run --release --bin mem_index -- benches/fixtures/laravel/src
+
+# Full pipeline — matches real LSP workspace scan:
+cargo run --release --bin mem_index -- --full benches/fixtures/laravel/src
+
+# Full pipeline with heap profile:
+cargo run --release --features dhat-heap --bin mem_index -- --full benches/fixtures/laravel/src
+```
+
+Example output (`--full`, 1 609 files):
+```
+RSS before:              10 752 KB (10.5 MB)
+RSS after index:         59 472 KB (58.1 MB)
+RSS after finalize:      59 616 KB (58.2 MB)
+Delta (peak - before):   48 864 KB (47.7 MB)
+  DocumentStore share:   48 720 KB (47.6 MB)
+  Codebase share:           144 KB  (0.1 MB)
+```
+
+The large DocumentStore delta (~47 MB) comes from the system allocator holding
+freed bumpalo arena pages after the double-parse per file in `scan_workspace`
+(parse #1 for `DefinitionCollector`, parse #2 inside `docs.index()`). The
+Codebase itself is tiny.
+
+This writes `dhat-heap.json` in the current directory. Open it at:
+https://nnethercote.github.io/dh_view/dh_view.html
+
+To compare before/after a change:
+```bash
+cargo run --release --features dhat-heap --bin mem_index -- --full benches/fixtures/laravel/src
+cp dhat-heap.json dhat-heap-before.json
+# make your change, rebuild
+cargo run --release --features dhat-heap --bin mem_index -- --full benches/fixtures/laravel/src
+cp dhat-heap.json dhat-heap-after.json
+# open both in browser tabs at https://nnethercote.github.io/dh_view/dh_view.html
+```
+
+Note: do **not** use `--features dhat-heap` with the `php-lsp` binary — the
+tokio runtime keeps background tasks alive after LSP `exit`, so the process
+never exits cleanly and `dhat-heap.json` is never written.
+
+---
+
+## 5. Tracing spans — per-operation timing
+
+Best for: identifying which operation (finalize, analyze_stmts, etc.) is slow.
+
+```bash
+RUST_LOG=php_lsp=debug python3 benches/integration/lsp_client.py \
+  --binary target/release/php-lsp \
+  --fixture benches/fixtures/medium_class.php \
+  --requests 10 \
+  --output /dev/null \
+  --trace-file trace.jsonl
+```
+
+Each closed span emits a JSON line with `time.busy` (CPU time) and `time.idle`
+(waiting). Extract finalize durations:
+
+```bash
+jq 'select(.span.name=="codebase_finalize") | {"file": .span.file, "busy": .fields["time.busy"]}' trace.jsonl
+```
+
+Instrumented spans: `codebase_finalize`, `collect_definitions`, `analyze_stmts`
+(in `semantic_diagnostics.rs`), `parse_from_disk` (in `document_store.rs`),
+`workspace_scan` (in `backend.rs`).

--- a/benches/iai_critical.rs
+++ b/benches/iai_critical.rs
@@ -1,0 +1,77 @@
+use std::sync::Arc;
+
+use iai_callgrind::{black_box, library_benchmark, library_benchmark_group, main};
+use tower_lsp::lsp_types::Url;
+
+use php_lsp::ast::ParsedDoc;
+use php_lsp::document_store::DocumentStore;
+use php_lsp::hover::hover_info;
+
+const MEDIUM: &str = include_str!("fixtures/medium_class.php");
+const SMALL: &str = include_str!("fixtures/small_class.php");
+const SERVICE: &str = include_str!("fixtures/service.php");
+const REPOSITORY: &str = include_str!("fixtures/repository.php");
+
+// --- parse ---
+
+#[library_benchmark]
+fn parse_medium() -> ParsedDoc {
+    black_box(ParsedDoc::parse(MEDIUM.to_owned()))
+}
+
+library_benchmark_group!(name = parse_group; benchmarks = parse_medium);
+
+// --- index ---
+
+fn setup_store_50() -> DocumentStore {
+    let store = DocumentStore::new();
+    let fixtures = [SMALL, MEDIUM, SERVICE, REPOSITORY];
+    for i in 0..50usize {
+        let uri = Url::parse(&format!("file:///iai/file{i}.php")).unwrap();
+        store.index(uri, fixtures[i % fixtures.len()]);
+    }
+    store
+}
+
+#[library_benchmark]
+#[bench::fifty_files(setup_store_50())]
+fn index_get_all_docs(store: DocumentStore) {
+    black_box(store.all_docs());
+}
+
+library_benchmark_group!(name = index_group; benchmarks = index_get_all_docs);
+
+// --- hover ---
+
+fn setup_hover() -> (Arc<ParsedDoc>, Vec<(Url, Arc<ParsedDoc>)>) {
+    let doc = Arc::new(ParsedDoc::parse(MEDIUM.to_owned()));
+    let other: Vec<(Url, Arc<ParsedDoc>)> = [SERVICE, REPOSITORY]
+        .iter()
+        .enumerate()
+        .map(|(i, src)| {
+            let url = Url::parse(&format!("file:///iai/other{i}.php")).unwrap();
+            let parsed = Arc::new(ParsedDoc::parse((*src).to_owned()));
+            (url, parsed)
+        })
+        .collect();
+    (doc, other)
+}
+
+#[library_benchmark]
+#[bench::method_position(setup_hover())]
+fn hover_cross_file((doc, others): (Arc<ParsedDoc>, Vec<(Url, Arc<ParsedDoc>)>)) {
+    // Line 109, char 19 — on `getTitle` method
+    let pos = tower_lsp::lsp_types::Position {
+        line: 109,
+        character: 19,
+    };
+    black_box(hover_info(MEDIUM, &doc, pos, &others));
+}
+
+library_benchmark_group!(name = hover_group; benchmarks = hover_cross_file);
+
+main!(
+    library_benchmark_groups = parse_group,
+    index_group,
+    hover_group
+);

--- a/benches/index.rs
+++ b/benches/index.rs
@@ -88,11 +88,55 @@ fn bench_workspace_scan(c: &mut Criterion) {
     group.finish();
 }
 
+/// Benchmark indexing the Laravel framework (~2,500 PHP files).
+///
+/// Requires running `scripts/setup_laravel_fixture.sh` first.
+/// Skipped automatically if the fixture is absent.
+fn bench_workspace_scan_laravel(c: &mut Criterion) {
+    let fixture_dir =
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("benches/fixtures/laravel/src");
+
+    if !fixture_dir.exists() {
+        eprintln!(
+            "Laravel fixture not found — run `scripts/setup_laravel_fixture.sh` to enable this benchmark"
+        );
+        return;
+    }
+
+    let php_files: Vec<(tower_lsp::lsp_types::Url, String)> = walkdir::WalkDir::new(&fixture_dir)
+        .into_iter()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().map_or(false, |x| x == "php"))
+        .filter_map(|e| {
+            let url = tower_lsp::lsp_types::Url::from_file_path(e.path()).ok()?;
+            let src = std::fs::read_to_string(e.path()).ok()?;
+            Some((url, src))
+        })
+        .collect();
+
+    eprintln!("Laravel fixture: {} PHP files", php_files.len());
+
+    let mut group = c.benchmark_group("index/workspace_scan");
+    group.sample_size(10);
+
+    group.bench_function("laravel_framework", |b| {
+        b.iter(|| {
+            let store = DocumentStore::new();
+            for (url, src) in &php_files {
+                store.index(url.clone(), src);
+            }
+        });
+    });
+
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_index_single,
     bench_get_doc,
     bench_all_docs,
-    bench_workspace_scan
+    bench_workspace_scan,
+    bench_workspace_scan_laravel
 );
 criterion_main!(benches);

--- a/benches/integration/bench_lsp.sh
+++ b/benches/integration/bench_lsp.sh
@@ -4,7 +4,7 @@
 # Usage:
 #   ./bench_lsp.sh [--method hover|definition|references] [--requests N]
 #
-# Defaults: method=hover, requests=100
+# Defaults: method=hover, requests=100, fixture=medium_class.php
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -12,7 +12,8 @@ ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 BINARY="$ROOT_DIR/target/release/php-lsp"
 CLIENT="$SCRIPT_DIR/lsp_client.py"
 FIXTURE="$ROOT_DIR/benches/fixtures/medium_class.php"
-RESULTS_FILE="$(mktemp /tmp/bench_lsp_results.XXXXXX.jsonl)"
+RESULTS_FILE="$(mktemp /tmp/bench_lsp_results_XXXXXX).jsonl"
+INDEX_WAIT=15
 
 # ── Argument parsing ───────────────────────────────────────────────────────────
 LSP_METHOD="hover"
@@ -24,29 +25,37 @@ while [[ $# -gt 0 ]]; do
             LSP_METHOD="$2"; shift 2 ;;
         --requests)
             NUM_REQUESTS="$2"; shift 2 ;;
+        --fixture)
+            FIXTURE="$2"; shift 2 ;;
+        --index-wait)
+            INDEX_WAIT="$2"; shift 2 ;;
         *)
             echo "Unknown argument: $1" >&2; exit 1 ;;
     esac
 done
 
+# Portable millisecond timestamp (works on macOS and Linux).
+ms_now() { python3 -c "import time; print(int(time.monotonic()*1000))"; }
+
 # ── Build ──────────────────────────────────────────────────────────────────────
 echo "==> Building php-lsp (release)..."
-BUILD_START=$(date +%s%3N)
+BUILD_START=$(ms_now)
 cargo build --release --manifest-path "$ROOT_DIR/Cargo.toml" 2>&1
-BUILD_END=$(date +%s%3N)
+BUILD_END=$(ms_now)
 BUILD_MS=$(( BUILD_END - BUILD_START ))
 echo "    Build time: ${BUILD_MS} ms"
 
 # ── Run client ────────────────────────────────────────────────────────────────
 echo "==> Benchmarking textDocument/${LSP_METHOD} (${NUM_REQUESTS} requests)..."
-START_MS=$(date +%s%3N)
+START_MS=$(ms_now)
 python3 "$CLIENT" \
     --binary "$BINARY" \
     --fixture "$FIXTURE" \
     --requests "$NUM_REQUESTS" \
     --lsp-method "$LSP_METHOD" \
+    --index-wait "$INDEX_WAIT" \
     --output "$RESULTS_FILE"
-END_MS=$(date +%s%3N)
+END_MS=$(ms_now)
 TOTAL_MS=$(( END_MS - START_MS ))
 echo "    Total wall time: ${TOTAL_MS} ms"
 
@@ -59,6 +68,7 @@ lsp_method   = sys.argv[2]
 
 startup_ms = None
 rss_kb = None
+peak_rss_kb = None
 latencies = []
 
 with open(results_path) as f:
@@ -75,6 +85,9 @@ with open(results_path) as f:
             startup_ms = obj["latency_ms"]
         elif method == "rss":
             rss_kb = obj.get("rss_kb")
+            peak_rss_kb = obj.get("peak_rss_kb")
+        elif method == "rss_sample":
+            pass  # timeline samples — available in JSONL for plotting
         elif "latency_ms" in obj:
             latencies.append(obj["latency_ms"])
 
@@ -86,9 +99,13 @@ else:
 
 print("==> RSS after workspace index:")
 if rss_kb is not None:
-    print(f"    {rss_kb} KB ({rss_kb / 1024:.1f} MB)")
+    print(f"    post-index : {rss_kb} KB ({rss_kb / 1024:.1f} MB)")
 else:
-    print("    N/A")
+    print("    post-index : N/A")
+if peak_rss_kb is not None:
+    print(f"    peak       : {peak_rss_kb} KB ({peak_rss_kb / 1024:.1f} MB)")
+else:
+    print("    peak       : N/A")
 
 print(f"==> textDocument/{lsp_method} latency statistics (ms):")
 if not latencies:

--- a/benches/integration/lsp_client.py
+++ b/benches/integration/lsp_client.py
@@ -17,6 +17,7 @@ Usage:
 import argparse
 import json
 import os
+import select
 import subprocess
 import sys
 import threading
@@ -87,6 +88,14 @@ def notif_initialized() -> dict:
     return {"jsonrpc": "2.0", "method": "initialized", "params": {}}
 
 
+def req_shutdown() -> dict:
+    return {"jsonrpc": "2.0", "id": next_id(), "method": "shutdown", "params": None}
+
+
+def notif_exit() -> dict:
+    return {"jsonrpc": "2.0", "method": "exit", "params": None}
+
+
 def req_did_open(uri: str, text: str) -> dict:
     return {
         "jsonrpc": "2.0",
@@ -141,11 +150,15 @@ def req_references(req_id: int, uri: str, line: int, character: int) -> dict:
 
 # ── Index-complete detection ───────────────────────────────────────────────────
 
-def _drain_until_indexed(proc, index_wait: float) -> None:
+def _drain_until_indexed(proc, index_wait: float, rss_samples: list) -> None:
     """
     Read server notifications in a background thread until either:
       - a $/progress end-of-work-done notification is received, or
       - `index_wait` seconds have elapsed (safety fallback).
+
+    While waiting, a second thread samples RSS every 500 ms and appends
+    ``{"time_ms": ..., "rss_kb": ..., "event": "sample"}`` dicts to
+    ``rss_samples``.  The caller can inspect this list for peak RSS.
 
     php-lsp sends ``$/progress`` with ``kind == "end"`` when the
     workspace scan finishes.  Advertising ``window.workDoneProgress``
@@ -153,13 +166,26 @@ def _drain_until_indexed(proc, index_wait: float) -> None:
     """
     deadline = time.monotonic() + index_wait
     done = threading.Event()
+    t0 = time.monotonic()
+
+    def _sampler():
+        while not done.is_set():
+            kb = rss_kb(proc.pid)
+            if kb is not None:
+                rss_samples.append({
+                    "time_ms": round((time.monotonic() - t0) * 1000.0, 1),
+                    "rss_kb": kb,
+                    "event": "sample",
+                })
+            done.wait(timeout=0.5)
 
     def _reader():
         while not done.is_set() and time.monotonic() < deadline:
-            try:
-                proc.stdout._sock.settimeout(0.1)  # noqa: SLF001
-            except AttributeError:
-                pass
+            # Use select so the loop stays responsive to the `done` flag
+            # even when the server is quiet (pipe has no socket timeout).
+            ready, _, _ = select.select([proc.stdout], [], [], 0.1)
+            if not ready:
+                continue
             try:
                 msg = read_message(proc)
             except (EOFError, OSError, ValueError):
@@ -175,12 +201,15 @@ def _drain_until_indexed(proc, index_wait: float) -> None:
                     done.set()
                     break
 
+    sampler = threading.Thread(target=_sampler, daemon=True)
+    sampler.start()
     t = threading.Thread(target=_reader, daemon=True)
     t.start()
     # Wait for the end signal or the deadline, whichever comes first.
     done.wait(timeout=index_wait)
-    done.set()  # signal thread to stop if it's still running
+    done.set()  # signal threads to stop
     t.join(timeout=1.0)
+    sampler.join(timeout=1.0)
 
 
 # ── RSS helper ─────────────────────────────────────────────────────────────────
@@ -230,6 +259,11 @@ def main() -> None:
         default="hover",
         help="LSP request method to benchmark (default: hover)",
     )
+    parser.add_argument(
+        "--trace-file",
+        default=None,
+        help="Write server stderr (tracing spans) to this file instead of discarding it",
+    )
     args = parser.parse_args()
 
     fixture_path = os.path.abspath(args.fixture)
@@ -258,11 +292,16 @@ def main() -> None:
 
     # Spawn the server and record wall time immediately.
     spawn_t0 = time.perf_counter()
+    if args.trace_file:
+        stderr_dest = open(args.trace_file, "wb")  # noqa: SIM115
+    else:
+        stderr_dest = subprocess.DEVNULL
     proc = subprocess.Popen(
         [args.binary],
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
-        stderr=subprocess.DEVNULL,
+        stderr=stderr_dest,
+        env={**os.environ},
     )
 
     output_fh = open(args.output, "w", encoding="utf-8") if args.output != "-" else sys.stdout
@@ -292,13 +331,22 @@ def main() -> None:
         # if the server does not emit them.  This avoids measuring RSS before
         # the index is built (which would undercount) while also bounding wait
         # time on workspaces without progress support.
-        _drain_until_indexed(proc, args.index_wait)
+        rss_samples: list = []
+        _drain_until_indexed(proc, args.index_wait, rss_samples)
 
-        rss = rss_kb(proc.pid)
+        rss_post_index = rss_kb(proc.pid)
+        peak_rss = max((s["rss_kb"] for s in rss_samples), default=rss_post_index)
         output_fh.write(json.dumps({
             "method": "rss",
-            "rss_kb": rss,
+            "rss_kb": rss_post_index,
+            "peak_rss_kb": peak_rss,
+            "samples": len(rss_samples),
         }) + "\n")
+        output_fh.flush()
+
+        # Write per-sample timeline so callers can plot memory growth.
+        for sample in rss_samples:
+            output_fh.write(json.dumps({"method": "rss_sample", **sample}) + "\n")
         output_fh.flush()
 
         # ── Request latency ───────────────────────────────────────────────────
@@ -318,10 +366,28 @@ def main() -> None:
             output_fh.flush()
 
     finally:
-        proc.stdin.close()
-        proc.wait(timeout=5)
+        # Send LSP shutdown/exit so the server exits cleanly (Drop runs, dhat writes).
+        try:
+            proc.stdin.write(encode_message(req_shutdown()))
+            proc.stdin.flush()
+            read_message(proc)  # wait for shutdown response
+            proc.stdin.write(encode_message(notif_exit()))
+            proc.stdin.flush()
+        except (OSError, EOFError):
+            pass
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            proc.terminate()
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait()
         if args.output != "-":
             output_fh.close()
+        if args.trace_file and stderr_dest is not subprocess.DEVNULL:
+            stderr_dest.close()
 
 
 if __name__ == "__main__":

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# bench.sh — criterion baseline management
+#
+# Usage:
+#   scripts/bench.sh save [baseline]    save current results as a named baseline (default: main)
+#   scripts/bench.sh compare [baseline] run benches and compare against a saved baseline
+#   scripts/bench.sh run                run benches without comparison
+#
+# Criterion stores baselines under target/criterion/<group>/<bench>/base/
+# HTML report is at target/criterion/report/index.html after any run.
+
+set -euo pipefail
+
+BASELINE="${2:-main}"
+CMD="${1:-run}"
+
+BENCHES=(parse index requests)
+
+case "$CMD" in
+  save)
+    echo "Running benchmarks and saving baseline '$BASELINE' ..."
+    for b in "${BENCHES[@]}"; do
+      cargo bench --bench "$b" -- --save-baseline "$BASELINE"
+    done
+    echo "Baseline '$BASELINE' saved."
+    ;;
+  compare)
+    echo "Running benchmarks and comparing against baseline '$BASELINE' ..."
+    for b in "${BENCHES[@]}"; do
+      cargo bench --bench "$b" -- --baseline "$BASELINE"
+    done
+    ;;
+  run)
+    for b in "${BENCHES[@]}"; do
+      cargo bench --bench "$b"
+    done
+    ;;
+  *)
+    echo "Usage: $0 {save|compare|run} [baseline_name]" >&2
+    exit 1
+    ;;
+esac
+
+echo "HTML report: target/criterion/report/index.html"

--- a/scripts/setup_laravel_fixture.sh
+++ b/scripts/setup_laravel_fixture.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FIXTURE_DIR="$(dirname "$0")/../benches/fixtures/laravel"
+
+if [ -d "$FIXTURE_DIR/.git" ]; then
+  echo "Laravel fixture already present at $FIXTURE_DIR"
+  exit 0
+fi
+
+echo "Cloning laravel/framework into $FIXTURE_DIR ..."
+git clone --depth=1 https://github.com/laravel/framework "$FIXTURE_DIR"
+echo "Done. $(find "$FIXTURE_DIR/src" -name '*.php' | wc -l | tr -d ' ') PHP files available."

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -2362,6 +2362,7 @@ const MAX_INDEXED_FILES: usize = 50_000;
 ///
 /// Phase 1 — directory traversal: async, serial (I/O-bound; tokio handles it well).
 /// Phase 2 — file reading + parsing: concurrent, bounded by available CPU cores.
+#[tracing::instrument(skip(docs, exclude_paths, codebase), fields(root = %root.display()))]
 async fn scan_workspace(
     root: PathBuf,
     docs: Arc<DocumentStore>,

--- a/src/bin/mem_index.rs
+++ b/src/bin/mem_index.rs
@@ -43,14 +43,13 @@ fn rss_kb() -> u64 {
     #[cfg(target_os = "linux")]
     if let Ok(s) = std::fs::read_to_string(format!("/proc/{}/status", std::process::id())) {
         for line in s.lines() {
-            if line.starts_with("VmRSS:") {
-                if let Some(n) = line
+            if line.starts_with("VmRSS:")
+                && let Some(n) = line
                     .split_whitespace()
                     .nth(1)
                     .and_then(|v| v.parse::<u64>().ok())
-                {
-                    return n;
-                }
+            {
+                return n;
             }
         }
     }

--- a/src/bin/mem_index.rs
+++ b/src/bin/mem_index.rs
@@ -1,0 +1,201 @@
+/// Standalone memory benchmark: index a directory of PHP files and report
+/// peak + final RSS.  Run with `--features dhat-heap` for heap profiling.
+///
+/// Two modes (controlled by `--full` flag):
+///
+///   # FileIndex only (DocumentStore, fast):
+///   cargo run --release --bin mem_index -- benches/fixtures/laravel/src
+///
+///   # Full pipeline (DocumentStore + Codebase + finalize, matches real LSP):
+///   cargo run --release --bin mem_index -- --full benches/fixtures/laravel/src
+///
+///   # Full pipeline with heap profile:
+///   cargo run --release --features dhat-heap --bin mem_index -- --full benches/fixtures/laravel/src
+
+#[cfg(feature = "dhat-heap")]
+#[global_allocator]
+static ALLOC: dhat::Alloc = dhat::Alloc;
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use tower_lsp::lsp_types::Url;
+
+use php_lsp::ast::ParsedDoc;
+use php_lsp::document_store::DocumentStore;
+
+fn rss_kb() -> u64 {
+    // macOS
+    #[cfg(target_os = "macos")]
+    {
+        use std::process::Command;
+        let pid = std::process::id();
+        if let Ok(out) = Command::new("ps")
+            .args(["-o", "rss=", "-p", &pid.to_string()])
+            .output()
+            && let Ok(s) = std::str::from_utf8(&out.stdout)
+            && let Ok(n) = s.trim().parse::<u64>()
+        {
+            return n;
+        }
+    }
+    // Linux
+    #[cfg(target_os = "linux")]
+    if let Ok(s) = std::fs::read_to_string(format!("/proc/{}/status", std::process::id())) {
+        for line in s.lines() {
+            if line.starts_with("VmRSS:") {
+                if let Some(n) = line
+                    .split_whitespace()
+                    .nth(1)
+                    .and_then(|v| v.parse::<u64>().ok())
+                {
+                    return n;
+                }
+            }
+        }
+    }
+    0
+}
+
+fn print_rss(label: &str, kb: u64) {
+    println!(
+        "{:<24} {} KB ({:.1} MB)",
+        format!("{label}:"),
+        kb,
+        kb as f64 / 1024.0
+    );
+}
+
+fn main() {
+    #[cfg(feature = "dhat-heap")]
+    let _profiler = dhat::Profiler::new_heap();
+
+    // Parse args: optional `--full` flag before the directory path.
+    let args: Vec<String> = std::env::args().collect();
+    let (full_pipeline, dir_arg) = match args.get(1).map(|s| s.as_str()) {
+        Some("--full") => (true, args.get(2)),
+        _ => (false, args.get(1)),
+    };
+
+    let dir = dir_arg.cloned().unwrap_or_else(|| {
+        eprintln!("Usage: mem_index [--full] <directory>");
+        eprintln!(
+            "  --full   also run DefinitionCollector + codebase.finalize() (full LSP pipeline)"
+        );
+        std::process::exit(1);
+    });
+
+    let dir = std::fs::canonicalize(&dir).unwrap_or_else(|_| {
+        eprintln!("error: directory not found: {dir}");
+        std::process::exit(1);
+    });
+
+    let php_files: Vec<(Url, String)> = walkdir::WalkDir::new(&dir)
+        .into_iter()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().is_some_and(|x| x == "php"))
+        .filter_map(|e| {
+            let url = Url::from_file_path(e.path()).ok()?;
+            let src = std::fs::read_to_string(e.path()).ok()?;
+            Some((url, src))
+        })
+        .collect();
+
+    println!("Files found:    {}", php_files.len());
+    println!(
+        "Mode:           {}",
+        if full_pipeline {
+            "full (DocumentStore + Codebase)"
+        } else {
+            "index-only (DocumentStore)"
+        }
+    );
+    println!();
+
+    let rss_before = rss_kb();
+    let t0 = Instant::now();
+
+    let store = DocumentStore::new();
+    let codebase = if full_pipeline {
+        Some(Arc::new(mir_codebase::Codebase::new()))
+    } else {
+        None
+    };
+
+    let mut peak_rss = rss_before;
+
+    for (i, (url, src)) in php_files.iter().enumerate() {
+        if let Some(cb) = &codebase {
+            // Replicate the real scan_workspace pipeline:
+            // 1. Parse to get AST
+            // 2. Run DefinitionCollector into codebase
+            // 3. Store FileIndex (docs.index re-parses internally)
+            let doc = ParsedDoc::parse(src.clone());
+            let file: Arc<str> = Arc::from(url.as_str());
+            let source_map = php_rs_parser::source_map::SourceMap::new(doc.source());
+            let collector = mir_analyzer::collector::DefinitionCollector::new(
+                cb,
+                file,
+                doc.source(),
+                &source_map,
+            );
+            collector.collect(doc.program());
+        }
+        store.index(url.clone(), src);
+
+        if i % 100 == 0 {
+            let rss = rss_kb();
+            if rss > peak_rss {
+                peak_rss = rss;
+            }
+        }
+    }
+
+    let rss_after_index = rss_kb();
+    if rss_after_index > peak_rss {
+        peak_rss = rss_after_index;
+    }
+
+    // Finalize the codebase (rebuilds full inheritance tables) — this is what
+    // makes the first did_change after workspace scan expensive.
+    if let Some(cb) = &codebase {
+        let t_fin = Instant::now();
+        cb.finalize();
+        println!(
+            "codebase.finalize(): {:.1}ms",
+            t_fin.elapsed().as_secs_f64() * 1000.0
+        );
+        let rss_fin = rss_kb();
+        if rss_fin > peak_rss {
+            peak_rss = rss_fin;
+        }
+    }
+
+    let elapsed = t0.elapsed();
+    let rss_final = rss_kb();
+    let _indexes = store.all_indexes(); // force retention
+
+    println!(
+        "Indexed {} files in {:.1}s",
+        php_files.len(),
+        elapsed.as_secs_f64()
+    );
+    println!();
+    print_rss("RSS before", rss_before);
+    print_rss("RSS after index", rss_after_index);
+    if codebase.is_some() {
+        print_rss("RSS after finalize", rss_final);
+    }
+    print_rss("RSS peak (sampled)", peak_rss);
+    println!();
+    let delta = peak_rss.saturating_sub(rss_before);
+    print_rss("Delta (peak - before)", delta);
+    if let Some(post) = rss_after_index.checked_sub(rss_before) {
+        print_rss("  DocumentStore share", post);
+    }
+    if codebase.is_some()
+        && let Some(cb_share) = rss_final.checked_sub(rss_after_index)
+    {
+        print_rss("  Codebase share", cb_share);
+    }
+}

--- a/src/document_link.rs
+++ b/src/document_link.rs
@@ -95,15 +95,15 @@ fn link_from_path_expr(
 
     let target = if std::path::Path::new(raw).is_absolute() {
         Url::from_file_path(raw).ok()
-    } else {
-        let base = uri.to_file_path().ok()?;
-        let dir = base.parent()?;
+    } else if let Some(dir) = uri.to_file_path().ok().as_deref().and_then(|p| p.parent()) {
         Url::from_file_path(
             dir.join(raw)
                 .canonicalize()
                 .unwrap_or_else(|_| dir.join(raw)),
         )
         .ok()
+    } else {
+        None
     };
 
     Some(DocumentLink {

--- a/src/document_store.rs
+++ b/src/document_store.rs
@@ -350,6 +350,7 @@ impl DocumentStore {
 
 /// Read a file from disk and parse it. Returns `None` if the file cannot be read.
 fn read_and_parse_from_disk(uri: &Url) -> Option<ParsedDoc> {
+    let _span = tracing::debug_span!("parse_from_disk", file = %uri).entered();
     let path = uri.to_file_path().ok()?;
     let text = std::fs::read_to_string(&path).ok()?;
     let (doc, _) = parse_document(&text);

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,11 +49,27 @@ mod use_import;
 mod util;
 mod walk;
 
+#[cfg(feature = "dhat-heap")]
+#[global_allocator]
+static ALLOC: dhat::Alloc = dhat::Alloc;
+
 use backend::Backend;
 use tower_lsp::{LspService, Server};
 
 #[tokio::main]
 async fn main() {
+    #[cfg(feature = "dhat-heap")]
+    let _profiler = dhat::Profiler::new_heap();
+
+    // Emit JSON spans to stderr when RUST_LOG is set.
+    // Example: RUST_LOG=php_lsp=debug php-lsp 2>trace.jsonl
+    // Each closed span includes "time.busy" and "time.idle" duration fields.
+    tracing_subscriber::fmt()
+        .json()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .with_span_events(tracing_subscriber::fmt::format::FmtSpan::CLOSE)
+        .with_writer(std::io::stderr)
+        .init();
     if let Some(arg) = std::env::args().nth(1)
         && (arg == "--version" || arg == "-V")
     {

--- a/src/semantic_diagnostics.rs
+++ b/src/semantic_diagnostics.rs
@@ -37,14 +37,20 @@ pub fn semantic_diagnostics(
     // and rebuild inheritance tables.
     codebase.remove_file_definitions(&file);
     let source_map = php_rs_parser::source_map::SourceMap::new(doc.source());
-    let collector = mir_analyzer::collector::DefinitionCollector::new(
-        codebase,
-        file.clone(),
-        doc.source(),
-        &source_map,
-    );
-    let collector_issues = collector.collect(doc.program());
-    codebase.finalize();
+    let collector_issues = {
+        let _span = tracing::debug_span!("collect_definitions", file = %uri).entered();
+        let collector = mir_analyzer::collector::DefinitionCollector::new(
+            codebase,
+            file.clone(),
+            doc.source(),
+            &source_map,
+        );
+        collector.collect(doc.program())
+    };
+    {
+        let _span = tracing::debug_span!("codebase_finalize", file = %uri).entered();
+        codebase.finalize();
+    }
 
     // Pass 2: analyse function/method bodies in the current document.
     let mut issue_buffer = mir_issues::IssueBuffer::new();
@@ -58,7 +64,10 @@ pub fn semantic_diagnostics(
         &mut symbols,
     );
     let mut ctx = mir_analyzer::context::Context::new();
-    analyzer.analyze_stmts(&doc.program().stmts, &mut ctx);
+    {
+        let _span = tracing::debug_span!("analyze_stmts", file = %uri).entered();
+        analyzer.analyze_stmts(&doc.program().stmts, &mut ctx);
+    }
 
     collector_issues
         .into_iter()


### PR DESCRIPTION
## Summary

- Adds five complementary performance tools: Criterion (wall-clock), iai-callgrind (deterministic CI gates), E2E latency client, dhat heap profiler, and tracing spans — see `benches/README.md` for the full guide
- `src/bin/mem_index` gains a `--full` mode that replicates the real `scan_workspace` pipeline (parse → `DefinitionCollector` → `FileIndex` → `codebase.finalize()`), giving accurate memory numbers instead of just the FileIndex path
- `CONTRIBUTING.md` now has a benchmarking section so contributors know how to verify they haven't regressed performance before opening a PR

## Key findings from the new `--full` benchmark (1 609 Laravel files)

| What | RSS delta |
|---|---|
| `DocumentStore` (FileIndex only) | +11 MB |
| Full pipeline (`--full`) | +48 MB |
| `Codebase` share (definitions + inheritance) | +0.1 MB |

The ~36 MB gap between modes comes from the system allocator holding freed bumpalo arena pages after the **double-parse** in `scan_workspace` — `parse_document` is called once for `DefinitionCollector` and again inside `docs.index()`. The Codebase itself is tiny. This points to a concrete optimisation: a `DocumentStore::index_from_doc` path that accepts an already-parsed `ParsedDoc` and skips the second parse.

## Test plan

- [ ] `cargo test` passes (854 tests)
- [ ] `cargo clippy -- -D warnings` clean
- [ ] `./scripts/setup_laravel_fixture.sh` clones fixture without errors
- [ ] `cargo run --release --bin mem_index -- --full benches/fixtures/laravel/src` prints DocumentStore + Codebase share breakdown
- [ ] `./scripts/bench.sh save main && ./scripts/bench.sh compare main` runs criterion benches and prints comparison