### PR TITLE
feat!: disable semantic diagnostics by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,6 @@
 
 All notable changes to php-lsp are documented here.
 
-## [Unreleased]
-
-### Changed
-
-- **Diagnostics off by default** (BREAKING): `initializationOptions.diagnostics.enabled` now defaults to `false`. Clients that want undefined-variable/function/class, arity, type, deprecated, and duplicate-declaration diagnostics must opt in with `"diagnostics": { "enabled": true }`. Parse errors are unaffected.
-
 ## [0.1.53] — 2026-04-12
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to php-lsp are documented here.
 
+## [Unreleased]
+
+### Changed
+
+- **Diagnostics off by default** (BREAKING): `initializationOptions.diagnostics.enabled` now defaults to `false`. Clients that want undefined-variable/function/class, arity, type, deprecated, and duplicate-declaration diagnostics must opt in with `"diagnostics": { "enabled": true }`. Parse errors are unaffected.
+
 ## [0.1.53] — 2026-04-12
 
 ### Bug fixes

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,7 +16,7 @@ All options are optional.
 
 | Key | Default | Description |
 |---|---|---|
-| `enabled` | `true` | Master switch — set to `false` to disable all diagnostics. |
+| `enabled` | `false` | Master switch — diagnostics are off by default; set to `true` to emit them. |
 | `undefinedVariables` | `true` | Undefined variable references. |
 | `undefinedFunctions` | `true` | Calls to undefined functions. |
 | `undefinedClasses` | `true` | References to undefined classes, interfaces, or traits. |
@@ -32,6 +32,7 @@ All options are optional.
   "phpVersion": "8.1",
   "excludePaths": ["cache/*", "storage/*", "tests/fixtures/*"],
   "diagnostics": {
+    "enabled": true,
     "undefinedVariables": true,
     "deprecatedCalls": false
   }

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -73,10 +73,13 @@ use crate::use_import::{build_use_import_edit, find_fqn_for_class};
 use crate::util::word_at;
 
 /// Per-category diagnostic toggle flags.
