### PR TITLE
perf: cache TypeMap in hover/completion; avoid Arc<str>→String in references

### DIFF
--- a/src/completion/mod.rs
+++ b/src/completion/mod.rs
@@ -565,14 +565,16 @@ fn match_arm_completions(
     let start_line = position.line as usize;
     let end_line = start_line.saturating_sub(5);
     let all_lines: Vec<&str> = source.lines().collect();
+    let type_map_cell: std::cell::OnceCell<TypeMap> = std::cell::OnceCell::new();
     for line_idx in (end_line..=start_line).rev() {
         let line = all_lines.get(line_idx).copied()?;
         if let Some(cap) = extract_match_subject(line) {
-            let type_map =
-                TypeMap::from_docs_with_meta(doc, other_docs.iter().map(|d| d.as_ref()), meta);
             let class_name = if cap == "this" {
                 enclosing_class_at(source, doc, position)?
             } else {
+                let type_map = type_map_cell.get_or_init(|| {
+                    TypeMap::from_docs_with_meta(doc, other_docs.iter().map(|d| d.as_ref()), meta)
+                });
                 type_map.get(&format!("${cap}"))?.to_string()
             };
             let all_docs: Vec<&ParsedDoc> = std::iter::once(doc)

--- a/src/hover.rs
+++ b/src/hover.rs
@@ -1,3 +1,4 @@
+use std::cell::OnceCell;
 use std::sync::Arc;
 
 use php_ast::{ClassMemberKind, EnumMemberKind, ExprKind, NamespaceBody, Param, Stmt, StmtKind};
@@ -57,23 +58,30 @@ pub fn hover_at(
 
     let word = word_at(source, position)?;
 
+    // TypeMap is expensive (scans all docs); build lazily and reuse across branches.
+    let type_map_cell: OnceCell<TypeMap> = OnceCell::new();
+    let type_map = || {
+        type_map_cell.get_or_init(|| {
+            TypeMap::from_docs_at_position(
+                doc,
+                other_docs.iter().map(|(_, d)| d.as_ref()),
+                None,
+                position,
+            )
+        })
+    };
+
     // Feature 2: hover on $variable shows its type
-    if word.starts_with('$') {
-        let type_map = TypeMap::from_docs_at_position(
-            doc,
-            other_docs.iter().map(|(_, d)| d.as_ref()),
-            None,
-            position,
-        );
-        if let Some(class_name) = type_map.get(&word) {
-            return Some(Hover {
-                contents: HoverContents::Markup(MarkupContent {
-                    kind: MarkupKind::Markdown,
-                    value: format!("`{}` `{}`", word, class_name),
-                }),
-                range: None,
-            });
-        }
+    if word.starts_with('$')
+        && let Some(class_name) = type_map().get(&word)
+    {
+        return Some(Hover {
+            contents: HoverContents::Markup(MarkupContent {
+                kind: MarkupKind::Markdown,
+                value: format!("`{}` `{}`", word, class_name),
+            }),
+            range: None,
+        });
     }
 
     // Class-specific method lookup: when the cursor is on a method call after `->`,
@@ -90,17 +98,12 @@ pub fn hover_at(
             if let Some(apos) = arrow_pos {
                 let before_arrow = &line_text[..apos];
                 if let Some(var_name) = extract_receiver_var_from_end(before_arrow) {
-                    let type_map = TypeMap::from_docs_at_position(
-                        doc,
-                        other_docs.iter().map(|(_, d)| d.as_ref()),
-                        None,
-                        position,
-                    );
+                    let tm = type_map();
                     let class_name = if var_name == "$this" {
                         crate::type_map::enclosing_class_at(source, doc, position)
-                            .or_else(|| type_map.get("$this").map(|s| s.to_string()))
+                            .or_else(|| tm.get("$this").map(|s| s.to_string()))
                     } else {
-                        type_map.get(&var_name).map(|s| s.to_string())
+                        tm.get(&var_name).map(|s| s.to_string())
                     };
                     if let Some(cls) = class_name {
                         let first_cls = cls.split('|').next().unwrap_or(&cls);
@@ -201,17 +204,12 @@ pub fn hover_at(
                 let before_arrow = &line_text[..apos];
                 let receiver_var = extract_receiver_var_from_end(before_arrow);
                 if let Some(var_name) = receiver_var {
-                    let type_map = TypeMap::from_docs_at_position(
-                        doc,
-                        other_docs.iter().map(|(_, d)| d.as_ref()),
-                        None,
-                        position,
-                    );
+                    let tm = type_map();
                     let class_name = if var_name == "$this" {
                         crate::type_map::enclosing_class_at(source, doc, position)
-                            .or_else(|| type_map.get("$this").map(|s| s.to_string()))
+                            .or_else(|| tm.get("$this").map(|s| s.to_string()))
                     } else {
-                        type_map.get(&var_name).map(|s| s.to_string())
+                        tm.get(&var_name).map(|s| s.to_string())
                     };
                     if let Some(cls) = class_name {
                         for d in

--- a/src/references.rs
+++ b/src/references.rs
@@ -192,7 +192,7 @@ pub fn find_references_codebase(
             // Collect method keys (FQCN::lowercase_name) for types where the
             // codebase index is authoritative or a reliable pre-filter.
             let mut method_keys: Vec<String> = Vec::new();
-            let mut decl_files: Vec<String> = Vec::new();
+            let mut candidate_arcs: Vec<Arc<str>> = Vec::new();
 
             for entry in codebase.classes.iter() {
                 let cls = entry.value();
@@ -201,7 +201,7 @@ pub fn find_references_codebase(
                 {
                     method_keys.push(format!("{}::{}", entry.key(), word_lower));
                     if include_declaration && let Some(loc) = &method.location {
-                        decl_files.push(loc.file.as_ref().to_string());
+                        candidate_arcs.push(loc.file.clone());
                     }
                 }
             }
@@ -212,7 +212,7 @@ pub fn find_references_codebase(
                 {
                     method_keys.push(format!("{}::{}", entry.key(), word_lower));
                     if include_declaration && let Some(loc) = &method.location {
-                        decl_files.push(loc.file.as_ref().to_string());
+                        candidate_arcs.push(loc.file.clone());
                     }
                 }
             }
@@ -222,15 +222,14 @@ pub fn find_references_codebase(
                 return None;
             }
 
-            // Collect candidate files from the reference index, then add
-            // declaration files so include_declaration=true works correctly.
-            let mut candidate_uris: std::collections::HashSet<String> =
-                decl_files.into_iter().collect();
+            // Collect candidate files from the reference index (declaration files
+            // already appended above so include_declaration=true works correctly).
             for key in &method_keys {
                 for (file, _, _) in codebase.get_reference_locations(key) {
-                    candidate_uris.insert(file.as_ref().to_string());
+                    candidate_arcs.push(file);
                 }
             }
+            let candidate_uris: HashSet<&str> = candidate_arcs.iter().map(|a| a.as_ref()).collect();
 
             // Restrict the AST walk to the candidate files only.
             let candidate_docs: Vec<(Url, Arc<ParsedDoc>)> = all_docs


### PR DESCRIPTION
## Summary

Three targeted allocation-thrashing fixes in LSP hot paths:

- **hover.rs** — `TypeMap` was rebuilt up to 3× per request across the `\$var`, method-call, and property branches. Now built once lazily via `OnceCell` and reused.
- **completion/mod.rs** — `match_arm_completions` rebuilt `TypeMap` on every iteration of its line-scan loop (up to 6×). Hoisted behind `OnceCell` so it's built at most once per call.
- **references.rs** — method fast-path now keeps `Arc<str>` file handles and uses `HashSet<&str>` for candidate-file membership, removing the per-file `Arc<str>.to_string()` conversions.

## Test plan

- [x] `cargo build` clean
- [x] `cargo test --lib` — 872 passed, 0 failed