### PR TITLE
perf: fast line/byte conversions via line_starts; drop O(n) utf16_pos_to_byte

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -189,6 +189,42 @@ impl<'a> SourceView<'a> {
         self.line_starts
     }
 
+    /// O(log lines) line number for a byte offset. Cheaper than
+    /// `position_of(..).line` because it skips the UTF-16 column scan.
+    #[inline]
+    pub fn line_of(self, offset: u32) -> u32 {
+        match self.line_starts.partition_point(|&s| s <= offset) {
+            0 => 0,
+            i => (i - 1) as u32,
+        }
+    }
+
+    /// O(log lines) UTF-16 `Position` -> byte offset. Uses the precomputed
+    /// `line_starts` table to jump to the target line and only scans that
+    /// line's characters. Much faster than a linear scan over the whole
+    /// source when the cursor is late in the file.
+    pub fn byte_of_position(self, pos: Position) -> u32 {
+        let line_idx = pos.line as usize;
+        let line_start = self.line_starts.get(line_idx).copied().unwrap_or(0) as usize;
+        let line_end = self
+            .line_starts
+            .get(line_idx + 1)
+            .map(|&s| (s as usize).saturating_sub(1))
+            .unwrap_or(self.source.len());
+        let raw = &self.source[line_start..line_end.min(self.source.len())];
+        let line = raw.strip_suffix('\r').unwrap_or(raw);
+        let mut col_utf16: u32 = 0;
+        let mut byte_in_line: usize = 0;
+        for ch in line.chars() {
+            if col_utf16 >= pos.character {
+                break;
+            }
+            col_utf16 += ch.len_utf16() as u32;
+            byte_in_line += ch.len_utf8();
+        }
+        (line_start + byte_in_line) as u32
+    }
+
     pub fn range_of(self, span: Span) -> Range {
         Range {
             start: self.position_of(span.start),

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1005,7 +1005,6 @@ impl LanguageServer for Backend {
                 &word,
                 &params.new_name,
                 uri,
-                &source,
                 &doc,
                 position,
             )))

--- a/src/definition.rs
+++ b/src/definition.rs
@@ -4,7 +4,7 @@ use php_ast::{ClassMemberKind, EnumMemberKind, NamespaceBody, Stmt, StmtKind};
 use tower_lsp::lsp_types::{Location, Position, Range, Url};
 
 use crate::ast::{ParsedDoc, SourceView, str_offset};
-use crate::util::{utf16_pos_to_byte, word_at};
+use crate::util::word_at;
 use crate::walk::collect_var_refs_in_scope;
 
 /// Find the definition of the symbol under `position`.
