### PR TITLE
perf(references): use codebase index to pre-filter files for Method references

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1098,6 +1098,7 @@ dependencies = [
  "dhat",
  "expect-test",
  "iai-callgrind",
+ "indexmap",
  "mir-analyzer",
  "mir-codebase",
  "mir-issues",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ version = "2"
 [dev-dependencies]
 tempfile = "3"
 expect-test = "1"
+indexmap = "2"
 criterion = { version = "0.8", features = ["html_reports"] }
 iai-callgrind = "0.14"
 

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -4,6 +4,14 @@ use std::sync::{Arc, RwLock};
 
 use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::notification::Progress as ProgressNotification;
+
+/// Sent to the client once Phase 3 (reference index build) finishes.
+/// Allows tests and tooling to wait for the codebase fast path to be active.
+enum IndexReadyNotification {}
+impl tower_lsp::lsp_types::notification::Notification for IndexReadyNotification {
+    type Params = ();
+    const METHOD: &'static str = "$/php-lsp/indexReady";
+}
 use tower_lsp::lsp_types::request::{
     CodeLensRefresh, InlayHintRefreshRequest, InlineValueRefreshRequest, SemanticTokensRefresh,
     WorkDoneProgressCreate, WorkspaceDiagnosticRefresh,
@@ -529,7 +537,7 @@ impl LanguageServer for Backend {
                 // find_references_codebase can serve O(k) lookups instead of
                 // scanning every file's AST. Runs after the progress notification
                 // so the editor considers indexing "done" while this completes.
-                build_reference_index(docs, codebase, ref_index_ready).await;
+                build_reference_index(docs, codebase, ref_index_ready, client).await;
             });
         }
 
