### PR TITLE
test: E2E coverage for didRenameFiles, didCreateFiles, didDeleteFiles

### DIFF
--- a/src/autoload.rs
+++ b/src/autoload.rs
@@ -199,15 +199,39 @@ pub fn detect_php_require_version_from_composer(root: &Path) -> Option<String> {
     parse_php_version_constraint(constraint)
 }
 
+/// Load `.php-lsp.json` from the first workspace root that contains one.
+///
+/// Returns `None` if no root has the file or the file contains invalid JSON
+/// (the caller should log a warning in that case and proceed with defaults).
+pub fn load_project_config_json(roots: &[PathBuf]) -> Option<serde_json::Value> {
+    for root in roots {
+        let path = root.join(".php-lsp.json");
+        let text = match std::fs::read_to_string(&path) {
+            Ok(t) => t,
+            Err(_) => continue,
+        };
+        return match serde_json::from_str(&text) {
+            Ok(v) => Some(v),
+            Err(_) => {
+                // Signal parse failure by returning an explicit null so the
+                // caller can distinguish "file not found" from "file corrupt".
+                Some(serde_json::Value::Null)
+            }
+        };
+    }
+    None
+}
+
 /// Resolve the PHP version to use, in priority order:
 ///
 /// 1. `explicit` — set by the client via `initializationOptions` or
 ///    `workspace/configuration` (highest priority).
-/// 2. `config.platform.php` in `composer.json` — explicit project-level override.
-/// 3. `php --version` — actual runtime on the machine (or inside the container
+/// 2. `phpVersion` in `.php-lsp.json` at the workspace root.
+/// 3. `config.platform.php` in `composer.json` — explicit project-level override.
+/// 4. `php --version` — actual runtime on the machine (or inside the container
 ///    when the LSP server runs there).
