### PR TITLE
perf(completion): cache per-doc method_returns on ParsedDoc (~325x on Laravel)

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,9 +1,14 @@
 /// Core AST infrastructure: arena-backed `ParsedDoc`, span utilities, and TypeHint formatting.
+use std::collections::HashMap;
 use std::mem::ManuallyDrop;
-use std::sync::{LazyLock, Mutex};
+use std::sync::{LazyLock, Mutex, OnceLock};
 
 use php_ast::{Program, Span, TypeHint, TypeHintKind};
 use tower_lsp::lsp_types::{Position, Range};
+
+/// Cached per-doc map of `class_name -> method_name -> return_class_name`.
+/// Exposed here (rather than in `type_map`) because it lives on `ParsedDoc`.
+pub type MethodReturnsMap = HashMap<String, HashMap<String, String>>;
 
 // ── BumpPool ──────────────────────────────────────────────────────────────────
 
@@ -72,6 +77,11 @@ pub struct ParsedDoc {
     #[allow(clippy::box_collection)]
     _source: Box<String>,
     line_starts: Vec<u32>,
+    /// Lazily-populated per-doc cache of method return types. Built on first
+    /// access by `type_map::build_method_returns`. Valid for the lifetime of
+    /// this `ParsedDoc` — a reparse produces a new instance, which naturally
+    /// invalidates the cache.
+    method_returns: OnceLock<MethodReturnsMap>,
     _arena: ArenaGuard,
 }
 
@@ -112,8 +122,18 @@ impl ParsedDoc {
             errors: result.errors,
             _source: source_box,
             line_starts,
+            method_returns: OnceLock::new(),
             _arena: ArenaGuard(Some(arena_box)),
         }
+    }
+
+    /// Return the cached per-doc method-return-type map, computing it on first
+    /// access via `build`. `build` is called at most once per `ParsedDoc`.
+    pub fn method_returns_cached<F>(&self, build: F) -> &MethodReturnsMap
+    where
+        F: FnOnce() -> MethodReturnsMap,
+    {
+        self.method_returns.get_or_init(build)
     }
 
     /// Borrow the program with lifetimes bounded by `&self`.

--- a/src/type_map.rs
+++ b/src/type_map.rs
@@ -9,7 +9,7 @@ use php_ast::{
 };
 use tower_lsp::lsp_types::Position;
 
-use crate::ast::{ParsedDoc, SourceView};
+use crate::ast::{MethodReturnsMap, ParsedDoc, SourceView};
 use crate::docblock::{docblock_before, parse_docblock};
 use crate::phpstorm_meta::PhpStormMeta;
 
