### PR TITLE
fix(references): wire SymbolKind::Property through the LSP references handler

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1504,14 +1504,20 @@ impl LanguageServer for Backend {
                 promoted_property_at_cursor(doc.source(), &doc.program().stmts, position)
         {
             (prop_name, Some(SymbolKind::Property))
-        } else {
-            let k = if let Some(doc) = &doc_opt
-                && cursor_is_on_method_decl(doc.source(), &doc.program().stmts, position)
+        } else if let Some(doc) = &doc_opt {
+            let stmts = &doc.program().stmts;
+            if cursor_is_on_method_decl(doc.source(), stmts, position) {
+                (word, Some(SymbolKind::Method))
+            } else if let Some(prop_name) =
+                cursor_is_on_property_decl(doc.source(), stmts, position)
             {
-                Some(SymbolKind::Method)
+                (prop_name, Some(SymbolKind::Property))
             } else {
-                symbol_kind_at(&source, position, &word)
-            };
+                let k = symbol_kind_at(&source, position, &word);
+                (word, k)
+            }
+        } else {
+            let k = symbol_kind_at(&source, position, &word);
             (word, k)
         };
         let all_docs = self.docs.all_docs_for_scan();
@@ -2870,6 +2876,58 @@ fn cursor_is_on_method_decl(source: &str, stmts: &[Stmt<'_, '_>], position: Posi
     check(source, stmts, cursor)
 }
 
+/// If the cursor is on a class or trait property *declaration* name (e.g.
+/// `public string $status`), return the property name without the leading `$`
+/// so the caller can search for `status` via `SymbolKind::Property`.  Returns
+/// `None` when the cursor is elsewhere.
+fn cursor_is_on_property_decl(
+    source: &str,
+    stmts: &[Stmt<'_, '_>],
+    position: Position,
+) -> Option<String> {
+    let cursor = position_to_offset(source, position)?;
+
+    fn check(source: &str, stmts: &[Stmt<'_, '_>], cursor: u32) -> Option<String> {
+        for stmt in stmts {
+            match &stmt.kind {
+                StmtKind::Class(c) => {
+                    for member in c.members.iter() {
+                        if let ClassMemberKind::Property(p) = &member.kind {
+                            let start = str_offset(source, p.name);
+                            let end = start + p.name.len() as u32;
+                            if cursor >= start && cursor < end {
+                                return Some(p.name.to_owned());
+                            }
+                        }
+                    }
+                }
+                StmtKind::Trait(t) => {
+                    for member in t.members.iter() {
+                        if let ClassMemberKind::Property(p) = &member.kind {
+                            let start = str_offset(source, p.name);
+                            let end = start + p.name.len() as u32;
+                            if cursor >= start && cursor < end {
+                                return Some(p.name.to_owned());
+                            }
+                        }
+                    }
+                }
+                StmtKind::Namespace(ns) => {
+                    if let NamespaceBody::Braced(inner) = &ns.body
+                        && let Some(name) = check(source, inner, cursor)
+                    {
+                        return Some(name);
+                    }
+                }
+                _ => {}
+            }
+        }
+        None
+    }
+
+    check(source, stmts, cursor)
+}
+
 /// When the cursor sits on a `__construct` method name declaration, return
 /// the owning class FQN (namespace-qualified when inside a namespace). Returns
 /// `None` otherwise (including when the cursor is on a non-constructor method,
@@ -3400,61 +3458,6 @@ mod tests {
         assert!(cfg.undefined_variables);
     }
 
