### PR TITLE
chore: upgrade mir crates to 0.8.0 and wire PhpVersion into analysis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1014,9 +1014,9 @@ dependencies = [
 
 [[package]]
 name = "mir-analyzer"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acfa5ca39ff24b6ec10806cb6726e5d83fc8951c14e5c29c3ea301ba2577489c"
+checksum = "bb017e434cb7884b5dadb6b3c2dfa691b12b0fc4b6c538c106c6b10ad8b77181"
 dependencies = [
  "blake3",
  "bumpalo",
@@ -1035,9 +1035,9 @@ dependencies = [
 
 [[package]]
 name = "mir-codebase"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7af4899e89f5721072bec485834e639670667617f7840cc0f13a1dcb2381b691"
+checksum = "7590194b797f3683ab8f7dc17fc9d121c488180a1fd48d6ee207956fdfd4f1bc"
 dependencies = [
  "dashmap 6.1.0",
  "indexmap",
@@ -1048,9 +1048,9 @@ dependencies = [
 
 [[package]]
 name = "mir-issues"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b181842ae14347149ab6cbca7fdc9db7f7efae1669094de553ba88a5e766c358"
+checksum = "91868def910081bf77b47dfb7566917320c80d30dd6414ce1c9a4838b568e4a3"
 dependencies = [
  "mir-types",
  "owo-colors",
@@ -1060,9 +1060,9 @@ dependencies = [
 
 [[package]]
 name = "mir-types"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3791cb5d47867052c26d1b9b8b8fa81aeb7a255ccf5e582bb8443e395f0afb7b"
+checksum = "c028d464cb143807f389d3fb019f8991fe459bea961ec3b65ec2080eb131ac9c"
 dependencies = [
  "indexmap",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,10 +39,10 @@ dhat = { version = "0.3", optional = true }
 mimalloc = { version = "0.1", default-features = false }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
-mir-analyzer = "0.7.1"
-mir-issues = "0.7.1"
-mir-codebase = "0.7.1"
-mir-types = "0.7.1"
+mir-analyzer = "0.8.0"
+mir-issues = "0.8.0"
+mir-codebase = "0.8.0"
+mir-types = "0.8.0"
 php-rs-parser = "0.9.0"
 php-ast = "0.9.0"
 bumpalo = { version = "3", features = ["collections"] }

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -532,7 +532,10 @@ impl LanguageServer for Backend {
                     )
                     .await;
             }
-            cfg.php_version = Some(ver);
+            cfg.php_version = Some(ver.clone());
+            if let Ok(pv) = ver.parse::<mir_analyzer::PhpVersion>() {
+                self.docs.set_php_version(pv);
+            }
             *self.config.write().unwrap() = cfg;
         }
 
@@ -858,7 +861,10 @@ impl LanguageServer for Backend {
                     )
                     .await;
             }
-            cfg.php_version = Some(ver);
+            cfg.php_version = Some(ver.clone());
+            if let Ok(pv) = ver.parse::<mir_analyzer::PhpVersion>() {
+                self.docs.set_php_version(pv);
+            }
             *self.config.write().unwrap() = cfg;
         }
     }

--- a/src/db/codebase.rs
+++ b/src/db/codebase.rs
@@ -89,7 +89,11 @@ mod tests {
             Arc::<str>::from("<?php\nnamespace B;\nclass Bar {}"),
             None,
         );
-        let ws = Workspace::new(host.db(), Arc::from([f1, f2]));
+        let ws = Workspace::new(
+            host.db(),
+            Arc::from([f1, f2]),
+            mir_analyzer::PhpVersion::LATEST,
+        );
 
         let cb = codebase(host.db(), ws);
         assert!(cb.get().type_exists("A\\Foo"));
@@ -106,7 +110,7 @@ mod tests {
             Arc::<str>::from("<?php\nclass Before {}"),
             None,
         );
-        let ws = Workspace::new(host.db(), Arc::from([f1]));
+        let ws = Workspace::new(host.db(), Arc::from([f1]), mir_analyzer::PhpVersion::LATEST);
 
         let a1 = codebase(host.db(), ws);
         assert!(a1.get().type_exists("Before"));
@@ -130,7 +134,7 @@ mod tests {
             Arc::<str>::from("<?php\nclass X {}"),
             None,
         );
-        let ws = Workspace::new(host.db(), Arc::from([f1]));
+        let ws = Workspace::new(host.db(), Arc::from([f1]), mir_analyzer::PhpVersion::LATEST);
 
         let a1 = codebase(host.db(), ws);
         let a2 = codebase(host.db(), ws);

--- a/src/db/input.rs
+++ b/src/db/input.rs
@@ -2,6 +2,7 @@
 
 use std::sync::Arc;
 
+use mir_analyzer::PhpVersion;
 use mir_codebase::storage::StubSlice;
 
 /// Opaque file identifier used as a stable key for a source file across edits.
@@ -44,4 +45,8 @@ pub struct SourceFile {
 #[salsa::input]
 pub struct Workspace {
     pub files: Arc<[SourceFile]>,
+    /// Target PHP version for analysis. Changing this invalidates all
+    /// `semantic_issues` queries so diagnostics are re-evaluated against the
+    /// new version's rules.
+    pub php_version: PhpVersion,
 }

--- a/src/db/refs.rs
+++ b/src/db/refs.rs
@@ -94,6 +94,7 @@ pub fn file_refs(db: &dyn Database, ws: Workspace, file: SourceFile) -> FileRefs
             &map,
             &mut issue_buffer,
             &mut symbols,
+            ws.php_version(db),
         );
         let mut ctx = mir_analyzer::context::Context::new();
         analyzer.analyze_stmts(&doc.get().program().stmts, &mut ctx);
@@ -157,7 +158,11 @@ mod tests {
             Arc::<str>::from("<?php\ngreet();"),
             None,
         );
-        let ws = Workspace::new(host.db(), Arc::from([f1, f2]));
+        let ws = Workspace::new(
+            host.db(),
+            Arc::from([f1, f2]),
+            mir_analyzer::PhpVersion::LATEST,
+        );
 
         let locs = symbol_refs(host.db(), ws, "greet".to_string());
         let found: Vec<&str> = locs.get().iter().map(|(u, _, _)| u.as_ref()).collect();
@@ -178,7 +183,7 @@ mod tests {
             Arc::<str>::from("<?php\nfunction hi(): void {}\nhi();"),
             None,
         );
-        let ws = Workspace::new(host.db(), Arc::from([f1]));
+        let ws = Workspace::new(host.db(), Arc::from([f1]), mir_analyzer::PhpVersion::LATEST);
 
         let a = symbol_refs(host.db(), ws, "hi".to_string());
         let b = symbol_refs(host.db(), ws, "hi".to_string());

--- a/src/db/semantic.rs
+++ b/src/db/semantic.rs
@@ -59,6 +59,7 @@ pub fn semantic_issues(db: &dyn Database, ws: Workspace, file: SourceFile) -> Is
 
     let mut issue_buffer = mir_issues::IssueBuffer::new();
     let mut symbols = Vec::new();
+    let php_version = ws.php_version(db);
     let mut analyzer = mir_analyzer::stmt::StatementsAnalyzer::new(
         cb.get(),
         uri_arc,
@@ -66,6 +67,7 @@ pub fn semantic_issues(db: &dyn Database, ws: Workspace, file: SourceFile) -> Is
         &source_map,
         &mut issue_buffer,
         &mut symbols,
+        php_version,
     );
     let mut ctx = mir_analyzer::context::Context::new();
     analyzer.analyze_stmts(&doc.program().stmts, &mut ctx);
@@ -101,7 +103,11 @@ mod tests {
     fn semantic_issues_flags_undefined_function() {
         let host = AnalysisHost::new();
         let file = new_file(&host, 0, "file:///a.php", "<?php\nfoo_bar_baz();");
-        let ws = Workspace::new(host.db(), Arc::from([file]));
+        let ws = Workspace::new(
+            host.db(),
+            Arc::from([file]),
+            mir_analyzer::PhpVersion::LATEST,
+        );
         let issues = semantic_issues(host.db(), ws, file);
         assert!(
             issues
@@ -117,7 +123,11 @@ mod tests {
     fn semantic_issues_memoizes_across_calls() {
         let host = AnalysisHost::new();
         let file = new_file(&host, 0, "file:///a.php", "<?php\nfoo_bar_baz();");
-        let ws = Workspace::new(host.db(), Arc::from([file]));
+        let ws = Workspace::new(
+            host.db(),
+            Arc::from([file]),
+            mir_analyzer::PhpVersion::LATEST,
+        );
         let a = semantic_issues(host.db(), ws, file);
         let b = semantic_issues(host.db(), ws, file);
         assert!(
@@ -130,7 +140,11 @@ mod tests {
     fn semantic_issues_reruns_after_edit() {
         let mut host = AnalysisHost::new();
         let file = new_file(&host, 0, "file:///a.php", "<?php\nfoo_bar_baz();");
-        let ws = Workspace::new(host.db(), Arc::from([file]));
+        let ws = Workspace::new(
+            host.db(),
+            Arc::from([file]),
+            mir_analyzer::PhpVersion::LATEST,
+        );
         let a = semantic_issues(host.db(), ws, file);
         let first_ptr = Arc::as_ptr(&a.0);
         file.set_text(host.db_mut())

--- a/src/db/workspace_index.rs
+++ b/src/db/workspace_index.rs
@@ -210,7 +210,11 @@ mod tests {
             "file:///b.php",
             "<?php\nclass Dog extends Animal {}\nclass Cat extends Animal {}",
         );
-        let ws = Workspace::new(host.db(), Arc::from([f1, f2]));
+        let ws = Workspace::new(
+            host.db(),
+            Arc::from([f1, f2]),
+            mir_analyzer::PhpVersion::LATEST,
+        );
 
         let wi = workspace_index(host.db(), ws);
         let data = wi.get();
@@ -236,7 +240,7 @@ mod tests {
     fn workspace_index_memoizes_and_invalidates() {
         let mut host = AnalysisHost::new();
         let f1 = new_file(&host, 0, "file:///a.php", "<?php\nclass A {}");
-        let ws = Workspace::new(host.db(), Arc::from([f1]));
+        let ws = Workspace::new(host.db(), Arc::from([f1]), mir_analyzer::PhpVersion::LATEST);
 
         let a = workspace_index(host.db(), ws);
         let b = workspace_index(host.db(), ws);
@@ -263,7 +267,7 @@ mod tests {
             "class Hi implements Greeter { use Shouting; }\n",
         );
         let f = new_file(&host, 0, "file:///m.php", src);
-        let ws = Workspace::new(host.db(), Arc::from([f]));
+        let ws = Workspace::new(host.db(), Arc::from([f]), mir_analyzer::PhpVersion::LATEST);
         let wi = workspace_index(host.db(), ws);
         let data = wi.get();
 

--- a/src/document_store.rs
+++ b/src/document_store.rs
@@ -79,7 +79,11 @@ impl Default for DocumentStore {
 impl DocumentStore {
     pub fn new() -> Self {
         let host = AnalysisHost::new();
-        let workspace = Workspace::new(host.db(), Arc::<[SourceFile]>::from(Vec::new()));
+        let workspace = Workspace::new(
+            host.db(),
+            Arc::<[SourceFile]>::from(Vec::new()),
+            mir_analyzer::PhpVersion::LATEST,
+        );
         DocumentStore {
             token_cache: DashMap::new(),
             host: Mutex::new(host),
@@ -352,6 +356,18 @@ impl DocumentStore {
         }
         let arc: Arc<[SourceFile]> = Arc::from(files);
         self.workspace.set_files(host.db_mut()).to(arc);
+    }
+
+    /// Update the PHP version tracked by the workspace. Salsa will invalidate
+    /// all `semantic_issues` queries so diagnostics are re-evaluated.
+    /// Skips the setter when the version hasn't changed to avoid spurious
+    /// query invalidation.
+    pub fn set_php_version(&self, version: mir_analyzer::PhpVersion) {
+        let mut host = self.host.lock().unwrap();
+        if self.workspace.php_version(host.db()) == version {
+            return;
+        }
+        self.workspace.set_php_version(host.db_mut()).to(version);
     }
 
     /// Salsa-backed finalized Codebase. Aggregates every known file's

--- a/src/references.rs
+++ b/src/references.rs
@@ -1694,7 +1694,7 @@ mod tests {
             template_params: vec![],
             assertions: vec![],
             throws: vec![],
-            is_deprecated: false,
+            deprecated: None,
             is_internal: false,
             is_pure: false,
             location: None,
@@ -1723,7 +1723,7 @@ mod tests {
             is_final,
             is_readonly: false,
             all_parents: vec![],
-            is_deprecated: false,
+            deprecated: None,
             is_internal: false,
             // Synthetic user-code location so the fast path treats this as a
             // user class (stubs have `location: None` and are skipped).

--- a/src/semantic_diagnostics.rs
+++ b/src/semantic_diagnostics.rs
@@ -13,10 +13,8 @@ use crate::backend::DiagnosticsConfig;
 /// evicted and re-collected, then `finalize()` rebuilds inheritance tables.
 ///
 /// `php_version` is a version string like `"8.1"` sourced from `LspConfig`.
-/// It is threaded through here so callers are already wired correctly once
-/// `mir_analyzer` gains version-gating support.
+/// Parsed to `mir_analyzer::PhpVersion` and forwarded to `StatementsAnalyzer`.
 ///
-/// TODO: pass `php_version` to `mir_analyzer` once it exposes a version API.
 /// Legacy mutating path — runs `remove_file_definitions` + collect + finalize
 /// on the codebase. Kept for benchmarks (`benches/semantic.rs`) and as the
 /// reference implementation while Phase D wraps Pass-2 in salsa. Not used by
@@ -27,7 +25,7 @@ pub fn semantic_diagnostics(
     doc: &ParsedDoc,
     codebase: &mir_codebase::Codebase,
     cfg: &DiagnosticsConfig,
-    _php_version: Option<&str>,
+    php_version: Option<&str>,
 ) -> Vec<Diagnostic> {
     if !cfg.enabled {
         return vec![];
@@ -55,6 +53,9 @@ pub fn semantic_diagnostics(
     }
 
     // Pass 2: analyse function/method bodies in the current document.
+    let ver = php_version
+        .and_then(|s| s.parse::<mir_analyzer::PhpVersion>().ok())
+        .unwrap_or(mir_analyzer::PhpVersion::LATEST);
     let mut issue_buffer = mir_issues::IssueBuffer::new();
     let mut symbols = Vec::new();
     let mut analyzer = mir_analyzer::stmt::StatementsAnalyzer::new(
@@ -64,6 +65,7 @@ pub fn semantic_diagnostics(
         &source_map,
         &mut issue_buffer,
         &mut symbols,
+        ver,
     );
     let mut ctx = mir_analyzer::context::Context::new();
     {
@@ -96,7 +98,7 @@ pub fn semantic_diagnostics_no_rebuild(
     doc: &ParsedDoc,
     codebase: &mir_codebase::Codebase,
     cfg: &DiagnosticsConfig,
-    _php_version: Option<&str>,
+    php_version: Option<&str>,
 ) -> Vec<Diagnostic> {
     if !cfg.enabled {
         return vec![];
@@ -108,6 +110,9 @@ pub fn semantic_diagnostics_no_rebuild(
     // Pass 2 only: analyse function/method bodies.
     // The codebase is already finalized — skip remove/re-collect/finalize so
     // that inheritance tables are not torn down and rebuilt for every file.
+    let ver = php_version
+        .and_then(|s| s.parse::<mir_analyzer::PhpVersion>().ok())
+        .unwrap_or(mir_analyzer::PhpVersion::LATEST);
     let mut issue_buffer = mir_issues::IssueBuffer::new();
     let mut symbols = Vec::new();
     let mut analyzer = mir_analyzer::stmt::StatementsAnalyzer::new(
@@ -117,6 +122,7 @@ pub fn semantic_diagnostics_no_rebuild(
         &source_map,
         &mut issue_buffer,
         &mut symbols,
+        ver,
     );
     let mut ctx = mir_analyzer::context::Context::new();
     analyzer.analyze_stmts(&doc.program().stmts, &mut ctx);


### PR DESCRIPTION
## Summary

- Bumps `mir-analyzer`, `mir-issues`, `mir-codebase`, `mir-types` from 0.7.1 → 0.8.0
- Resolves the `TODO` in `semantic_diagnostics.rs`: `mir-analyzer` 0.8.0 added `PhpVersion` as a required argument to `StatementsAnalyzer::new()`, so the PHP version configured via `.php-lsp.json` / `initializationOptions` now actually gates analysis
- Adapts to the `mir-codebase` 0.8.0 API change: `is_deprecated: bool` → `deprecated: Option<Arc<str>>`

## What changed in the LSP

`PhpVersion` is now a tracked salsa input on `Workspace`. Changing the PHP version (e.g. user edits `.php-lsp.json` and triggers a config reload) automatically invalidates all `semantic_issues` queries so diagnostics are re-evaluated under the new version's rules.

The flow: `initialize` / `did_change_configuration` → `resolve_php_version` → `DocumentStore::set_php_version` → salsa `Workspace.php_version` → `semantic_issues` / `file_refs` → `StatementsAnalyzer::new(..., php_version)`.

## Test plan

- [ ] All existing tests pass (`cargo test`)
- [ ] Build is clean (`cargo build`)