@@ -26,14 +26,14 @@ impl TypeMap {
     /// Build from a parsed document, optionally enriched by PHPStorm metadata
     /// for factory-method return type inference.
     pub fn from_doc_with_meta(doc: &ParsedDoc, meta: Option<&PhpStormMeta>) -> Self {
-        let method_returns = build_method_returns(doc);
+        let method_returns = cached_method_returns(doc);
         let mut map = HashMap::new();
         collect_types_stmts(
             doc.source(),
             &doc.program().stmts,
             &mut map,
             meta,
-            &method_returns,
+            std::slice::from_ref(&method_returns),
             None,
         );
         TypeMap(map)
@@ -46,20 +46,19 @@ impl TypeMap {
         other_docs: impl IntoIterator<Item = &'a ParsedDoc>,
         meta: Option<&'a PhpStormMeta>,
     ) -> Self {
-        let mut method_returns = build_method_returns(doc);
-        for other in other_docs {
-            let other_returns = build_method_returns(other);
-            for (class, methods) in other_returns {
-                method_returns.entry(class).or_default().extend(methods);
-            }
-        }
+        let doc_returns = cached_method_returns(doc);
+        let other_returns: Vec<&MethodReturnsMap> =
+            other_docs.into_iter().map(cached_method_returns).collect();
+        let mut all_returns: Vec<&MethodReturnsMap> = Vec::with_capacity(other_returns.len() + 1);
+        all_returns.push(doc_returns);
+        all_returns.extend(other_returns);
         let mut map = HashMap::new();
         collect_types_stmts(
             doc.source(),
             &doc.program().stmts,
             &mut map,
             meta,
-            &method_returns,
+            &all_returns,
             None,
         );
         TypeMap(map)
@@ -90,20 +89,19 @@ impl TypeMap {
                 None
             }
         };
-        let mut method_returns = build_method_returns(doc);
-        for other in other_docs {
-            let other_returns = build_method_returns(other);
-            for (class, methods) in other_returns {
-                method_returns.entry(class).or_default().extend(methods);
-            }
-        }
+        let doc_returns = cached_method_returns(doc);
+        let other_returns: Vec<&MethodReturnsMap> =
+            other_docs.into_iter().map(cached_method_returns).collect();
+        let mut all_returns: Vec<&MethodReturnsMap> = Vec::with_capacity(other_returns.len() + 1);
+        all_returns.push(doc_returns);
+        all_returns.extend(other_returns);
         let mut map = HashMap::new();
         collect_types_stmts(
             doc.source(),
             &doc.program().stmts,
             &mut map,
             meta,
-            &method_returns,
+            &all_returns,
             cursor_byte,
         );
         TypeMap(map)
@@ -115,11 +113,35 @@ impl TypeMap {
     }
 }
 
-/// Pre-build a map of class_name → method_name → return_class_name from all given docs.
-pub fn build_method_returns(doc: &ParsedDoc) -> HashMap<String, HashMap<String, String>> {
+/// Pre-build a map of class_name → method_name → return_class_name for a single doc.
+pub fn build_method_returns(doc: &ParsedDoc) -> MethodReturnsMap {
     let mut out = HashMap::new();
     collect_method_returns_stmts(doc.source(), &doc.program().stmts, &mut out);
     out
+}
+
+/// Return the doc's cached method-returns map, building it on first access.
+/// Subsequent calls on the same `ParsedDoc` return the memoized result.
+fn cached_method_returns(doc: &ParsedDoc) -> &MethodReturnsMap {
+    doc.method_returns_cached(|| build_method_returns(doc))
+}
+
+/// Look up `class.method() -> return_class` across a stack of per-doc maps.
+/// Returns the first match — later docs override earlier ones, matching the
+/// previous merge-based behavior.
+fn lookup_method_return<'a>(
+    maps: &'a [&'a MethodReturnsMap],
+    class_name: &str,
+    method_name: &str,
+) -> Option<&'a str> {
+    for m in maps.iter().rev() {
+        if let Some(class_rets) = m.get(class_name)
+            && let Some(ret) = class_rets.get(method_name)
+        {
+            return Some(ret.as_str());
+        }
+    }
+    None
 }
 
 fn collect_method_returns_stmts(
@@ -251,7 +273,7 @@ fn collect_types_stmts(
     stmts: &[Stmt<'_, '_>],
     map: &mut HashMap<String, String>,
     meta: Option<&PhpStormMeta>,
-    method_returns: &HashMap<String, HashMap<String, String>>,
+    method_returns: &[&MethodReturnsMap],
     cursor_byte: Option<u32>,
 ) {
     for stmt in stmts {
@@ -580,7 +602,7 @@ fn collect_types_expr(
     expr: &php_ast::Expr<'_, '_>,
     map: &mut HashMap<String, String>,
     meta: Option<&PhpStormMeta>,
-    method_returns: &HashMap<String, HashMap<String, String>>,
+    method_returns: &[&MethodReturnsMap],
     cursor_byte: Option<u32>,
 ) {
     match &expr.kind {
@@ -615,10 +637,10 @@ fn collect_types_expr(
                     && let (ExprKind::Variable(obj_var), ExprKind::Identifier(method_name)) =
                         (&mc.object.kind, &mc.method.kind)
                     && let Some(obj_class) = map.get(&format!("${}", obj_var.as_str())).cloned()
-                    && let Some(class_rets) = method_returns.get(&obj_class)
-                    && let Some(ret_type) = class_rets.get(method_name.as_str())
+                    && let Some(ret_type) =
+                        lookup_method_return(method_returns, &obj_class, method_name.as_str())
                 {
-                    map.insert(format!("${}", var_name.as_str()), ret_type.clone());
+                    map.insert(format!("${}", var_name.as_str()), ret_type.to_string());
                 }
                 // PHPStorm meta: `$var = $obj->make(SomeClass::class)`
                 if let Some(meta) = meta


### PR DESCRIPTION
## Summary

Follow-up to #201, #202. \`TypeMap::from_docs_with_meta\` / \`from_docs_at_position\` were rebuilding \`build_method_returns(other_doc)\` on every cross-file doc, every completion/hover request. On the Laravel fixture (1609 files) that's ~1609 AST walks per keystroke, dominating at **~31 ms per completion**.

## Fix

1. Add a \`OnceLock<MethodReturnsMap>\` field to \`ParsedDoc\`. First access builds + caches; a reparse produces a new \`ParsedDoc\`, so the cache is automatically invalidated. Public accessor \`method_returns_cached(build)\` keeps the build logic in \`type_map.rs\`.
2. Drop the per-call merge into a master \`HashMap\`. \`collect_types_stmts\` now takes \`&[&MethodReturnsMap]\` and looks up across the stack (later docs shadow earlier ones, matching prior behavior). Avoids cloning thousands of \`String\` keys/values per call.

## Benchmark (\`cargo bench --bench requests -- completion\`)

| Bench | Before | After | Speedup |
|---|---|---|---|
| \`completion/laravel_framework\` | ~31.2 ms | **~96 µs** | **~325×** |
| \`completion/cross_file_arrow\` (2 docs) | ~17 µs | ~17 µs | unchanged |

## Test plan

- [x] \`cargo test --release\` — 873 passed, 0 failed
- [ ] Manual: member completion on \`\$obj->\` still resolves correctly across files (chained returns, trait returns, enum methods)
- [ ] Manual: edits invalidate cache — after a \`did_change\` that adds/removes a method, subsequent completion reflects the change