@@ -22,7 +22,7 @@ pub fn goto_definition(
     let sv = doc.view();
     if word.starts_with('$') {
         let bare = word.trim_start_matches('$');
-        let byte_off = utf16_pos_to_byte(sv.source(), position);
+        let byte_off = sv.byte_of_position(position) as usize;
         let mut spans = Vec::new();
         collect_var_refs_in_scope(&doc.program().stmts, bare, byte_off, &mut spans);
         if let Some(span) = spans.into_iter().min_by_key(|s| s.start) {

--- a/src/document_highlight.rs
+++ b/src/document_highlight.rs
@@ -1,7 +1,7 @@
 use tower_lsp::lsp_types::{DocumentHighlight, DocumentHighlightKind, Position, Range};
 
 use crate::ast::ParsedDoc;
-use crate::util::{utf16_pos_to_byte, word_at};
+use crate::util::word_at;
 use crate::walk::{collect_var_refs_in_scope, refs_in_stmts};
 
 /// Return all ranges in the document where the word at `position` appears.
@@ -20,16 +20,15 @@ pub fn document_highlights(
 
     let word_utf16_len: u32 = word.chars().map(|c| c.len_utf16() as u32).sum();
     let mut spans = Vec::new();
+    let sv = doc.view();
 
     if word.starts_with('$') {
         let bare = word.trim_start_matches('$');
-        let byte_off = utf16_pos_to_byte(source, position);
+        let byte_off = sv.byte_of_position(position) as usize;
         collect_var_refs_in_scope(&doc.program().stmts, bare, byte_off, &mut spans);
     } else {
         refs_in_stmts(source, &doc.program().stmts, &word, &mut spans);
     }
-
-    let sv = doc.view();
     spans
         .into_iter()
         .map(|span| {

--- a/src/folding.rs
+++ b/src/folding.rs
@@ -31,21 +31,21 @@ fn fold_body(body: &Stmt<'_, '_>, sv: SourceView<'_>, out: &mut Vec<FoldingRange
 fn fold_stmt(stmt: &Stmt<'_, '_>, sv: SourceView<'_>, out: &mut Vec<FoldingRange>) {
     match &stmt.kind {
         StmtKind::Function(f) => {
-            let start_line = sv.position_of(stmt.span.start).line;
-            let end_line = sv.position_of(stmt.span.end).line;
+            let start_line = sv.line_of(stmt.span.start);
+            let end_line = sv.line_of(stmt.span.end);
             push(out, start_line, end_line, None);
             fold_stmts(&f.body, sv, out);
         }
         StmtKind::Class(c) => {
-            let start_line = sv.position_of(stmt.span.start).line;
-            let end_line = sv.position_of(stmt.span.end).line;
+            let start_line = sv.line_of(stmt.span.start);
+            let end_line = sv.line_of(stmt.span.end);
             push(out, start_line, end_line, None);
             for member in c.members.iter() {
                 if let ClassMemberKind::Method(m) = &member.kind {
-                    let m_start = sv.position_of(member.span.start).line;
+                    let m_start = sv.line_of(member.span.start);
                     // member.span.end is exclusive and includes the trailing newline;
                     // subtract 1 so the end line is the line containing the closing `}`.
-                    let m_end = sv.position_of(member.span.end.saturating_sub(1)).line;
+                    let m_end = sv.line_of(member.span.end.saturating_sub(1));
                     push(out, m_start, m_end, None);
                     if let Some(body) = &m.body {
                         fold_stmts(body, sv, out);
@@ -54,29 +54,29 @@ fn fold_stmt(stmt: &Stmt<'_, '_>, sv: SourceView<'_>, out: &mut Vec<FoldingRange
             }
         }
         StmtKind::Interface(i) => {
-            let start_line = sv.position_of(stmt.span.start).line;
-            let end_line = sv.position_of(stmt.span.end).line;
+            let start_line = sv.line_of(stmt.span.start);
+            let end_line = sv.line_of(stmt.span.end);
             push(out, start_line, end_line, None);
             // Interface methods are abstract (no body) — nothing to fold per method.
             for member in i.members.iter() {
                 if let ClassMemberKind::Method(m) = &member.kind
                     && let Some(body) = &m.body
                 {
-                    let m_start = sv.position_of(member.span.start).line;
-                    let m_end = sv.position_of(member.span.end.saturating_sub(1)).line;
+                    let m_start = sv.line_of(member.span.start);
+                    let m_end = sv.line_of(member.span.end.saturating_sub(1));
                     push(out, m_start, m_end, None);
                     fold_stmts(body, sv, out);
                 }
             }
         }
         StmtKind::Trait(t) => {
-            let start_line = sv.position_of(stmt.span.start).line;
-            let end_line = sv.position_of(stmt.span.end).line;
+            let start_line = sv.line_of(stmt.span.start);
+            let end_line = sv.line_of(stmt.span.end);
             push(out, start_line, end_line, None);
             for member in t.members.iter() {
                 if let ClassMemberKind::Method(m) = &member.kind {
-                    let m_start = sv.position_of(member.span.start).line;
-                    let m_end = sv.position_of(member.span.end.saturating_sub(1)).line;
+                    let m_start = sv.line_of(member.span.start);
+                    let m_end = sv.line_of(member.span.end.saturating_sub(1));
                     push(out, m_start, m_end, None);
                     if let Some(body) = &m.body {
                         fold_stmts(body, sv, out);
@@ -85,13 +85,13 @@ fn fold_stmt(stmt: &Stmt<'_, '_>, sv: SourceView<'_>, out: &mut Vec<FoldingRange
             }
         }
         StmtKind::Enum(e) => {
-            let start_line = sv.position_of(stmt.span.start).line;
-            let end_line = sv.position_of(stmt.span.end).line;
+            let start_line = sv.line_of(stmt.span.start);
+            let end_line = sv.line_of(stmt.span.end);
             push(out, start_line, end_line, None);
             for member in e.members.iter() {
                 if let EnumMemberKind::Method(m) = &member.kind {
-                    let m_start = sv.position_of(member.span.start).line;
-                    let m_end = sv.position_of(member.span.end.saturating_sub(1)).line;
+                    let m_start = sv.line_of(member.span.start);
+                    let m_end = sv.line_of(member.span.end.saturating_sub(1));
                     push(out, m_start, m_end, None);
                     if let Some(body) = &m.body {
                         fold_stmts(body, sv, out);
@@ -100,8 +100,8 @@ fn fold_stmt(stmt: &Stmt<'_, '_>, sv: SourceView<'_>, out: &mut Vec<FoldingRange
             }
         }
         StmtKind::If(i) => {
-            let start_line = sv.position_of(stmt.span.start).line;
-            let end_line = sv.position_of(stmt.span.end).line;
+            let start_line = sv.line_of(stmt.span.start);
+            let end_line = sv.line_of(stmt.span.end);
             push(out, start_line, end_line, None);
             fold_body(i.then_branch, sv, out);
             for ei in i.elseif_branches.iter() {
@@ -112,32 +112,32 @@ fn fold_stmt(stmt: &Stmt<'_, '_>, sv: SourceView<'_>, out: &mut Vec<FoldingRange
             }
         }
         StmtKind::While(w) => {
-            let start_line = sv.position_of(stmt.span.start).line;
-            let end_line = sv.position_of(stmt.span.end).line;
+            let start_line = sv.line_of(stmt.span.start);
+            let end_line = sv.line_of(stmt.span.end);
             push(out, start_line, end_line, None);
             fold_body(w.body, sv, out);
         }
         StmtKind::For(f) => {
-            let start_line = sv.position_of(stmt.span.start).line;
-            let end_line = sv.position_of(stmt.span.end).line;
+            let start_line = sv.line_of(stmt.span.start);
+            let end_line = sv.line_of(stmt.span.end);
             push(out, start_line, end_line, None);
             fold_body(f.body, sv, out);
         }
         StmtKind::Foreach(f) => {
-            let start_line = sv.position_of(stmt.span.start).line;
-            let end_line = sv.position_of(stmt.span.end).line;
+            let start_line = sv.line_of(stmt.span.start);
+            let end_line = sv.line_of(stmt.span.end);
             push(out, start_line, end_line, None);
             fold_body(f.body, sv, out);
         }
         StmtKind::DoWhile(d) => {
-            let start_line = sv.position_of(stmt.span.start).line;
-            let end_line = sv.position_of(stmt.span.end).line;
+            let start_line = sv.line_of(stmt.span.start);
+            let end_line = sv.line_of(stmt.span.end);
             push(out, start_line, end_line, None);
             fold_body(d.body, sv, out);
         }
         StmtKind::TryCatch(t) => {
-            let start_line = sv.position_of(stmt.span.start).line;
-            let end_line = sv.position_of(stmt.span.end).line;
+            let start_line = sv.line_of(stmt.span.start);
+            let end_line = sv.line_of(stmt.span.end);
             push(out, start_line, end_line, None);
             fold_stmts(&t.body, sv, out);
             for catch in t.catches.iter() {
@@ -148,14 +148,14 @@ fn fold_stmt(stmt: &Stmt<'_, '_>, sv: SourceView<'_>, out: &mut Vec<FoldingRange
             }
         }
         StmtKind::Block(stmts) => {
-            let start_line = sv.position_of(stmt.span.start).line;
-            let end_line = sv.position_of(stmt.span.end).line;
+            let start_line = sv.line_of(stmt.span.start);
+            let end_line = sv.line_of(stmt.span.end);
             push(out, start_line, end_line, None);
             fold_stmts(stmts, sv, out);
         }
         StmtKind::Namespace(ns) => {
-            let start_line = sv.position_of(stmt.span.start).line;
-            let end_line = sv.position_of(stmt.span.end).line;
+            let start_line = sv.line_of(stmt.span.start);
+            let end_line = sv.line_of(stmt.span.end);
             push(out, start_line, end_line, None);
             if let NamespaceBody::Braced(inner) = &ns.body {
                 fold_stmts(inner, sv, out);
@@ -171,11 +171,11 @@ fn fold_use_groups(stmts: &[Stmt<'_, '_>], sv: SourceView<'_>, out: &mut Vec<Fol
     let mut group_end: u32 = 0;
     for stmt in stmts {
         if matches!(stmt.kind, StmtKind::Use(_)) {
-            let line = sv.position_of(stmt.span.start).line;
+            let line = sv.line_of(stmt.span.start);
             if group_start.is_none() {
                 group_start = Some(line);
             }
-            group_end = sv.position_of(stmt.span.end).line;
+            group_end = sv.line_of(stmt.span.end);
         } else {
             if let Some(start) = group_start.take() {
                 push(out, start, group_end, Some(FoldingRangeKind::Imports));
@@ -231,7 +231,7 @@ fn fold_regions(source: &str, out: &mut Vec<FoldingRange>) {
 }
 
 fn line_at(sv: SourceView<'_>, byte_offset: usize) -> u32 {
-    sv.position_of(byte_offset as u32).line
+    sv.line_of(byte_offset as u32)
 }
 
 fn push(

--- a/src/rename.rs
+++ b/src/rename.rs
@@ -5,7 +5,6 @@ use tower_lsp::lsp_types::{Position, Range, TextEdit, Url, WorkspaceEdit};
 
 use crate::ast::ParsedDoc;
 use crate::references::find_references_with_use;
-use crate::util::utf16_pos_to_byte;
 use crate::walk::{collect_var_refs_in_scope, property_refs_in_stmts};
 
 /// Compute a WorkspaceEdit that renames every occurrence of `word` to `new_name`
@@ -73,7 +72,6 @@ pub fn rename_variable(
     var_name: &str,
     new_name: &str,
     uri: &Url,
-    source: &str,
     doc: &ParsedDoc,
     position: Position,
 ) -> WorkspaceEdit {
@@ -81,9 +79,9 @@ pub fn rename_variable(
     let new_bare = new_name.trim_start_matches('$');
     let new_text = format!("${new_bare}");
 
-    let byte_off = utf16_pos_to_byte(source, position);
     let stmts = &doc.program().stmts;
     let sv = doc.view();
+    let byte_off = sv.byte_of_position(position) as usize;
 
     let mut spans = Vec::new();
     collect_var_refs_in_scope(stmts, bare, byte_off, &mut spans);
@@ -308,7 +306,7 @@ mod tests {
     fn rename_variable_within_function() {
         let src = "<?php\nfunction foo() {\n    $x = 1;\n    echo $x;\n}";
         let doc = Arc::new(ParsedDoc::parse(src.to_string()));
-        let edit = rename_variable("$x", "$y", &uri("/a.php"), src, &doc, pos(2, 5));
+        let edit = rename_variable("$x", "$y", &uri("/a.php"), &doc, pos(2, 5));
         let changes = edit.changes.unwrap();
         let edits = &changes[&uri("/a.php")];
         assert!(edits.len() >= 2, "should rename both assignment and usage");
@@ -319,7 +317,7 @@ mod tests {
     fn rename_variable_does_not_cross_function_boundary() {
         let src = "<?php\nfunction foo() { $x = 1; }\nfunction bar() { $x = 2; }";
         let doc = Arc::new(ParsedDoc::parse(src.to_string()));
-        let edit = rename_variable("$x", "$z", &uri("/a.php"), src, &doc, pos(1, 20));
+        let edit = rename_variable("$x", "$z", &uri("/a.php"), &doc, pos(1, 20));
         let changes = edit.changes.unwrap();
         let edits = &changes[&uri("/a.php")];
         // Only the $x in foo() should be renamed, not the one in bar()

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,28 +1,5 @@
 use tower_lsp::lsp_types::Position;
 
-/// Convert a UTF-16 LSP `Position` to a byte offset in `source`.
-pub(crate) fn utf16_pos_to_byte(source: &str, position: Position) -> usize {
-    let mut byte_off = 0usize;
-    for (line_idx, line) in source.split('\n').enumerate() {
-        // `split('\n')` keeps any '\r', so line.len() includes it — correct for byte accounting.
-        // Strip '\r' only when iterating chars for UTF-16 column counting.
-        let line_content = line.strip_suffix('\r').unwrap_or(line);
-        if line_idx == position.line as usize {
-            let mut col_utf16 = 0u32;
-            for ch in line_content.chars() {
-                if col_utf16 >= position.character {
-                    break;
-                }
-                col_utf16 += ch.len_utf16() as u32;
-                byte_off += ch.len_utf8();
-            }
-            return byte_off;
-        }
-        byte_off += line.len() + 1; // +1 for '\n'; line.len() includes '\r' when present
-    }
-    byte_off
-}
-
 /// Returns `true` if `query` matches `candidate` using camelCase/underscore
 /// abbreviation rules.
 ///


### PR DESCRIPTION
## Summary

Follow-up to #201. Two small audit findings turned into helpers on `SourceView`:

- `line_of(offset)` — line number for a byte offset, skipping the UTF-16 column scan that `position_of(..).line` wastes when callers only care about the line.
- `byte_of_position(pos)` — UTF-16 `Position` → byte offset via a \`line_starts\` jump; only scans the target line. Replaces \`util::utf16_pos_to_byte\`, which was a linear O(bytes-until-cursor) scan.

Changes in callers:
- \`folding.rs\` — every stmt/member conversion was going through \`position_of(..).line\`, computing and throwing away the UTF-16 column. Uses \`line_of\` instead.
- \`document_highlight.rs\`, \`definition.rs\`, \`rename.rs\` — all three were computing the cursor byte offset via the linear scan; now use \`sv.byte_of_position(..)\`.
- \`rename_variable\` no longer needs its \`source: &str\` parameter (was only used for the scan). Dropped from signature + 3 call sites.
- \`util::utf16_pos_to_byte\` removed — no remaining callers.

## Benchmark

Ad-hoc in-process measurement (release, \`black_box\`'d) on \`Illuminate/Database/Query/Builder.php\` (4939 lines):

| | Before | After |
|---|---|---|
| \`folding_ranges\` | ~424 µs | **~260 µs** (~40% faster) |

\`utf16_pos_to_byte\` callers get a similar speedup when the cursor is deep in the file — the exact delta scales with cursor byte offset. I didn't bench the \`$variable\` cursor path on \`document_highlight\` specifically; the non-\`$\` path (word match scan) dominates there.

## Audit scope

Per the audit done on top of #201, the other handlers are either already optimal (conversion only for kept results: \`document_highlight\`, \`walk.rs\`, \`semantic_tokens\`) or structurally required to convert all spans anyway (\`symbols.rs\`). No further optimization targets found in this pass.

## Test plan

- [x] \`cargo test --release\` — 873 passed, 0 failed
- [ ] Manual sanity: folding in an editor still produces correct ranges for classes/methods/control flow