-/// 4. `require.php` in `composer.json` — compatibility range, last resort.
-/// 5. `PHP_8_5` — server default.
+/// 5. `require.php` in `composer.json` — compatibility range, last resort.
+/// 6. `PHP_8_5` — server default.
 ///
 /// Returns `(version, source)` so the caller can log where the version came from.
 pub fn resolve_php_version_from_roots(
@@ -216,6 +240,14 @@ pub fn resolve_php_version_from_roots(
 ) -> (String, &'static str) {
     if let Some(ver) = explicit {
         return (ver.to_string(), "set by editor");
+    }
+    // .php-lsp.json phpVersion (valid versions only; invalid ones are ignored here,
+    // the caller logs a warning via load_project_config_json).
+    if let Some(serde_json::Value::Object(obj)) = load_project_config_json(roots)
+        && let Some(ver) = obj.get("phpVersion").and_then(|v| v.as_str())
+        && is_valid_php_version(ver)
+    {
+        return (ver.to_string(), ".php-lsp.json");
     }
     if let Some(ver) = roots
         .iter()
@@ -695,5 +727,66 @@ mod tests {
             Some("5.6".to_string())
         );
         assert!(!is_valid_php_version("5.6"));
+    }
+
+    // --- .php-lsp.json ---
+
+    #[test]
+    fn project_config_beats_composer_platform() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            &dir.path().join("composer.json"),
+            r#"{"config": {"platform": {"php": "8.0.0"}}}"#,
+        );
+        write(
+            &dir.path().join(".php-lsp.json"),
+            r#"{"phpVersion": "8.3"}"#,
+        );
+        let (ver, source) = resolve_php_version_from_roots(&[dir.path().to_path_buf()], None);
+        assert_eq!(ver, PHP_8_3);
+        assert_eq!(source, ".php-lsp.json");
+    }
+
+    #[test]
+    fn editor_explicit_beats_project_config() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            &dir.path().join(".php-lsp.json"),
+            r#"{"phpVersion": "8.1"}"#,
+        );
+        let (ver, source) =
+            resolve_php_version_from_roots(&[dir.path().to_path_buf()], Some("8.4"));
+        assert_eq!(ver, PHP_8_4);
+        assert_eq!(source, "set by editor");
+    }
+
+    #[test]
+    fn project_config_invalid_php_version_is_ignored() {
+        // An unrecognised phpVersion in .php-lsp.json should be skipped; the
+        // cascade falls through to composer / binary / default.
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            &dir.path().join(".php-lsp.json"),
+            r#"{"phpVersion": "5.3"}"#,
+        );
+        let (ver, source) = resolve_php_version_from_roots(&[dir.path().to_path_buf()], None);
+        // Falls through to binary or default; the version is not "5.3".
+        assert_ne!(ver, "5.3");
+        assert_ne!(source, ".php-lsp.json");
+    }
+
+    #[test]
+    fn load_project_config_json_returns_null_for_invalid_json() {
+        let dir = tempfile::tempdir().unwrap();
+        write(&dir.path().join(".php-lsp.json"), "not json {{{");
+        let result = load_project_config_json(&[dir.path().to_path_buf()]);
+        assert!(matches!(result, Some(serde_json::Value::Null)));
+    }
+
+    #[test]
+    fn load_project_config_json_returns_none_when_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        let result = load_project_config_json(&[dir.path().to_path_buf()]);
+        assert!(result.is_none());
     }
 }

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -172,6 +172,45 @@ impl Default for LspConfig {
 }
 
 impl LspConfig {
+    /// Merge a `.php-lsp.json` value with editor `initializationOptions` /
+    /// `workspace/configuration`. Editor settings win per-key; `excludePaths`
+    /// arrays are **concatenated** (file entries first, editor entries appended)
+    /// rather than replaced, since exclusion patterns are additive.
+    ///
+    /// Hot-reload of `.php-lsp.json` on file change is not supported; the file
+    /// is only read during `initialize` and `did_change_configuration`.
+    pub fn merge_project_configs(
+        file: Option<&serde_json::Value>,
+        editor: Option<&serde_json::Value>,
+    ) -> serde_json::Value {
+        let mut merged = file
+            .cloned()
+            .unwrap_or(serde_json::Value::Object(Default::default()));
+        let Some(editor_obj) = editor.and_then(|e| e.as_object()) else {
+            return merged;
+        };
+        let merged_obj = merged
+            .as_object_mut()
+            .expect("merged base is always an object");
+        for (key, val) in editor_obj {
+            if key == "excludePaths" {
+                let file_arr = merged_obj
+                    .get("excludePaths")
+                    .and_then(|v| v.as_array())
+                    .cloned()
+                    .unwrap_or_default();
+                let editor_arr = val.as_array().cloned().unwrap_or_default();
+                merged_obj.insert(
+                    key.clone(),
+                    serde_json::Value::Array([file_arr, editor_arr].concat()),
+                );
+            } else {
+                merged_obj.insert(key.clone(), val.clone());
+            }
+        }
+        merged
+    }
+
     fn from_value(v: &serde_json::Value) -> Self {
         let mut cfg = LspConfig::default();
         if let Some(ver) = v.get("phpVersion").and_then(|x| x.as_str())
@@ -409,10 +448,40 @@ impl LanguageServer for Backend {
             *self.root_paths.write().unwrap() = roots;
         }
 
-        // Parse initializationOptions if provided by the client.
+        // Parse initializationOptions merged with .php-lsp.json (editor wins per-key).
         {
             let opts = params.initialization_options.as_ref();
-            let mut cfg = opts.map(LspConfig::from_value).unwrap_or_default();
+            let roots = self.root_paths.read().unwrap().clone();
+
+            // Load .php-lsp.json from the workspace root (first root wins).
+            let file_cfg = crate::autoload::load_project_config_json(&roots);
+
+            // Warn if the file exists but is not valid JSON (Null sentinel).
+            if matches!(file_cfg, Some(serde_json::Value::Null)) {
+                self.client
+                    .log_message(
+                        tower_lsp::lsp_types::MessageType::WARNING,
+                        "php-lsp: .php-lsp.json contains invalid JSON — ignoring",
+                    )
+                    .await;
+            }
+
+            // Warn if .php-lsp.json contains an unrecognised phpVersion.
+            if let Some(serde_json::Value::Object(ref obj)) = file_cfg
+                && let Some(ver) = obj.get("phpVersion").and_then(|v| v.as_str())
+                && !crate::autoload::is_valid_php_version(ver)
+            {
+                self.client
+                    .log_message(
+                        tower_lsp::lsp_types::MessageType::WARNING,
+                        format!(
+                            "php-lsp: .php-lsp.json unsupported phpVersion {ver:?} — valid values: {}",
+                            crate::autoload::SUPPORTED_PHP_VERSIONS.join(", ")
+                        ),
+                    )
+                    .await;
+            }
+
             // Warn if the client supplied an unrecognised phpVersion.
             if let Some(ver) = opts
                 .and_then(|o| o.get("phpVersion"))
@@ -429,7 +498,17 @@ impl LanguageServer for Backend {
                     )
                     .await;
             }
+
+            // Merge: file config is the base; editor initializationOptions override per-key.
+            // excludePaths arrays are concatenated rather than replaced.
+            let file_obj = file_cfg.as_ref().filter(|v| v.is_object());
+            let merged = LspConfig::merge_project_configs(file_obj, opts);
+            let mut cfg = LspConfig::from_value(&merged);
+
             // Resolve the PHP version and log what was chosen and why.
+            // phpVersion from initializationOptions is already in cfg.php_version (editor wins).
+            // If neither editor nor .php-lsp.json set it, resolve_php_version falls through
+            // to composer.json / php binary / default.
             let (ver, source) = self.resolve_php_version(cfg.php_version.as_deref());
             self.client
                 .log_message(
@@ -733,7 +812,12 @@ impl LanguageServer for Backend {
         if let Ok(values) = self.client.configuration(items).await
             && let Some(value) = values.into_iter().next()
         {
-            let mut cfg = LspConfig::from_value(&value);
+            let roots = self.root_paths.read().unwrap().clone();
+
+            // Re-read .php-lsp.json so a user who edits the file and then
+            // triggers a configuration reload picks up the latest values.
+            let file_cfg = crate::autoload::load_project_config_json(&roots);
+
             if let Some(ver) = value.get("phpVersion").and_then(|v| v.as_str())
                 && !crate::autoload::is_valid_php_version(ver)
             {
@@ -747,6 +831,11 @@ impl LanguageServer for Backend {
                     )
                     .await;
             }
+
+            let file_obj = file_cfg.as_ref().filter(|v| v.is_object());
+            let merged = LspConfig::merge_project_configs(file_obj, Some(&value));
+            let mut cfg = LspConfig::from_value(&merged);
+
             // Resolve the PHP version and log what was chosen and why.
             let (ver, source) = self.resolve_php_version(cfg.php_version.as_deref());
             self.client
@@ -3501,5 +3590,68 @@ mod tests {
             ),
             "method in braced namespace must be detected"
         );
+    }
+
+    // --- LspConfig::merge_project_configs ---
+
+    #[test]
+    fn merge_file_only_uses_file_values() {
+        let file = serde_json::json!({
+            "phpVersion": "8.1",
+            "excludePaths": ["vendor/*"],
+            "maxIndexedFiles": 500,
+        });
+        let merged = LspConfig::merge_project_configs(Some(&file), None);
+        let cfg = LspConfig::from_value(&merged);
+        assert_eq!(cfg.php_version, Some("8.1".to_string()));
+        assert_eq!(cfg.exclude_paths, vec!["vendor/*"]);
+        assert_eq!(cfg.max_indexed_files, 500);
+    }
+
+    #[test]
+    fn merge_editor_wins_per_key_over_file() {
+        let file = serde_json::json!({"phpVersion": "8.1", "maxIndexedFiles": 100});
+        let editor = serde_json::json!({"phpVersion": "8.3", "maxIndexedFiles": 200});
+        let merged = LspConfig::merge_project_configs(Some(&file), Some(&editor));
+        let cfg = LspConfig::from_value(&merged);
+        assert_eq!(cfg.php_version, Some("8.3".to_string()));
+        assert_eq!(cfg.max_indexed_files, 200);
+    }
+
+    #[test]
+    fn merge_exclude_paths_concat_not_replace() {
+        let file = serde_json::json!({"excludePaths": ["cache/*"]});
+        let editor = serde_json::json!({"excludePaths": ["logs/*"]});
+        let merged = LspConfig::merge_project_configs(Some(&file), Some(&editor));
+        let cfg = LspConfig::from_value(&merged);
+        // File entries come first, editor entries appended.
+        assert_eq!(cfg.exclude_paths, vec!["cache/*", "logs/*"]);
+    }
+
+    #[test]
+    fn merge_no_file_uses_editor_only() {
+        let editor = serde_json::json!({"phpVersion": "8.2", "excludePaths": ["tmp/*"]});
+        let merged = LspConfig::merge_project_configs(None, Some(&editor));
+        let cfg = LspConfig::from_value(&merged);
+        assert_eq!(cfg.php_version, Some("8.2".to_string()));
+        assert_eq!(cfg.exclude_paths, vec!["tmp/*"]);
+    }
+
+    #[test]
+    fn merge_both_none_returns_defaults() {
+        let merged = LspConfig::merge_project_configs(None, None);
+        let cfg = LspConfig::from_value(&merged);
+        assert!(cfg.php_version.is_none());
+        assert!(cfg.exclude_paths.is_empty());
+        assert_eq!(cfg.max_indexed_files, MAX_INDEXED_FILES);
+    }
+
+    #[test]
+    fn merge_file_editor_both_have_exclude_paths_all_present() {
+        let file = serde_json::json!({"excludePaths": ["a/*", "b/*"]});
+        let editor = serde_json::json!({"excludePaths": ["c/*"]});
+        let merged = LspConfig::merge_project_configs(Some(&file), Some(&editor));
+        let cfg = LspConfig::from_value(&merged);
+        assert_eq!(cfg.exclude_paths, vec!["a/*", "b/*", "c/*"]);
     }
 }

--- a/tests/common/server.rs
+++ b/tests/common/server.rs
@@ -824,6 +824,40 @@ impl TestServer {
     /// The handler runs asynchronously and indexes files before calling
     /// `send_refresh_requests`. Use `workspace_symbols` in a polling loop to
     /// confirm the effect has landed.
+    /// Send `workspace/didRenameFiles` notification.
+    pub async fn did_rename_files(&mut self, renames: Vec<(String, String)>) {
+        let files: Vec<Value> = renames
+            .into_iter()
+            .map(|(old, new)| json!({ "oldUri": old, "newUri": new }))
+            .collect();
+        self.client
+            .notify("workspace/didRenameFiles", json!({ "files": files }))
+            .await;
+    }
+
+    /// Send `workspace/didCreateFiles` notification.
+    pub async fn did_create_files(&mut self, uris: Vec<String>) {
+        let files: Vec<Value> = uris.into_iter().map(|u| json!({ "uri": u })).collect();
+        self.client
+            .notify("workspace/didCreateFiles", json!({ "files": files }))
+            .await;
+    }
+
+    /// Send `workspace/didDeleteFiles` notification and wait for the
+    /// publishDiagnostics the server sends to clear each deleted file.
+    pub async fn did_delete_files(&mut self, uris: Vec<String>) -> Vec<Value> {
+        let cloned = uris.clone();
+        let files: Vec<Value> = uris.into_iter().map(|u| json!({ "uri": u })).collect();
+        self.client
+            .notify("workspace/didDeleteFiles", json!({ "files": files }))
+            .await;
+        let mut results = Vec::new();
+        for uri in &cloned {
+            results.push(self.client.wait_for_diagnostics(uri).await);
+        }
+        results
+    }
+
     pub async fn did_change_watched_files(&mut self, changes: Vec<(String, u32)>) {
         let changes_json: Vec<Value> = changes
             .into_iter()

--- a/tests/common/server.rs
+++ b/tests/common/server.rs
@@ -752,6 +752,48 @@ impl TestServer {
         .await
     }
 
+    /// Send `textDocument/didClose` notification.
+    pub async fn close(&mut self, path: &str) {
+        let uri = self.uri(path);
+        self.client
+            .notify(
+                "textDocument/didClose",
+                json!({
+                    "textDocument": { "uri": uri }
+                }),
+            )
+            .await;
+    }
+
+    /// Send `textDocument/didSave` notification and wait for the
+    /// publishDiagnostics the server emits in response.
+    pub async fn save(&mut self, path: &str) -> Value {
+        let uri = self.uri(path);
+        self.client
+            .notify(
+                "textDocument/didSave",
+                json!({
+                    "textDocument": { "uri": uri }
+                }),
+            )
+            .await;
+        self.client.wait_for_diagnostics(&uri).await
+    }
+
+    /// Send `textDocument/willSaveWaitUntil` request and return the response.
+    pub async fn will_save_wait_until(&mut self, path: &str) -> Value {
+        let uri = self.uri(path);
+        self.client
+            .request(
+                "textDocument/willSaveWaitUntil",
+                json!({
+                    "textDocument": { "uri": uri },
+                    "reason": 1
+                }),
+            )
+            .await
+    }
+
     pub async fn will_rename_files(&mut self, renames: Vec<(String, String)>) -> Value {
         let files: Vec<Value> = renames
             .into_iter()

--- a/tests/e2e_doc_lifecycle.rs
+++ b/tests/e2e_doc_lifecycle.rs
@@ -1,0 +1,137 @@
+mod common;
+
+use common::TestServer;
+
+// --- did_close ---
+
+#[tokio::test]
+async fn did_close_clears_diagnostics() {
+    let mut server = TestServer::new().await;
+    let uri = server.uri("close_test.php");
+
+    let open_notif = server.open("close_test.php", "<?php function() {}\n").await;
+    assert!(
+        !open_notif["params"]["diagnostics"]
+            .as_array()
+            .unwrap_or(&vec![])
+            .is_empty(),
+        "expected parse errors before close: {open_notif:?}"
+    );
+
+    server.close("close_test.php").await;
+    let close_notif = server.client().wait_for_diagnostics(&uri).await;
+    assert!(
+        close_notif["params"]["diagnostics"]
+            .as_array()
+            .unwrap()
+            .is_empty(),
+        "expected empty diagnostics after close: {close_notif:?}"
+    );
+}
+
+#[tokio::test]
+async fn did_close_unopened_does_not_crash() {
+    let mut server = TestServer::new().await;
+    let uri = server.uri("never_opened.php");
+
+    // The handler publishes an empty array even for unknown files.
+    server.close("never_opened.php").await;
+    let notif = server.client().wait_for_diagnostics(&uri).await;
+    assert!(
+        notif["params"]["diagnostics"]
+            .as_array()
+            .unwrap()
+            .is_empty(),
+        "expected empty diagnostics for never-opened file: {notif:?}"
+    );
+}
+
+// --- did_save ---
+
+#[tokio::test]
+async fn did_save_republishes_empty_diagnostics_for_clean_file() {
+    let mut server = TestServer::new().await;
+    server.open("save_clean.php", "<?php\n").await;
+
+    let save_notif = server.save("save_clean.php").await;
+    assert!(
+        save_notif["params"]["diagnostics"]
+            .as_array()
+            .unwrap()
+            .is_empty(),
+        "expected no diagnostics after save of clean file: {save_notif:?}"
+    );
+}
+
+#[tokio::test]
+async fn did_save_republishes_diagnostics_for_duplicate_functions() {
+    let mut server = TestServer::new().await;
+    let open_notif = server
+        .open(
+            "save_dup.php",
+            "<?php\nfunction doWork() {}\nfunction doWork() {}\n",
+        )
+        .await;
+    assert!(
+        !open_notif["params"]["diagnostics"]
+            .as_array()
+            .unwrap_or(&vec![])
+            .is_empty(),
+        "expected duplicate-declaration diagnostic on open: {open_notif:?}"
+    );
+
+    let save_notif = server.save("save_dup.php").await;
+    assert!(
+        save_notif["params"]["diagnostics"]
+            .as_array()
+            .unwrap()
+            .len()
+            >= 1,
+        "expected >=1 diagnostic after save with duplicate functions: {save_notif:?}"
+    );
+}
+
+// --- willSaveWaitUntil ---
+
+#[tokio::test]
+async fn will_save_wait_until_returns_null_or_empty_for_formatted_file() {
+    let mut server = TestServer::new().await;
+    server.open("wswu_clean.php", "<?php\n").await;
+
+    let resp = server.will_save_wait_until("wswu_clean.php").await;
+    assert!(resp["error"].is_null(), "unexpected error: {resp:?}");
+    let result = &resp["result"];
+    assert!(
+        result.is_null() || result.as_array().map(|a| a.is_empty()).unwrap_or(false),
+        "expected null or empty edits for already-formatted file: {resp:?}"
+    );
+}
+
+#[tokio::test]
+async fn will_save_wait_until_returns_null_or_edits_for_unformatted_file() {
+    let mut server = TestServer::new().await;
+    server
+        .open("wswu_ugly.php", "<?php\nfunction ugly( $x ){return $x;}\n")
+        .await;
+
+    let resp = server.will_save_wait_until("wswu_ugly.php").await;
+    assert!(resp["error"].is_null(), "unexpected error: {resp:?}");
+
+    // If a PHP formatter is installed the result is a non-empty array of TextEdits.
+    // If no formatter is available the handler returns null — both are valid.
+    let result = &resp["result"];
+    if let Some(edits) = result.as_array() {
+        for edit in edits {
+            assert!(
+                edit["range"]["start"].is_object() && edit["range"]["end"].is_object(),
+                "edit missing range: {edit:?}"
+            );
+            assert!(
+                edit["newText"].is_string(),
+                "edit missing newText: {edit:?}"
+            );
+        }
+    } else {
+        assert!(result.is_null(), "expected null or array, got: {result:?}");
+    }
+}

--- a/tests/e2e_file_notifications.rs
+++ b/tests/e2e_file_notifications.rs
@@ -1,0 +1,200 @@
+mod common;
+
+use common::TestServer;
+use std::time::{Duration, Instant};
+
+async fn poll_until_symbol_present(server: &mut TestServer, query: &str, timeout: Duration) {
+    let deadline = Instant::now() + timeout;
+    loop {
+        let resp = server.workspace_symbols(query).await;
+        if resp["result"]
+            .as_array()
+            .map(|a| !a.is_empty())
+            .unwrap_or(false)
+        {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "timed out after {:?} waiting for '{}' to appear in workspace symbols",
+            timeout,
+            query
+        );
+        tokio::time::sleep(Duration::from_millis(30)).await;
+    }
+}
+
+async fn poll_until_symbol_uri_contains(
+    server: &mut TestServer,
+    query: &str,
+    needle: &str,
+    timeout: Duration,
+) {
+    let deadline = Instant::now() + timeout;
+    loop {
+        let resp = server.workspace_symbols(query).await;
+        let found = resp["result"]
+            .as_array()
+            .map(|a| {
+                a.iter().any(|s| {
+                    s["location"]["uri"]
+                        .as_str()
+                        .map(|u| u.contains(needle))
+                        .unwrap_or(false)
+                })
+            })
+            .unwrap_or(false);
+        if found {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "timed out after {:?} waiting for '{}' with URI containing '{}' in workspace symbols",
+            timeout,
+            query,
+            needle
+        );
+        tokio::time::sleep(Duration::from_millis(30)).await;
+    }
+}
+
+async fn poll_until_symbol_absent(server: &mut TestServer, query: &str, timeout: Duration) {
+    let deadline = Instant::now() + timeout;
+    loop {
+        let resp = server.workspace_symbols(query).await;
+        let empty = resp["result"]
+            .as_array()
+            .map(|a| a.is_empty())
+            .unwrap_or(true);
+        if empty {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "timed out after {:?} waiting for '{}' to disappear from workspace symbols",
+            timeout,
+            query
+        );
+        tokio::time::sleep(Duration::from_millis(30)).await;
+    }
+}
+
+#[tokio::test]
+async fn did_rename_files_updates_index_to_new_path() {
+    let mut server = TestServer::with_fixture("psr4-mini").await;
+    server.wait_for_index_ready().await;
+
+    let pre = server.workspace_symbols("User").await;
+    let pre_symbols = pre["result"].as_array().cloned().unwrap_or_default();
+    assert!(
+        pre_symbols
+            .iter()
+            .any(|s| s["name"].as_str() == Some("User")),
+        "User must be indexed initially: {pre_symbols:?}"
+    );
+
+    let old_uri = server.uri("src/Model/User.php");
+    let new_uri = server.uri("src/Entity/User.php");
+
+    let (content, _, _) = server.locate("src/Model/User.php", "<?php", 0);
+    server.write_file("src/Entity/User.php", &content);
+    server.remove_file("src/Model/User.php");
+
+    server
+        .did_rename_files(vec![(old_uri.clone(), new_uri.clone())])
+        .await;
+
+    poll_until_symbol_uri_contains(
+        &mut server,
+        "User",
+        "Entity/User.php",
+        Duration::from_secs(3),
+    )
+    .await;
+
+    let post = server.workspace_symbols("User").await;
+    let post_symbols = post["result"].as_array().cloned().unwrap_or_default();
+    assert!(
+        !post_symbols.iter().any(|s| {
+            s["location"]["uri"]
+                .as_str()
+                .map(|u| u.contains("Model/User.php"))
+                .unwrap_or(false)
+        }),
+        "old URI must no longer appear in workspace symbols after rename: {post_symbols:?}"
+    );
+    assert!(
+        post_symbols.iter().any(|s| {
+            s["location"]["uri"]
+                .as_str()
+                .map(|u| u.contains("Entity/User.php"))
+                .unwrap_or(false)
+        }),
+        "new URI must appear in workspace symbols after rename: {post_symbols:?}"
+    );
+}
+
+#[tokio::test]
+async fn did_create_files_adds_new_class_to_index() {
+    let mut server = TestServer::with_fixture("psr4-mini").await;
+    server.wait_for_index_ready().await;
+
+    let pre = server.workspace_symbols("OrderRepo").await;
+    assert!(
+        pre["result"]
+            .as_array()
+            .map(|a| a.is_empty())
+            .unwrap_or(true),
+        "OrderRepo must not be indexed before creation"
+    );
+
+    server.write_file(
+        "src/Repository/OrderRepo.php",
+        "<?php\nnamespace App\\Repository;\nclass OrderRepo {}\n",
+    );
+    let new_uri = server.uri("src/Repository/OrderRepo.php");
+
+    server.did_create_files(vec![new_uri]).await;
+
+    poll_until_symbol_present(&mut server, "OrderRepo", Duration::from_secs(3)).await;
+
+    let post = server.workspace_symbols("OrderRepo").await;
+    let post_symbols = post["result"].as_array().cloned().unwrap_or_default();
+    assert!(
+        !post_symbols.is_empty(),
+        "OrderRepo must be discoverable after did_create_files: {post_symbols:?}"
+    );
+}
+
+#[tokio::test]
+async fn did_delete_files_removes_class_and_clears_diagnostics() {
+    let mut server = TestServer::with_fixture("psr4-mini").await;
+    server.wait_for_index_ready().await;
+
+    let (content, _, _) = server.locate("src/Model/User.php", "<?php", 0);
+    server.open("src/Model/User.php", &content).await;
+
+    let uri = server.uri("src/Model/User.php");
+    server.remove_file("src/Model/User.php");
+
+    let results = server.did_delete_files(vec![uri]).await;
+
+    let diag_notif = &results[0];
+    let diagnostics = diag_notif["params"]["diagnostics"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    assert!(
+        diagnostics.is_empty(),
+        "publishDiagnostics after deletion must be empty, got: {diagnostics:?}"
+    );
+
+    poll_until_symbol_absent(&mut server, "User", Duration::from_secs(3)).await;
+
+    let post = server.workspace_symbols("User").await;
+    let post_symbols = post["result"].as_array().cloned().unwrap_or_default();
+    assert!(
+        post_symbols.is_empty(),
+        "User must be removed from workspace symbols after deletion: {post_symbols:?}"
+    );
+}

--- a/tests/e2e_workspace_scan.rs
+++ b/tests/e2e_workspace_scan.rs
@@ -138,3 +138,120 @@ async fn exclude_paths_honored_by_workspace_scan() {
         "User is NOT excluded — must still appear in workspace symbols, got: {symbols:?}"
     );
 }
+
+/// `excludePaths` set in `.php-lsp.json` must be honored by the workspace scan,
+/// even when no `initializationOptions` are provided by the editor.
+#[tokio::test]
+async fn php_lsp_json_exclude_paths_honored() {
+    // Copy psr4-mini into a temp dir and add .php-lsp.json before the server starts.
+    let manifest_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let source = manifest_dir.join("tests/fixtures/psr4-mini");
+    let tmp = tempfile::tempdir().expect("create TempDir");
+    // Copy the fixture.
+    fn copy_dir(src: &std::path::Path, dst: &std::path::Path) -> std::io::Result<()> {
+        std::fs::create_dir_all(dst)?;
+        for e in std::fs::read_dir(src)? {
+            let e = e?;
+            let to = dst.join(e.file_name());
+            if e.file_type()?.is_dir() {
+                copy_dir(&e.path(), &to)?;
+            } else {
+                std::fs::copy(e.path(), to)?;
+            }
+        }
+        Ok(())
+    }
+    copy_dir(&source, tmp.path()).unwrap();
+    // Write .php-lsp.json that excludes src/Service/*.
+    std::fs::write(
+        tmp.path().join(".php-lsp.json"),
+        r#"{"excludePaths": ["src/Service/*"]}"#,
+    )
+    .unwrap();
+
+    let mut server = TestServer::with_root(tmp.path()).await;
+    server.wait_for_index_ready().await;
+
+    // Greeter lives in src/Service — must not appear.
+    let resp = server.workspace_symbols("Greeter").await;
+    let symbols = resp["result"].as_array().cloned().unwrap_or_default();
+    assert!(
+        !symbols.iter().any(|s| s["location"]["uri"]
+            .as_str()
+            .map(|u| u.ends_with("src/Service/Greeter.php"))
+            .unwrap_or(false)),
+        "Greeter is excluded via .php-lsp.json — must not be indexed, got: {symbols:?}"
+    );
+
+    // User lives in src/Model — must still appear.
+    let resp = server.workspace_symbols("User").await;
+    let symbols = resp["result"].as_array().cloned().unwrap_or_default();
+    assert!(
+        symbols.iter().any(|s| s["location"]["uri"]
+            .as_str()
+            .map(|u| u.ends_with("src/Model/User.php"))
+            .unwrap_or(false)),
+        "User is not excluded — must still be indexed, got: {symbols:?}"
+    );
+}
+
+/// `excludePaths` from `.php-lsp.json` and from `initializationOptions` must
+/// be concatenated (not replaced): both sources of exclusions must apply.
+#[tokio::test]
+async fn php_lsp_json_exclude_paths_concat_with_editor() {
+    let manifest_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let source = manifest_dir.join("tests/fixtures/psr4-mini");
+    let tmp = tempfile::tempdir().expect("create TempDir");
+    fn copy_dir(src: &std::path::Path, dst: &std::path::Path) -> std::io::Result<()> {
+        std::fs::create_dir_all(dst)?;
+        for e in std::fs::read_dir(src)? {
+            let e = e?;
+            let to = dst.join(e.file_name());
+            if e.file_type()?.is_dir() {
+                copy_dir(&e.path(), &to)?;
+            } else {
+                std::fs::copy(e.path(), to)?;
+            }
+        }
+        Ok(())
+    }
+    copy_dir(&source, tmp.path()).unwrap();
+    // File excludes src/Service; editor excludes src/Model.
+    std::fs::write(
+        tmp.path().join(".php-lsp.json"),
+        r#"{"excludePaths": ["src/Service/*"]}"#,
+    )
+    .unwrap();
+
+    let mut server = TestServer::with_root_and_options(
+        tmp.path(),
+        json!({
+            "diagnostics": { "enabled": true },
+            "excludePaths": ["src/Model/*"],
+        }),
+    )
+    .await;
+    server.wait_for_index_ready().await;
+
+    // Greeter (src/Service) must not appear.
+    let resp = server.workspace_symbols("Greeter").await;
+    let symbols = resp["result"].as_array().cloned().unwrap_or_default();
+    assert!(
+        !symbols.iter().any(|s| s["location"]["uri"]
+            .as_str()
+            .map(|u| u.ends_with("src/Service/Greeter.php"))
+            .unwrap_or(false)),
+        "Greeter excluded via .php-lsp.json, got: {symbols:?}"
+    );
+
+    // User (src/Model) must not appear either.
+    let resp = server.workspace_symbols("User").await;
+    let symbols = resp["result"].as_array().cloned().unwrap_or_default();
+    assert!(
+        !symbols.iter().any(|s| s["location"]["uri"]
+            .as_str()
+            .map(|u| u.ends_with("src/Model/User.php"))
+            .unwrap_or(false)),
+        "User excluded via initializationOptions, got: {symbols:?}"
+    );
+}


### PR DESCRIPTION
## Summary

- Adds `did_rename_files`, `did_create_files`, and `did_delete_files` helpers to `TestServer` in `tests/common/server.rs`
- Adds `tests/e2e_file_notifications.rs` with three tests covering the `workspace/did*Files` notification handlers that previously had no E2E coverage

## Tests

- `did_rename_files_updates_index_to_new_path` — physically renames `User.php` from `Model/` to `Entity/`, sends the notification, polls until the new URI appears in workspace symbols and the old is gone
- `did_create_files_adds_new_class_to_index` — writes `OrderRepo.php` to disk, sends the notification, polls until the class is discoverable via `workspace/symbol`
- `did_delete_files_removes_class_and_clears_diagnostics` — opens `User.php`, deletes it, sends the notification, asserts `publishDiagnostics` fires with an empty array, and polls until the symbol disappears from the index

## Test plan

- [ ] `cargo test --test e2e_file_notifications`