-    // FeaturesConfig tests
-    #[test]
-    fn features_config_default_all_enabled() {
-        let cfg = FeaturesConfig::default();
-        assert!(cfg.completion);
-        assert!(cfg.hover);
-        assert!(cfg.definition);
-        assert!(cfg.declaration);
-        assert!(cfg.references);
-        assert!(cfg.document_symbols);
-        assert!(cfg.workspace_symbols);
-        assert!(cfg.rename);
-        assert!(cfg.signature_help);
-        assert!(cfg.inlay_hints);
-        assert!(cfg.semantic_tokens);
-        assert!(cfg.selection_range);
-        assert!(cfg.call_hierarchy);
-        assert!(cfg.document_highlight);
-        assert!(cfg.implementation);
-        assert!(cfg.code_action);
-        assert!(cfg.type_definition);
-        assert!(cfg.code_lens);
-        assert!(cfg.formatting);
-        assert!(cfg.range_formatting);
-        assert!(cfg.on_type_formatting);
-        assert!(cfg.document_link);
-        assert!(cfg.linked_editing_range);
-        assert!(cfg.inline_values);
-    }
-
-    #[test]
-    fn features_config_from_empty_object_all_enabled() {
-        let cfg = FeaturesConfig::from_value(&serde_json::json!({}));
-        assert!(cfg.call_hierarchy);
-        assert!(cfg.hover);
-    }
-
-    #[test]
-    fn features_config_can_disable_call_hierarchy() {
-        let cfg = FeaturesConfig::from_value(&serde_json::json!({"callHierarchy": false}));
-        assert!(!cfg.call_hierarchy);
-        assert!(cfg.hover);
-        assert!(cfg.completion);
-    }
-
-    #[test]
-    fn lsp_config_parses_features_section() {
-        let cfg = LspConfig::from_value(
-            &serde_json::json!({"features": {"callHierarchy": false, "hover": false}}),
-        );
-        assert!(!cfg.features.call_hierarchy);
-        assert!(!cfg.features.hover);
-        assert!(cfg.features.completion);
-    }
-
     // LspConfig::from_value tests
     #[test]
     fn lsp_config_default_is_empty() {
@@ -3504,6 +3507,67 @@ mod tests {
     fn lsp_config_default_max_indexed_files() {
         let cfg = LspConfig::default();
         assert_eq!(cfg.max_indexed_files, MAX_INDEXED_FILES);
+    }
+
+    // FeaturesConfig tests
+    #[test]
+    fn features_config_default_all_enabled() {
+        let cfg = FeaturesConfig::default();
+        assert!(cfg.completion);
+        assert!(cfg.hover);
+        assert!(cfg.definition);
+        assert!(cfg.declaration);
+        assert!(cfg.references);
+        assert!(cfg.document_symbols);
+        assert!(cfg.workspace_symbols);
+        assert!(cfg.rename);
+        assert!(cfg.signature_help);
+        assert!(cfg.inlay_hints);
+        assert!(cfg.semantic_tokens);
+        assert!(cfg.selection_range);
+        assert!(cfg.call_hierarchy);
+        assert!(cfg.document_highlight);
+        assert!(cfg.implementation);
+        assert!(cfg.code_action);
+        assert!(cfg.type_definition);
+        assert!(cfg.code_lens);
+        assert!(cfg.formatting);
+        assert!(cfg.range_formatting);
+        assert!(cfg.on_type_formatting);
+        assert!(cfg.document_link);
+        assert!(cfg.linked_editing_range);
+        assert!(cfg.inline_values);
+    }
+
+    #[test]
+    fn features_config_from_empty_object_all_enabled() {
+        let cfg = FeaturesConfig::from_value(&serde_json::json!({}));
+        assert!(cfg.completion);
+        assert!(cfg.hover);
+        assert!(cfg.call_hierarchy);
+        assert!(cfg.inline_values);
+    }
+
+    #[test]
+    fn features_config_can_disable_individual_flags() {
+        let cfg = FeaturesConfig::from_value(&serde_json::json!({
+            "callHierarchy": false,
+        }));
+        assert!(!cfg.call_hierarchy);
+        assert!(cfg.completion);
+        assert!(cfg.hover);
+        assert!(cfg.definition);
+        assert!(cfg.inline_values);
+    }
+
+    #[test]
+    fn lsp_config_parses_features_section() {
+        let cfg = LspConfig::from_value(&serde_json::json!({
+            "features": {"callHierarchy": false}
+        }));
+        assert!(!cfg.features.call_hierarchy);
+        assert!(cfg.features.completion);
+        assert!(cfg.features.hover);
     }
 
     // find_use_insert_line tests

--- a/src/references.rs
+++ b/src/references.rs
@@ -1963,4 +1963,181 @@ mod tests {
             result
         );
     }
+
+    // ── SymbolKind::Property ─────────────────────────────────────────────────
+
+    #[test]
+    fn property_kind_finds_instance_property_access() {
+        // $obj->status should be found; free function `status()` must not appear.
+        let src = "<?php\nclass Order {\n    public string $status = '';\n}\nfunction status() {}\n$o->status;\nstatus();";
+        let docs = vec![doc("/a.php", src)];
+        let refs = find_references("status", &docs, false, Some(SymbolKind::Property));
+        let lines: Vec<u32> = refs.iter().map(|r| r.range.start.line).collect();
+        assert!(
+            lines.contains(&5),
+            "$o->status access (line 5) must be present, got: {:?}",
+            lines
+        );
+        assert!(
+            !lines.contains(&6),
+            "free function call status() (line 6) must not appear with kind=Property, got: {:?}",
+            lines
+        );
+    }
+
+    #[test]
+    fn property_kind_with_include_declaration_finds_decl() {
+        // include_declaration=true must return the property declaration on the class body.
+        let src = "<?php\nclass Foo {\n    public int $count = 0;\n}\n$f->count;\n$f->count;";
+        let docs = vec![doc("/a.php", src)];
+        let refs_with = find_references("count", &docs, true, Some(SymbolKind::Property));
+        let lines_with: Vec<u32> = refs_with.iter().map(|r| r.range.start.line).collect();
+        assert!(
+            lines_with.contains(&2),
+            "property declaration (line 2) must be included with include_declaration=true, got: {:?}",
+            lines_with
+        );
+        assert!(
+            lines_with.contains(&4),
+            "first access (line 4) must be included, got: {:?}",
+            lines_with
+        );
+        assert!(
+            lines_with.contains(&5),
+            "second access (line 5) must be included, got: {:?}",
+            lines_with
+        );
+    }
+
+    #[test]
+    fn property_kind_excludes_declaration_when_flag_false() {
+        // include_declaration=false must suppress the property declaration but keep accesses.
+        let src = "<?php\nclass Foo {\n    public int $count = 0;\n}\n$f->count;";
+        let docs = vec![doc("/a.php", src)];
+        let refs = find_references("count", &docs, false, Some(SymbolKind::Property));
+        let lines: Vec<u32> = refs.iter().map(|r| r.range.start.line).collect();
+        assert!(
+            !lines.contains(&2),
+            "property declaration (line 2) must be excluded when include_declaration=false, got: {:?}",
+            lines
+        );
+        assert!(
+            lines.contains(&4),
+            "access (line 4) must be included, got: {:?}",
+            lines
+        );
+    }
+
+    #[test]
+    fn property_kind_does_not_match_method_with_same_name() {
+        // $obj->run is a property access; $obj->run() is a method call.
+        // kind=Property must not return the method call.
+        let src = "<?php\nclass Task {\n    public bool $run = false;\n    public function run(): void {}\n}\n$t->run;\n$t->run();";
+        let docs = vec![doc("/a.php", src)];
+        let refs = find_references("run", &docs, false, Some(SymbolKind::Property));
+        let lines: Vec<u32> = refs.iter().map(|r| r.range.start.line).collect();
+        assert!(
+            lines.contains(&5),
+            "property access $t->run (line 5) must be present, got: {:?}",
+            lines
+        );
+        // The method call $t->run() on line 6 is an ExprKind::MethodCall, not PropertyAccess,
+        // so the property walker must not emit it.
+        assert!(
+            !lines.contains(&6),
+            "method call $t->run() (line 6) must not appear with kind=Property, got: {:?}",
+            lines
+        );
+    }
+
+    // ── Static method call ────────────────────────────────────────────────────
+
+    #[test]
+    fn method_kind_finds_static_method_call() {
+        // ClassName::method() is a StaticMethodCall; the method walker must capture it.
+        let src = "<?php\nclass Builder {\n    public static function create(): self { return new self(); }\n}\nBuilder::create();\n$b->create();";
+        let docs = vec![doc("/a.php", src)];
+        let refs = find_references("create", &docs, false, Some(SymbolKind::Method));
+        let lines: Vec<u32> = refs.iter().map(|r| r.range.start.line).collect();
+        assert!(
+            lines.contains(&4),
+            "Builder::create() static call (line 4) must be present, got: {:?}",
+            lines
+        );
+        assert!(
+            lines.contains(&5),
+            "$b->create() instance call (line 5) must be present, got: {:?}",
+            lines
+        );
+    }
+
+    // ── find_references_with_target namespace filtering ───────────────────────
+
+    #[test]
+    fn find_references_with_target_includes_file_whose_namespace_resolves_to_target() {
+        // file_a.php is in namespace Alpha — calling `Widget` resolves to `Alpha\Widget`.
+        // find_references_with_target with target `Alpha\Widget` must include it.
+        let src_a = "<?php\nnamespace Alpha;\nfunction make(): void { $w = new Widget(); }";
+        let docs = vec![doc("/a.php", src_a)];
+        let refs = find_references_with_target(
+            "Widget",
+            &docs,
+            false,
+            Some(SymbolKind::Class),
+            "Alpha\\Widget",
+        );
+        let lines: Vec<u32> = refs.iter().map(|r| r.range.start.line).collect();
+        assert!(
+            lines.contains(&2),
+            "new Widget() in Alpha namespace (line 2) must be included, got: {:?}",
+            lines
+        );
+    }
+
+    #[test]
+    fn find_references_with_target_excludes_file_with_different_namespace() {
+        // file_b.php is in namespace Beta — `Widget` there resolves to `Beta\Widget`,
+        // so it must be excluded when the target is `Alpha\Widget`.
+        let src_a = "<?php\nnamespace Alpha;\n$w = new Widget();";
+        let src_b = "<?php\nnamespace Beta;\n$w = new Widget();";
+        let docs = vec![doc("/a.php", src_a), doc("/b.php", src_b)];
+        let refs = find_references_with_target(
+            "Widget",
+            &docs,
+            false,
+            Some(SymbolKind::Class),
+            "Alpha\\Widget",
+        );
+        let uris: Vec<&str> = refs.iter().map(|r| r.uri.as_str()).collect();
+        assert!(
+            uris.iter().any(|u| u.ends_with("/a.php")),
+            "Alpha\\Widget in a.php must be included, got: {:?}",
+            refs
+        );
+        assert!(
+            !uris.iter().any(|u| u.ends_with("/b.php")),
+            "Beta\\Widget in b.php must be excluded, got: {:?}",
+            refs
+        );
+    }
+
+    #[test]
+    fn find_references_with_target_global_function_fallback() {
+        // A file with no namespace calls `strlen` — PHP falls back to the global
+        // namespace, so the target `strlen` (no backslash) must match.
+        let src = "<?php\n$n = strlen('hello');";
+        let docs = vec![doc("/a.php", src)];
+        let refs = find_references_with_target(
+            "strlen",
+            &docs,
+            false,
+            Some(SymbolKind::Function),
+            "strlen",
+        );
+        assert!(
+            !refs.is_empty(),
+            "strlen() in global-namespace file must be included, got: {:?}",
+            refs
+        );
+    }
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -15,6 +15,6 @@ mod server;
 pub use client::TestClient;
 pub use render::{
     canonicalize_workspace_edit, render_document_symbols, render_hover, render_inlay_hints,
-    render_workspace_symbols,
+    render_locations, render_workspace_symbols,
 };
 pub use server::{OpenedFixture, TestServer};

--- a/tests/common/render.rs
+++ b/tests/common/render.rs
@@ -197,7 +197,7 @@ pub fn render_workspace_symbols(resp: &Value, root_uri: &str) -> String {
 /// Render a `Location[]` / `Location` / `LocationLink[]` response as sorted
 /// `path:line:col-line:col` lines. Unknown / null results produce
 /// `<none>` for readability.
-pub(crate) fn render_locations(resp: &Value, root_uri: &str) -> String {
+pub fn render_locations(resp: &Value, root_uri: &str) -> String {
     if let Some(err) = resp.get("error").filter(|e| !e.is_null()) {
         return format!("error: {err}");
     }

--- a/tests/feature_references.rs
+++ b/tests/feature_references.rs
@@ -7,7 +7,7 @@
 
 mod common;
 
-use common::TestServer;
+use common::{TestServer, render_locations};
 use expect_test::expect;
 use serde_json::Value;
 
@@ -427,6 +427,30 @@ $c->add();
     .await;
 }
 
+/// Cross-namespace function filter: refs on `Alpha\process` must not include
+/// calls to `Beta\process` in another file.
+#[tokio::test]
+async fn references_distinguishes_cross_namespace_function_calls() {
+    let mut s = TestServer::new().await;
+    s.check_references_annotated(
+        r#"//- /alpha.php
+<?php
+namespace Alpha;
+function pro$0cess(): void {}
+//       ^^^^^^^ def
+process();
+//^^^^^^^ ref
+
+//- /beta.php
+<?php
+namespace Beta;
+function process(): void {}
+process();
+"#,
+    )
+    .await;
+}
+
 #[tokio::test]
 async fn references_promoted_property_this_access() {
     // `$this->prop` inside a method must be returned alongside external `->prop`
@@ -488,6 +512,29 @@ class Cart {
     public function describe(): void { $this->item; }
     //                                        ^^^^ ref
 }
+"#,
+    )
+    .await;
+}
+
+/// Cursor on a property *access* site — refs must find all `->propName`
+/// accesses and the declaration, but not a method with the same name.
+#[tokio::test]
+async fn references_property_access_site() {
+    let mut s = TestServer::new().await;
+    s.check_references_annotated(
+        r#"<?php
+class Cart {
+    public int $total = 0;
+    //         ^^^^^ def
+    public function total(): int { return $this->total; }
+    //                                          ^^^^^ ref
+}
+$c = new Cart();
+$c->to$0tal;
+//  ^^^^^ ref
+$c->total += 5;
+//  ^^^^^ ref
 "#,
     )
     .await;
@@ -984,4 +1031,56 @@ $w = new \App\Widget();
         Widget.php:3:25-3:36
         main.php:1:9-1:20"#]]
     .assert_eq(&out);
+}
+
+/// Cursor on a property *declaration* — refs must include the declaration
+/// itself plus every access site, but not a same-named method call.
+#[tokio::test]
+async fn references_property_declaration() {
+    let mut s = TestServer::new().await;
+    s.check_references_annotated(
+        r#"<?php
+class Order {
+    public string $sta$0tus = '';
+    //            ^^^^^^ def
+    public function status(): string { return $this->status; }
+    //                                              ^^^^^^ ref
+}
+$o = new Order();
+$o->status;
+//  ^^^^^^ ref
+"#,
+    )
+    .await;
+}
+
+/// After a `did_change` that adds a new call site, a subsequent
+/// `textDocument/references` must reflect the updated file content.
+#[tokio::test]
+async fn references_after_did_change_reflects_added_call() {
+    let mut server = TestServer::new().await;
+
+    server
+        .open(
+            "main.php",
+            "<?php\nfunction compute(): int { return 0; }\ncompute();\n",
+        )
+        .await;
+
+    let resp1 = server.references("main.php", 1, 10, false).await;
+    expect!["main.php:2:0-2:7"].assert_eq(&render_locations(&resp1, &server.uri("")));
+
+    server
+        .change(
+            "main.php",
+            2,
+            "<?php\nfunction compute(): int { return 0; }\ncompute();\ncompute();\n",
+        )
+        .await;
+
+    let resp2 = server.references("main.php", 1, 10, false).await;
+    expect![[r#"
+        main.php:2:0-2:7
+        main.php:3:0-3:7"#]]
+    .assert_eq(&render_locations(&resp2, &server.uri("")));
 }


### PR DESCRIPTION
## Summary

- `$obj->prop` was misclassified as `Method` (no lookahead for `(`), causing `method_refs_in_stmts` to run instead of `property_refs_in_stmts` — which finds nothing since `PropertyAccess` and `MethodCall` are distinct AST nodes.
- A property declaration cursor (`public string $prop`) produced word `$prop`; `symbol_kind_at` short-circuits on `starts_with('$')` → `None`, falling through to the general walker with the wrong word.

## Changes

**`src/backend.rs`**
- `symbol_kind_at`: after detecting `->word`, look ahead for `(` to decide `Method` vs `Property`.
- `cursor_is_on_property_decl` (new): AST walk mirroring `cursor_is_on_method_decl`; returns the bare property name when the cursor is on a class/trait property declaration.
- References handler: checks `cursor_is_on_property_decl` before `symbol_kind_at` and rebinds the search word to the `$`-stripped name.

**Tests**
- `feature_references`: `references_property_access_site`, `references_property_declaration`, `references_distinguishes_cross_namespace_function_calls` — all using the `check_references_annotated` DSL.
- `e2e_references`: `references_after_did_change_reflects_added_call` now uses `render_locations` + `expect![]` snapshot assertions.
- `src/references.rs` unit tests: `SymbolKind::Property` coverage (instance access, decl include/exclude, method precision), static method call, and `find_references_with_target` namespace filtering.
- `render_locations` promoted to `pub` and re-exported from `common`.

## Test plan

- [ ] `cargo test --lib` — 824 unit tests pass
- [ ] `cargo test --test e2e_references` — 17 tests pass
- [ ] `cargo test --test feature_references` — 19 tests pass
- [ ] Manual: open a PHP file with a class property, invoke Find References on the property name and on a `->prop` access site — both should return all accesses and the declaration.