@@ -2473,6 +2481,7 @@ async fn build_reference_index(
     docs: Arc<DocumentStore>,
     codebase: Arc<mir_codebase::Codebase>,
     ready: Arc<AtomicBool>,
+    client: Client,
 ) {
     // The codebase was already finalized at the end of the workspace scan
     // (Phase 2). Calling finalize() again here would race with concurrent
@@ -2501,6 +2510,7 @@ async fn build_reference_index(
 
     while set.join_next().await.is_some() {}
     ready.store(true, Ordering::Release);
+    client.send_notification::<IndexReadyNotification>(()).await;
 }
 
 #[cfg(test)]
@@ -3087,6 +3097,7 @@ mod tests {
 mod integration {
     use super::Backend;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tower_lsp::lsp_types::Url;
     use tower_lsp::{LspService, Server};
 
     /// Encode a JSON value as an LSP-framed message.
@@ -3198,6 +3209,38 @@ mod integration {
             .unwrap_or_else(|_| panic!("timed out waiting for {method} notification"))
         }
 
+        /// Wait until the server sends `$/php-lsp/indexReady` (10 s timeout).
+        /// The fast path in `find_references_codebase` is only active after this.
+        ///
+        /// The workspace scan sends server-to-client requests (`WorkDoneProgressCreate`,
+        /// `client/registerCapability`) and blocks until they're answered.  This loop
+        /// auto-responds with `{"result": null}` to any server request so those don't
+        /// deadlock the scan.
+        async fn wait_for_index_ready(&mut self) {
+            tokio::time::timeout(tokio::time::Duration::from_secs(10), async {
+                loop {
+                    let msg = read_msg(&mut self.read).await;
+                    if msg.get("method") == Some(&serde_json::json!("$/php-lsp/indexReady")) {
+                        return;
+                    }
+                    // Server-to-client request (has both "id" and "method"):
+                    // send a null-result response so the server isn't blocked.
+                    if msg.get("method").is_some() {
+                        if let Some(id) = msg.get("id") {
+                            let response = serde_json::json!({
+                                "jsonrpc": "2.0",
+                                "id": id,
+                                "result": null
+                            });
+                            self.write.write_all(&frame(&response)).await.unwrap();
+                        }
+                    }
+                }
+            })
+            .await
+            .unwrap_or_else(|_| panic!("timed out waiting for $/php-lsp/indexReady"))
+        }
+
         /// Read `textDocument/publishDiagnostics` notifications until one arrives for `uri`.
         async fn read_diagnostics_for(&mut self, uri: &str) -> serde_json::Value {
             let uri_val = serde_json::json!(uri);
@@ -3245,6 +3288,29 @@ mod integration {
         // Send initialized notification (required by LSP spec)
         client.notify("initialized", serde_json::json!({})).await;
         resp
+    }
+
+    /// Initialize with a workspace root so the server runs the workspace scan
+    /// and builds the reference index (Phase 3).  Callers must then call
+    /// `client.wait_for_index_ready()` before exercising the codebase fast path.
+    async fn initialize_with_root(client: &mut TestClient, root: &std::path::Path) {
+        let root_uri = Url::from_file_path(root).unwrap();
+        client
+            .request(
+                "initialize",
+                serde_json::json!({
+                    "processId": null,
+                    "rootUri": root_uri.as_str(),
+                    "capabilities": {
+                        "textDocument": {
+                            "hover": { "contentFormat": ["markdown", "plaintext"] },
+                            "completion": { "completionItem": { "snippetSupport": true } }
+                        }
+                    }
+                }),
+            )
+            .await;
+        client.notify("initialized", serde_json::json!({})).await;
     }
 
     #[tokio::test]
@@ -3753,6 +3819,107 @@ mod integration {
             !hits.contains(&("file:///b.php", 2)),
             "free-function call (b.php line 2) must be excluded, got: {:?}",
             hits
+        );
+    }
+
+    /// E2E: the codebase fast path (find_references_codebase) is exercised for a
+    /// `final` class method across multiple files.
+    ///
+    /// The key difference from the AST-walk tests: the server is initialized with a
+    /// real workspace root so the workspace scan and reference-index build (Phase 3)
+    /// run.  We wait for `$/php-lsp/indexReady` before sending the references request
+    /// to guarantee the fast path is active, not the fallback AST scan.
+    ///
+    /// ignored.php has a same-named call on an unknown receiver; the fast path must
+    /// restrict the scan to files the codebase tracked, so ignored.php must not appear.
+    #[tokio::test]
+    async fn references_fast_path_final_class_cross_file_e2e() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // class.php — final class definition, no call sites.
+        std::fs::write(
+            dir.path().join("class.php"),
+            "<?php\nfinal class Order {\n    public function submit(): void {}\n}\n",
+        )
+        .unwrap();
+        // caller.php — typed call site: $order is known to be Order.
+        std::fs::write(
+            dir.path().join("caller.php"),
+            "<?php\n$order = new Order();\n$order->submit();\n",
+        )
+        .unwrap();
+        // ignored.php — untyped call: mir cannot resolve the receiver.
+        std::fs::write(
+            dir.path().join("ignored.php"),
+            "<?php\n$unknown->submit();\n",
+        )
+        .unwrap();
+
+        let class_uri = Url::from_file_path(dir.path().join("class.php"))
+            .unwrap()
+            .to_string();
+        let caller_uri = Url::from_file_path(dir.path().join("caller.php"))
+            .unwrap()
+            .to_string();
+        let ignored_uri = Url::from_file_path(dir.path().join("ignored.php"))
+            .unwrap()
+            .to_string();
+
+        let mut client = start_server();
+        initialize_with_root(&mut client, dir.path()).await;
+
+        // Wait for Phase 3 to complete so the codebase fast path is active.
+        client.wait_for_index_ready().await;
+
+        // Open class.php and place the cursor on "submit" in the declaration.
+        // Line 2: "    public function submit(): void {}"
+        //                             ^ character 20
+        client
+            .notify(
+                "textDocument/didOpen",
+                serde_json::json!({
+                    "textDocument": {
+                        "uri": class_uri,
+                        "languageId": "php",
+                        "version": 1,
+                        "text": "<?php\nfinal class Order {\n    public function submit(): void {}\n}\n"
+                    }
+                }),
+            )
+            .await;
+
+        // Give the async did_open handler time to store the document text.
+        tokio::time::sleep(tokio::time::Duration::from_millis(150)).await;
+
+        let resp = client
+            .request(
+                "textDocument/references",
+                serde_json::json!({
+                    "textDocument": { "uri": class_uri },
+                    "position": { "line": 2, "character": 20 },
+                    "context": { "includeDeclaration": false }
+                }),
+            )
+            .await;
+
+        assert!(
+            resp["error"].is_null(),
+            "references should not error: {:?}",
+            resp
+        );
+
+        let locs = resp["result"].as_array().expect("expected location array");
+        let uris: Vec<&str> = locs.iter().map(|l| l["uri"].as_str().unwrap()).collect();
+
+        assert!(
+            uris.iter().any(|u| *u == caller_uri.as_str()),
+            "caller.php (typed call) must appear in results, got: {:?}",
+            uris
+        );
+        assert!(
+            !uris.iter().any(|u| *u == ignored_uri.as_str()),
+            "ignored.php (untyped call) must be excluded by the fast path, got: {:?}",
+            uris
         );
     }
 

--- a/src/references.rs
+++ b/src/references.rs
@@ -232,12 +232,6 @@ fn find_references_inner(
             }
         }
 
-        // Deduplicate spans before converting — multiple walk paths can emit
-        // the same byte offset (e.g. a declaration that also appears as an
-        // identifier reference in the general walker).
-        spans.sort_unstable_by_key(|s| s.start);
-        spans.dedup_by_key(|s| s.start);
-
         let sv = doc.view();
         for span in spans {
             let start = sv.position_of(span.start);

--- a/src/references.rs
+++ b/src/references.rs
@@ -232,6 +232,12 @@ fn find_references_inner(
             }
         }
 
+        // Deduplicate spans before converting — multiple walk paths can emit
+        // the same byte offset (e.g. a declaration that also appears as an
+        // identifier reference in the general walker).
+        spans.sort_unstable_by_key(|s| s.start);
+        spans.dedup_by_key(|s| s.start);
+
         let sv = doc.view();
         for span in spans {
             let start = sv.position_of(span.start);

--- a/src/references.rs
+++ b/src/references.rs
@@ -49,13 +49,22 @@ pub fn find_references_with_use(
 
 /// Fast path: look up pre-computed reference locations from the mir codebase index.
 ///
-/// Only handles `Function` and `Class` kinds — for those the mir analyzer records every
-/// call-site / instantiation with a precise name-only span via `mark_*_referenced_at`.
-/// Returns `None` for `Method` (type-unaware callers would be missed) and for `None`
-/// kind (caller should use the general AST walker instead).
+/// Handles `Function`, `Class`, and (partially) `Method` kinds.  For `Function` and
+/// `Class` the mir analyzer records every call-site / instantiation via
+/// `mark_*_referenced_at` and the index is authoritative.
 ///
-/// Returns `None` also when the symbol is not found in the codebase, signalling the
-/// caller to fall back to the AST scan.
+/// For `Method`, the index is used as a pre-filter: only files that contain a tracked
+/// call site for the method are scanned with the AST walker.  This fast path is
+/// activated for two cases where the tracked set is reliably complete or narrows the
+/// search scope without missing real references:
+///   • `private` methods — PHP semantics guarantee that private methods are only
+///     callable from within the class body, so mir always resolves the receiver type.
+///   • methods on `final` classes — no subclassing means call sites on the concrete
+///     type are unambiguous; the codebase set covers all statically-typed callers.
+///
+/// Returns `None` for public/protected methods on non-final classes and for `None`
+/// kind (caller should use the general AST walker instead).  Also returns `None` when
+/// no matching symbol is found in the codebase.
 pub fn find_references_codebase(
     word: &str,
     all_docs: &[(Url, Arc<ParsedDoc>)],
@@ -177,9 +186,71 @@ pub fn find_references_codebase(
             }
         }
 
-        // Method references: mir only tracks calls on known types; fall back to
-        // the AST walker so dynamic / unknown-type call sites are included.
-        Some(SymbolKind::Method) | None => None,
+        Some(SymbolKind::Method) => {
+            let word_lower = word.to_lowercase();
+
+            // Collect method keys (FQCN::lowercase_name) for types where the
+            // codebase index is authoritative or a reliable pre-filter.
+            let mut method_keys: Vec<String> = Vec::new();
+            let mut decl_files: Vec<String> = Vec::new();
+
+            for entry in codebase.classes.iter() {
+                let cls = entry.value();
+                if let Some(method) = cls.own_methods.get(word_lower.as_str())
+                    && (cls.is_final || method.visibility == mir_codebase::Visibility::Private)
+                {
+                    method_keys.push(format!("{}::{}", entry.key(), word_lower));
+                    if include_declaration && let Some(loc) = &method.location {
+                        decl_files.push(loc.file.as_ref().to_string());
+                    }
+                }
+            }
+            for entry in codebase.enums.iter() {
+                let enm = entry.value();
+                if let Some(method) = enm.own_methods.get(word_lower.as_str())
+                    && method.visibility == mir_codebase::Visibility::Private
+                {
+                    method_keys.push(format!("{}::{}", entry.key(), word_lower));
+                    if include_declaration && let Some(loc) = &method.location {
+                        decl_files.push(loc.file.as_ref().to_string());
+                    }
+                }
+            }
+
+            if method_keys.is_empty() {
+                // No qualifying class/enum found — fall back to the full AST scan.
+                return None;
+            }
+
+            // Collect candidate files from the reference index, then add
+            // declaration files so include_declaration=true works correctly.
+            let mut candidate_uris: std::collections::HashSet<String> =
+                decl_files.into_iter().collect();
+            for key in &method_keys {
+                for (file, _, _) in codebase.get_reference_locations(key) {
+                    candidate_uris.insert(file.as_ref().to_string());
+                }
+            }
+
+            // Restrict the AST walk to the candidate files only.
+            let candidate_docs: Vec<(Url, Arc<ParsedDoc>)> = all_docs
+                .iter()
+                .filter(|(url, _)| candidate_uris.contains(url.as_str()))
+                .cloned()
+                .collect();
+
+            let locations = find_references_inner(
+                word,
+                &candidate_docs,
+                include_declaration,
+                false,
+                Some(SymbolKind::Method),
+            );
+            Some(locations)
+        }
+
+        // General walker already handles None kind; codebase index adds no value.
+        None => None,
     }
 }
 
@@ -1164,6 +1235,251 @@ mod tests {
             lines.contains(&2),
             "init() in trait property default (line 2) must be present, got: {:?}",
             lines
+        );
+    }
+
+    // ── find_references_codebase: Method fast-path ──────────────────────────
+
+    fn make_class(
+        fqcn: &str,
+        is_final: bool,
+        method_name: &str,
+        visibility: mir_codebase::Visibility,
+    ) -> mir_codebase::ClassStorage {
+        use indexmap::IndexMap;
+        let method = mir_codebase::MethodStorage {
+            name: std::sync::Arc::from(method_name),
+            fqcn: std::sync::Arc::from(fqcn),
+            params: vec![],
+            return_type: None,
+            inferred_return_type: None,
+            visibility,
+            is_static: false,
+            is_abstract: false,
+            is_final: false,
+            is_constructor: false,
+            template_params: vec![],
+            assertions: vec![],
+            throws: vec![],
+            is_deprecated: false,
+            is_internal: false,
+            is_pure: false,
+            location: None,
+        };
+        let mut methods: IndexMap<
+            std::sync::Arc<str>,
+            std::sync::Arc<mir_codebase::MethodStorage>,
+        > = IndexMap::new();
+        // own_methods keys are lowercase (PHP method names are case-insensitive).
+        methods.insert(
+            std::sync::Arc::from(method_name.to_lowercase().as_str()),
+            std::sync::Arc::new(method),
+        );
+        mir_codebase::ClassStorage {
+            fqcn: std::sync::Arc::from(fqcn),
+            short_name: std::sync::Arc::from(fqcn.rsplit('\\').next().unwrap_or(fqcn)),
+            parent: None,
+            interfaces: vec![],
+            traits: vec![],
+            own_methods: methods,
+            own_properties: IndexMap::new(),
+            own_constants: IndexMap::new(),
+            template_params: vec![],
+            is_abstract: false,
+            is_final,
+            is_readonly: false,
+            all_parents: vec![],
+            is_deprecated: false,
+            is_internal: false,
+            location: None,
+        }
+    }
+
+    #[test]
+    fn codebase_method_falls_back_for_public_method_on_nonfinal_class() {
+        // Public method on a non-final class: no fast path → None → full AST scan.
+        let cb = mir_codebase::Codebase::new();
+        cb.classes.insert(
+            std::sync::Arc::from("Foo"),
+            make_class("Foo", false, "process", mir_codebase::Visibility::Public),
+        );
+        cb.mark_method_referenced_at(
+            "Foo",
+            "process",
+            std::sync::Arc::from("file:///a.php"),
+            10,
+            17,
+        );
+
+        let src = "<?php\nclass Foo { public function process() {} }\n$foo->process();";
+        let docs = vec![doc("/a.php", src)];
+        let result =
+            find_references_codebase("process", &docs, false, Some(SymbolKind::Method), &cb);
+        assert!(
+            result.is_none(),
+            "public method on non-final class must return None (fall back to AST), got: {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn codebase_method_fast_path_private_method_filters_files() {
+        // Private method: only files tracked in the codebase index are scanned.
+        // File b.php has a same-named call but is not in the codebase index —
+        // it must be excluded, proving the fast path is active.
+        let cb = mir_codebase::Codebase::new();
+        cb.classes.insert(
+            std::sync::Arc::from("Foo"),
+            make_class("Foo", false, "execute", mir_codebase::Visibility::Private),
+        );
+        // Only a.php is tracked.
+        cb.mark_method_referenced_at(
+            "Foo",
+            "execute",
+            std::sync::Arc::from("file:///a.php"),
+            10,
+            17,
+        );
+
+        // a.php: Foo with private execute + a call to $this->execute() inside the class.
+        let src_a = "<?php\nclass Foo {\n    private function execute() {}\n    public function run() { $this->execute(); }\n}";
+        // b.php: also calls ->execute() but is NOT in the codebase index.
+        let src_b = "<?php\n$other->execute();";
+
+        let docs = vec![doc("/a.php", src_a), doc("/b.php", src_b)];
+        let result =
+            find_references_codebase("execute", &docs, false, Some(SymbolKind::Method), &cb);
+
+        assert!(
+            result.is_some(),
+            "private method must activate the fast path"
+        );
+        let locs = result.unwrap();
+
+        let uris: Vec<&str> = locs.iter().map(|l| l.uri.as_str()).collect();
+        assert!(
+            uris.iter().all(|u| u.ends_with("/a.php")),
+            "all results must be from a.php (b.php was not in the codebase index), got: {:?}",
+            locs
+        );
+        assert!(
+            !locs.is_empty(),
+            "expected at least the $this->execute() call in a.php, got: {:?}",
+            locs
+        );
+    }
+
+    #[test]
+    fn codebase_method_fast_path_final_class_filters_files() {
+        // Final class: method is on a final class, so the fast path applies.
+        // File b.php is not tracked → excluded.
+        let cb = mir_codebase::Codebase::new();
+        cb.classes.insert(
+            std::sync::Arc::from("Counter"),
+            make_class(
+                "Counter",
+                true, // is_final
+                "increment",
+                mir_codebase::Visibility::Public,
+            ),
+        );
+        cb.mark_method_referenced_at(
+            "Counter",
+            "increment",
+            std::sync::Arc::from("file:///a.php"),
+            10,
+            19,
+        );
+
+        let src_a = "<?php\nfinal class Counter {\n    public function increment() {}\n}\n$c = new Counter();\n$c->increment();";
+        let src_b = "<?php\n$other->increment();";
+
+        let docs = vec![doc("/a.php", src_a), doc("/b.php", src_b)];
+        let result =
+            find_references_codebase("increment", &docs, false, Some(SymbolKind::Method), &cb);
+
+        assert!(
+            result.is_some(),
+            "final class method must activate the fast path"
+        );
+        let locs = result.unwrap();
+
+        let uris: Vec<&str> = locs.iter().map(|l| l.uri.as_str()).collect();
+        assert!(
+            uris.iter().all(|u| u.ends_with("/a.php")),
+            "all results must be from a.php only, got: {:?}",
+            locs
+        );
+    }
+
+    #[test]
+    fn codebase_method_fast_path_cross_file_reference() {
+        // Realistic cross-file scenario: class defined in class.php, called from
+        // caller.php and ignored.php (not tracked).
+        // The fast path must include caller.php (tracked) and exclude ignored.php.
+        let cb = mir_codebase::Codebase::new();
+        cb.classes.insert(
+            std::sync::Arc::from("Order"),
+            make_class(
+                "Order",
+                true, // is_final
+                "submit",
+                mir_codebase::Visibility::Public,
+            ),
+        );
+        // The codebase tracks caller.php as referencing Order::submit.
+        cb.mark_method_referenced_at(
+            "Order",
+            "submit",
+            std::sync::Arc::from("file:///caller.php"),
+            50,
+            56,
+        );
+
+        // class.php: defines the final class (no calls here).
+        let src_class = "<?php\nfinal class Order {\n    public function submit() {}\n}";
+        // caller.php: calls $order->submit() — tracked in codebase.
+        let src_caller = "<?php\n$order = new Order();\n$order->submit();";
+        // ignored.php: also calls ->submit() on an unknown type — NOT tracked.
+        let src_ignored = "<?php\n$unknown->submit();";
+
+        let docs = vec![
+            doc("/class.php", src_class),
+            doc("/caller.php", src_caller),
+            doc("/ignored.php", src_ignored),
+        ];
+
+        let result =
+            find_references_codebase("submit", &docs, false, Some(SymbolKind::Method), &cb);
+
+        assert!(result.is_some(), "fast path must activate for final class");
+        let locs = result.unwrap();
+
+        let uris: Vec<&str> = locs.iter().map(|l| l.uri.as_str()).collect();
+        assert!(
+            uris.iter().any(|u| u.ends_with("/caller.php")),
+            "caller.php (tracked) must appear in results, got: {:?}",
+            locs
+        );
+        assert!(
+            !uris.iter().any(|u| u.ends_with("/ignored.php")),
+            "ignored.php (not tracked) must be excluded, got: {:?}",
+            locs
+        );
+    }
+
+    #[test]
+    fn codebase_method_fast_path_empty_codebase_falls_back() {
+        // Empty codebase: no qualifying class found → None → caller falls back to full AST.
+        let cb = mir_codebase::Codebase::new();
+        let src = "<?php\n$obj->doWork();";
+        let docs = vec![doc("/a.php", src)];
+        let result =
+            find_references_codebase("doWork", &docs, false, Some(SymbolKind::Method), &cb);
+        assert!(
+            result.is_none(),
+            "empty codebase must return None for Method kind, got: {:?}",
+            result
         );
     }
 }


### PR DESCRIPTION
## Summary

- `find_references_codebase` previously returned `None` for all `Method` requests, forcing a sequential O(n) AST walk over every file in the workspace on every invocation
- Adds a fast path for **private methods** (receiver type always known to mir) and **methods on `final` classes** (no subclassing, unambiguous call sites): candidate files are collected from the mir reference index, then the AST walk is restricted to those files only
- Public/protected methods on non-final classes still fall back to the full scan — mir may miss call sites where the receiver type is unresolved

Closes #192

## Test plan

- [ ] `cargo test` — all 870 tests pass, including 4 new unit tests for the fast path:
  - `codebase_method_falls_back_for_public_method_on_nonfinal_class` — verifies `None` is returned (full scan triggered)
  - `codebase_method_fast_path_private_method_filters_files` — verifies b.php is excluded when not tracked in codebase
  - `codebase_method_fast_path_final_class_filters_files` — same for final class methods
  - `codebase_method_fast_path_empty_codebase_falls_back` — empty codebase returns `None`