-/// All flags default to `true` (enabled). Set to `false` to suppress that category.
+/// The master `enabled` switch defaults to `false` — clients must opt in via
+/// `initializationOptions.diagnostics.enabled = true`. Individual category
+/// flags default to `true`, so flipping `enabled` on enables everything unless
+/// specific categories are turned off.
 #[derive(Debug, Clone)]
 pub struct DiagnosticsConfig {
-    /// Master switch: when `false`, no diagnostics are emitted.
+    /// Master switch: when `false`, no diagnostics are emitted. Defaults to `false`.
     pub enabled: bool,
     /// Undefined variable references.
     pub undefined_variables: bool,
@@ -97,7 +100,7 @@ pub struct DiagnosticsConfig {
 impl Default for DiagnosticsConfig {
     fn default() -> Self {
         DiagnosticsConfig {
-            enabled: true,
+            enabled: false,
             undefined_variables: true,
             undefined_functions: true,
             undefined_classes: true,
@@ -110,11 +113,24 @@ impl Default for DiagnosticsConfig {
 }
 
 impl DiagnosticsConfig {
+    /// All categories on. Used in tests and by clients that explicitly enable
+    /// diagnostics without overriding individual flags.
+    #[cfg(test)]
+    pub fn all_enabled() -> Self {
+        DiagnosticsConfig {
+            enabled: true,
+            ..DiagnosticsConfig::default()
+        }
+    }
+
     fn from_value(v: &serde_json::Value) -> Self {
         let mut cfg = DiagnosticsConfig::default();
         let Some(obj) = v.as_object() else { return cfg };
         let flag = |key: &str| obj.get(key).and_then(|x| x.as_bool()).unwrap_or(true);
-        cfg.enabled = flag("enabled");
+        cfg.enabled = obj
+            .get("enabled")
+            .and_then(|x| x.as_bool())
+            .unwrap_or(false);
         cfg.undefined_variables = flag("undefinedVariables");
         cfg.undefined_functions = flag("undefinedFunctions");
         cfg.undefined_classes = flag("undefinedClasses");
@@ -2521,9 +2537,11 @@ mod tests {
 
     // DiagnosticsConfig::from_value tests
     #[test]
-    fn diagnostics_config_defaults_all_enabled() {
+    fn diagnostics_config_default_is_disabled() {
         let cfg = DiagnosticsConfig::default();
-        assert!(cfg.enabled);
+        assert!(!cfg.enabled);
+        // Category flags still default to true so that flipping `enabled`
+        // on turns everything on unless explicitly disabled.
         assert!(cfg.undefined_variables);
         assert!(cfg.undefined_functions);
         assert!(cfg.undefined_classes);
@@ -2534,16 +2552,16 @@ mod tests {
     }
 
     #[test]
-    fn diagnostics_config_from_empty_object_uses_defaults() {
+    fn diagnostics_config_from_empty_object_is_disabled() {
         let cfg = DiagnosticsConfig::from_value(&serde_json::json!({}));
-        assert!(cfg.enabled);
+        assert!(!cfg.enabled);
         assert!(cfg.undefined_variables);
     }
 
     #[test]
     fn diagnostics_config_from_non_object_uses_defaults() {
         let cfg = DiagnosticsConfig::from_value(&serde_json::json!(null));
-        assert!(cfg.enabled);
+        assert!(!cfg.enabled);
     }
 
     #[test]
@@ -2576,13 +2594,20 @@ mod tests {
         assert!(cfg.undefined_variables);
     }
 
+    #[test]
+    fn diagnostics_config_master_switch_enables_all() {
+        let cfg = DiagnosticsConfig::from_value(&serde_json::json!({"enabled": true}));
+        assert!(cfg.enabled);
+        assert!(cfg.undefined_variables);
+    }
+
     // LspConfig::from_value tests
     #[test]
     fn lsp_config_default_is_empty() {
         let cfg = LspConfig::default();
         assert!(cfg.php_version.is_none());
         assert!(cfg.exclude_paths.is_empty());
-        assert!(cfg.diagnostics.enabled);
+        assert!(!cfg.diagnostics.enabled);
     }
 
     #[test]
@@ -3281,7 +3306,8 @@ mod integration {
                             "hover": { "contentFormat": ["markdown", "plaintext"] },
                             "completion": { "completionItem": { "snippetSupport": true } }
                         }
-                    }
+                    },
+                    "initializationOptions": { "diagnostics": { "enabled": true } }
                 }),
             )
             .await;
@@ -3306,7 +3332,8 @@ mod integration {
                             "hover": { "contentFormat": ["markdown", "plaintext"] },
                             "completion": { "completionItem": { "snippetSupport": true } }
                         }
-                    }
+                    },
+                    "initializationOptions": { "diagnostics": { "enabled": true } }
                 }),
             )
             .await;

--- a/src/semantic_diagnostics.rs
+++ b/src/semantic_diagnostics.rs
@@ -578,7 +578,7 @@ mod tests {
         let src =
             "<?php\n/** @deprecated Use newFunc() instead */\nfunction oldFunc() {}\n\noldFunc();";
         let doc = ParsedDoc::parse(src.to_string());
-        let diags = deprecated_call_diagnostics(src, &doc, &[], &DiagnosticsConfig::default());
+        let diags = deprecated_call_diagnostics(src, &doc, &[], &DiagnosticsConfig::all_enabled());
         assert_eq!(
             diags.len(),
             1,
@@ -596,7 +596,7 @@ mod tests {
     fn duplicate_class_emits_warning() {
         let src = "<?php\nclass Foo {}\nclass Foo {}";
         let doc = ParsedDoc::parse(src.to_string());
-        let diags = duplicate_declaration_diagnostics(src, &doc, &DiagnosticsConfig::default());
+        let diags = duplicate_declaration_diagnostics(src, &doc, &DiagnosticsConfig::all_enabled());
         assert_eq!(
             diags.len(),
             1,
@@ -614,7 +614,7 @@ mod tests {
     fn no_duplicate_for_unique_declarations() {
         let src = "<?php\nclass Foo {}\nclass Bar {}";
         let doc = ParsedDoc::parse(src.to_string());
-        let diags = duplicate_declaration_diagnostics(src, &doc, &DiagnosticsConfig::default());
+        let diags = duplicate_declaration_diagnostics(src, &doc, &DiagnosticsConfig::all_enabled());
         assert!(diags.is_empty());
     }
 
@@ -623,7 +623,7 @@ mod tests {
         // Two classes named `Foo` in different namespaces — should produce zero diagnostics.
         let src = "<?php\nnamespace App\\A {\nclass Foo {}\n}\nnamespace App\\B {\nclass Foo {}\n}";
         let doc = ParsedDoc::parse(src.to_string());
-        let diags = duplicate_declaration_diagnostics(src, &doc, &DiagnosticsConfig::default());
+        let diags = duplicate_declaration_diagnostics(src, &doc, &DiagnosticsConfig::all_enabled());
         assert!(
             diags.is_empty(),
             "classes with same name in different namespaces should not be flagged, got: {:?}",
@@ -636,7 +636,7 @@ mod tests {
         // Same interface defined twice in same file — should produce exactly one error.
         let src = "<?php\ninterface Logger {}\ninterface Logger {}";
         let doc = ParsedDoc::parse(src.to_string());
-        let diags = duplicate_declaration_diagnostics(src, &doc, &DiagnosticsConfig::default());
+        let diags = duplicate_declaration_diagnostics(src, &doc, &DiagnosticsConfig::all_enabled());
         assert_eq!(
             diags.len(),
             1,
@@ -659,7 +659,7 @@ mod tests {
         // Same trait defined twice in same file — should produce exactly one error.
         let src = "<?php\ntrait Serializable {}\ntrait Serializable {}";
         let doc = ParsedDoc::parse(src.to_string());
-        let diags = duplicate_declaration_diagnostics(src, &doc, &DiagnosticsConfig::default());
+        let diags = duplicate_declaration_diagnostics(src, &doc, &DiagnosticsConfig::all_enabled());
         assert_eq!(
             diags.len(),
             1,
@@ -690,7 +690,7 @@ mod tests {
             "$m->send();\n",
         );
         let doc = ParsedDoc::parse(src.to_string());
-        let diags = deprecated_call_diagnostics(src, &doc, &[], &DiagnosticsConfig::default());
+        let diags = deprecated_call_diagnostics(src, &doc, &[], &DiagnosticsConfig::all_enabled());
         assert_eq!(
             diags.len(),
             1,
@@ -717,7 +717,7 @@ mod tests {
         // word "Deprecated" (case-sensitive per implementation: "Deprecated: …").
         let src = "<?php\n/** @deprecated old API */\nfunction legacyFn() {}\n\nlegacyFn();";
         let doc = ParsedDoc::parse(src.to_string());
-        let diags = deprecated_call_diagnostics(src, &doc, &[], &DiagnosticsConfig::default());
+        let diags = deprecated_call_diagnostics(src, &doc, &[], &DiagnosticsConfig::all_enabled());
         assert_eq!(diags.len(), 1, "expected exactly 1 diagnostic");
         let msg = &diags[0].message;
         assert!(
@@ -736,7 +736,7 @@ mod tests {
         // (Note: `duplicate_declaration_diagnostics` emits DiagnosticSeverity::WARNING.)
         let src = "<?php\nfunction doWork() {}\nfunction doWork() {}";
         let doc = ParsedDoc::parse(src.to_string());
-        let diags = duplicate_declaration_diagnostics(src, &doc, &DiagnosticsConfig::default());
+        let diags = duplicate_declaration_diagnostics(src, &doc, &DiagnosticsConfig::all_enabled());
         assert_eq!(diags.len(), 1, "expected exactly 1 duplicate diagnostic");
         assert_eq!(
             diags[0].severity,
@@ -756,7 +756,7 @@ mod tests {
             "wrapper(oldFn());\n",
         );
         let doc = ParsedDoc::parse(src.to_string());
-        let diags = deprecated_call_diagnostics(src, &doc, &[], &DiagnosticsConfig::default());
+        let diags = deprecated_call_diagnostics(src, &doc, &[], &DiagnosticsConfig::all_enabled());
         assert_eq!(
             diags.len(),
             1,
@@ -783,7 +783,7 @@ mod tests {
             "$a->log();\n",
         );
         let doc = ParsedDoc::parse(src.to_string());
-        let diags = deprecated_call_diagnostics(src, &doc, &[], &DiagnosticsConfig::default());
+        let diags = deprecated_call_diagnostics(src, &doc, &[], &DiagnosticsConfig::all_enabled());
         assert_eq!(
             diags.len(),
             1,
@@ -809,7 +809,7 @@ mod tests {
             "$s->label();\n",
         );
         let doc = ParsedDoc::parse(src.to_string());
-        let diags = deprecated_call_diagnostics(src, &doc, &[], &DiagnosticsConfig::default());
+        let diags = deprecated_call_diagnostics(src, &doc, &[], &DiagnosticsConfig::all_enabled());
         assert_eq!(
             diags.len(),
             1,
@@ -827,7 +827,7 @@ mod tests {
         // Two classes named `Foo` in different unbraced namespaces — should not be a duplicate.
         let src = "<?php\nnamespace App\\A;\nclass Foo {}\nnamespace App\\B;\nclass Foo {}";
         let doc = ParsedDoc::parse(src.to_string());
-        let diags = duplicate_declaration_diagnostics(src, &doc, &DiagnosticsConfig::default());
+        let diags = duplicate_declaration_diagnostics(src, &doc, &DiagnosticsConfig::all_enabled());
         assert!(
             diags.is_empty(),
             "classes with same name in different unbraced namespaces should not be flagged, got: {:?}",
@@ -840,7 +840,7 @@ mod tests {
         // Two classes named `Foo` in the same unbraced namespace — should produce one warning.
         let src = "<?php\nnamespace App;\nclass Foo {}\nclass Foo {}";
         let doc = ParsedDoc::parse(src.to_string());
-        let diags = duplicate_declaration_diagnostics(src, &doc, &DiagnosticsConfig::default());
+        let diags = duplicate_declaration_diagnostics(src, &doc, &DiagnosticsConfig::all_enabled());
         assert_eq!(
             diags.len(),
             1,
@@ -855,7 +855,7 @@ mod tests {
         // Duplicate declaration diagnostic range should span the entire name, not just first character.
         let src = "<?php\nclass Foo {}\nclass Foo {}";
         let doc = ParsedDoc::parse(src.to_string());
-        let diags = duplicate_declaration_diagnostics(src, &doc, &DiagnosticsConfig::default());
+        let diags = duplicate_declaration_diagnostics(src, &doc, &DiagnosticsConfig::all_enabled());
         assert_eq!(diags.len(), 1, "expected exactly 1 duplicate diagnostic");
 
         let d = &diags[0];
@@ -885,7 +885,7 @@ mod tests {
         // Function duplicate should also span the full function name.
         let src = "<?php\nfunction doWork() {}\nfunction doWork() {}";
         let doc = ParsedDoc::parse(src.to_string());
-        let diags = duplicate_declaration_diagnostics(src, &doc, &DiagnosticsConfig::default());
+        let diags = duplicate_declaration_diagnostics(src, &doc, &DiagnosticsConfig::all_enabled());
         assert_eq!(diags.len(), 1, "expected exactly 1 duplicate diagnostic");
 
         let d = &diags[0];
@@ -915,7 +915,7 @@ mod tests {
         // Interface duplicate should span the full interface name.
         let src = "<?php\ninterface Logger {}\ninterface Logger {}";
         let doc = ParsedDoc::parse(src.to_string());
-        let diags = duplicate_declaration_diagnostics(src, &doc, &DiagnosticsConfig::default());
+        let diags = duplicate_declaration_diagnostics(src, &doc, &DiagnosticsConfig::all_enabled());
         assert_eq!(diags.len(), 1, "expected exactly 1 duplicate diagnostic");
 
         let d = &diags[0];
@@ -945,7 +945,7 @@ mod tests {
         // Diagnostic range should be on the correct line.
         let src = "<?php\nclass Foo {}\n\nclass Foo {}";
         let doc = ParsedDoc::parse(src.to_string());
-        let diags = duplicate_declaration_diagnostics(src, &doc, &DiagnosticsConfig::default());
+        let diags = duplicate_declaration_diagnostics(src, &doc, &DiagnosticsConfig::all_enabled());
         assert_eq!(diags.len(), 1, "expected exactly 1 duplicate diagnostic");
 
         let d = &diags[0];


### PR DESCRIPTION
## Summary

- Flip `initializationOptions.diagnostics.enabled` default from `true` to `false`. Clients must now opt in to receive undefined-variable/function/class, arity, type, deprecated, and duplicate-declaration diagnostics.
- Parse errors are unchanged — they still emit regardless of this flag.
- Updated unit tests (new `DiagnosticsConfig::all_enabled()` test helper) and threaded `{ diagnostics: { enabled: true } }` into the E2E `initialize`/`initialize_with_root` helpers so diagnostic-consuming tests still exercise the feature.
- Updated `docs/configuration.md` and `CHANGELOG.md` (`[Unreleased]`, flagged as breaking).

## Test plan

- [x] `cargo test --workspace` — 873 passed
- [ ] Verify in-editor: diagnostics silent on default init, appear after setting `"diagnostics": { "enabled": true }`