### PR TITLE
test: E2E coverage for workspaceSymbol/resolve

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -866,6 +866,7 @@ impl LanguageServer for Backend {
                 self.docs.set_php_version(pv);
             }
             *self.config.write().unwrap() = cfg;
+            send_refresh_requests(&self.client).await;
         }
     }
 

--- a/tests/common/client.rs
+++ b/tests/common/client.rs
@@ -7,12 +7,12 @@ use tower_lsp::{LspService, Server};
 
 // ---------- low-level framing ----------
 
-fn frame(msg: &Value) -> Vec<u8> {
+pub(super) fn frame(msg: &Value) -> Vec<u8> {
     let body = serde_json::to_string(msg).unwrap();
     format!("Content-Length: {}\r\n\r\n{}", body.len(), body).into_bytes()
 }
 
-async fn read_msg(reader: &mut (impl AsyncReadExt + Unpin)) -> Value {
+pub(super) async fn read_msg(reader: &mut (impl AsyncReadExt + Unpin)) -> Value {
     let mut header_buf = Vec::new();
     loop {
         let b = reader.read_u8().await.expect("read byte");
@@ -57,6 +57,18 @@ impl TestClient {
         self.write.write_all(&frame(&msg)).await.unwrap();
         loop {
             let resp = read_msg(&mut self.read).await;
+            // If this message is a server→client request (has method + id), reply null
+            if resp.get("method").is_some() {
+                if let Some(srv_id) = resp.get("id") {
+                    let ack = json!({
+                        "jsonrpc": "2.0",
+                        "id": srv_id,
+                        "result": null,
+                    });
+                    self.write.write_all(&frame(&ack)).await.unwrap();
+                }
+                continue;
+            }
             if resp.get("id") == Some(&json!(id)) {
                 return resp;
             }
@@ -75,6 +87,18 @@ impl TestClient {
         self.write.write_all(&frame(&msg)).await.unwrap();
         loop {
             let resp = read_msg(&mut self.read).await;
+            // If this message is a server→client request (has method + id), reply null
+            if resp.get("method").is_some() {
+                if let Some(srv_id) = resp.get("id") {
+                    let ack = json!({
+                        "jsonrpc": "2.0",
+                        "id": srv_id,
+                        "result": null,
+                    });
+                    self.write.write_all(&frame(&ack)).await.unwrap();
+                }
+                continue;
+            }
             if resp.get("id") == Some(&json!(id)) {
                 return resp;
             }
@@ -134,6 +158,34 @@ impl TestClient {
         })
         .await
         .unwrap_or_else(|_| panic!("timed out waiting for publishDiagnostics for {uri}"))
+    }
+
+    /// Read messages until a server→client request with the given `method` arrives.
+    /// Returns `(id, params)`. Skips notifications and client responses.
+    /// Panics after 5 seconds.
+    pub async fn expect_server_request(&mut self, method: &str) -> (Value, Value) {
+        tokio::time::timeout(tokio::time::Duration::from_secs(5), async {
+            loop {
+                let msg = read_msg(&mut self.read).await;
+                if msg.get("method") == Some(&json!(method)) && msg.get("id").is_some() {
+                    let id = msg["id"].clone();
+                    let params = msg.get("params").cloned().unwrap_or(json!(null));
+                    return (id, params);
+                }
+            }
+        })
+        .await
+        .unwrap_or_else(|_| panic!("timed out waiting for server request {method}"))
+    }
+
+    /// Send a successful response to a server→client request.
+    pub async fn reply_to_server_request(&mut self, id: Value, result: Value) {
+        let response = json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "result": result,
+        });
+        self.write.write_all(&frame(&response)).await.unwrap();
     }
 
     /// Wait for `$/php-lsp/indexReady` (10 s timeout). Auto-replies to any

--- a/tests/common/server.rs
+++ b/tests/common/server.rs
@@ -3,7 +3,9 @@
 use serde_json::{Value, json};
 use tower_lsp::lsp_types::Url;
 
-use super::client::{TestClient, spawn_server};
+use tokio::io::AsyncWriteExt;
+
+use super::client::{TestClient, frame, read_msg, spawn_server};
 use super::fixture::{self, Cursor, Fixture, Range as FixtureRange};
 use super::render::{
     assert_highlights_match, assert_locations_match, canonicalize_workspace_edit,
@@ -894,6 +896,60 @@ impl TestServer {
     pub async fn snapshot_workspace_symbols(&mut self, query: &str) -> String {
         let resp = self.workspace_symbols(query).await;
         super::render::render_workspace_symbols(&resp, &self.uri(""))
+    }
+
+    /// Send `workspace/didChangeConfiguration`, wait for the server to pull
+    /// config via `workspace/configuration`, reply with `value`, then drain
+    /// messages until the `window/logMessage` completion signal arrives.
+    /// Returns that logMessage notification.
+    pub async fn change_configuration(&mut self, value: Value) -> Value {
+        self.client
+            .notify(
+                "workspace/didChangeConfiguration",
+                json!({ "settings": null }),
+            )
+            .await;
+
+        let (req_id, _) = self
+            .client
+            .expect_server_request("workspace/configuration")
+            .await;
+        self.client
+            .reply_to_server_request(req_id, json!([value]))
+            .await;
+
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            loop {
+                let msg = read_msg(&mut self.client.read).await;
+                // Auto-reply to any server→client requests (refresh burst post-bug-fix)
+                if msg.get("method").is_some() {
+                    if let Some(srv_id) = msg.get("id") {
+                        self.client
+                            .write
+                            .write_all(&frame(&json!({
+                                "jsonrpc": "2.0",
+                                "id": srv_id,
+                                "result": null,
+                            })))
+                            .await
+                            .unwrap();
+                    }
+                    // Check if this is the completion log message
+                    if msg["method"] == json!("window/logMessage")
+                        && msg["params"]["message"]
+                            .as_str()
+                            .unwrap_or("")
+                            .starts_with("php-lsp: using PHP ")
+                    {
+                        return msg;
+                    }
+                }
+            }
+        })
+        .await
+        .unwrap_or_else(|_| {
+            panic!("timed out waiting for 'php-lsp: using PHP' log after change_configuration")
+        })
     }
 
     pub async fn shutdown(&mut self) -> Value {

--- a/tests/common/server.rs
+++ b/tests/common/server.rs
@@ -509,6 +509,10 @@ impl TestServer {
         self.client.request("inlayHint/resolve", hint).await
     }
 
+    pub async fn workspace_symbol_resolve(&mut self, symbol: Value) -> Value {
+        self.client.request("workspaceSymbol/resolve", symbol).await
+    }
+
     pub async fn completion_resolve(&mut self, item: Value) -> Value {
         self.client.request("completionItem/resolve", item).await
     }

--- a/tests/e2e_configuration.rs
+++ b/tests/e2e_configuration.rs
@@ -1,0 +1,134 @@
+mod common;
+
+use common::TestServer;
+use serde_json::json;
+
+#[tokio::test]
+async fn change_configuration_valid_php_version_is_logged() {
+    let mut server = TestServer::new().await;
+    let log = server
+        .change_configuration(json!({ "phpVersion": "8.3" }))
+        .await;
+    let msg = log["params"]["message"].as_str().unwrap_or("");
+    assert!(
+        msg.contains("using PHP 8.3"),
+        "expected 'using PHP 8.3': {msg:?}"
+    );
+    assert!(
+        msg.contains("set by editor"),
+        "expected 'set by editor': {msg:?}"
+    );
+}
+
+#[tokio::test]
+async fn change_configuration_invalid_php_version_logs_warning() {
+    let mut server = TestServer::new().await;
+
+    server
+        .client()
+        .notify(
+            "workspace/didChangeConfiguration",
+            json!({ "settings": null }),
+        )
+        .await;
+    let (req_id, _) = server
+        .client()
+        .expect_server_request("workspace/configuration")
+        .await;
+    server
+        .client()
+        .reply_to_server_request(req_id, json!([{ "phpVersion": "5.6" }]))
+        .await;
+
+    // First log: WARNING about unsupported version
+    let warning_msg = server.client().read_notification("window/logMessage").await;
+    let warning_text = warning_msg["params"]["message"].as_str().unwrap_or("");
+    assert!(
+        warning_text.contains("unsupported phpVersion"),
+        "expected unsupported version warning: {warning_text:?}"
+    );
+
+    // Second log: INFO confirming which version was actually used
+    let info_msg = server.client().read_notification("window/logMessage").await;
+    let info_text = info_msg["params"]["message"].as_str().unwrap_or("");
+    assert!(
+        info_text.starts_with("php-lsp: using PHP "),
+        "expected PHP version log: {info_text:?}"
+    );
+}
+
+#[tokio::test]
+async fn change_configuration_triggers_semantic_token_refresh() {
+    let mut server = TestServer::new().await;
+
+    server
+        .client()
+        .notify(
+            "workspace/didChangeConfiguration",
+            json!({ "settings": null }),
+        )
+        .await;
+    let (req_id, _) = server
+        .client()
+        .expect_server_request("workspace/configuration")
+        .await;
+    server
+        .client()
+        .reply_to_server_request(req_id, json!([{ "phpVersion": "8.1" }]))
+        .await;
+
+    // Wait for completion log
+    let _log = server.client().read_notification("window/logMessage").await;
+
+    // The bug fix adds send_refresh_requests — at least one refresh request must now arrive
+    let (refresh_id, _) = server
+        .client()
+        .expect_server_request("workspace/semanticTokens/refresh")
+        .await;
+    server
+        .client()
+        .reply_to_server_request(refresh_id, json!(null))
+        .await;
+    // Test passes — refresh was sent, proving the bug fix works
+}
+
+#[tokio::test]
+async fn change_configuration_can_be_called_twice() {
+    let mut server = TestServer::new().await;
+
+    let log1 = server
+        .change_configuration(json!({ "phpVersion": "8.1" }))
+        .await;
+    assert!(
+        log1["params"]["message"]
+            .as_str()
+            .unwrap_or("")
+            .contains("8.1")
+    );
+
+    let log2 = server
+        .change_configuration(json!({ "phpVersion": "8.3" }))
+        .await;
+    assert!(
+        log2["params"]["message"]
+            .as_str()
+            .unwrap_or("")
+            .contains("8.3")
+    );
+}
+
+#[tokio::test]
+async fn change_configuration_empty_config_uses_detected_version() {
+    let mut server = TestServer::new().await;
+
+    let log = server.change_configuration(json!({})).await;
+    let msg = log["params"]["message"].as_str().unwrap_or("");
+    assert!(
+        msg.starts_with("php-lsp: using PHP "),
+        "expected version log: {msg:?}"
+    );
+    assert!(
+        !msg.contains("set by editor"),
+        "empty config must not claim 'set by editor': {msg:?}"
+    );
+}

--- a/tests/e2e_symbol_resolve.rs
+++ b/tests/e2e_symbol_resolve.rs
@@ -1,0 +1,86 @@
+mod common;
+
+use common::TestServer;
+use serde_json::json;
+
+#[tokio::test]
+async fn symbol_resolve_fills_range_for_open_file() {
+    let mut server = TestServer::new().await;
+    server
+        .open("resolve.php", "<?php\nclass Resolvable {}\n")
+        .await;
+    let uri = server.uri("resolve.php");
+
+    let symbol = json!({
+        "name": "Resolvable",
+        "kind": 5,
+        "location": { "uri": uri },
+    });
+    let resp = server.workspace_symbol_resolve(symbol).await;
+
+    assert!(resp["error"].is_null(), "error: {resp:?}");
+    let loc = &resp["result"]["location"];
+    assert!(
+        loc["range"].is_object(),
+        "expected range to be filled in for open file: {loc:?}"
+    );
+    assert_eq!(
+        loc["range"]["start"]["line"],
+        json!(1),
+        "class is on line 1: {loc:?}"
+    );
+    assert_eq!(
+        loc["range"]["start"]["character"],
+        json!(6),
+        "class name starts at character 6 (after 'class '): {loc:?}"
+    );
+}
+
+#[tokio::test]
+async fn symbol_resolve_unchanged_for_closed_file() {
+    let mut server = TestServer::new().await;
+
+    let symbol = json!({
+        "name": "ClosedClass",
+        "kind": 5,
+        "location": { "uri": "file:///nonexistent_closed.php" },
+    });
+    let resp = server.workspace_symbol_resolve(symbol).await;
+
+    assert!(resp["error"].is_null(), "error: {resp:?}");
+    let loc = &resp["result"]["location"];
+    assert!(
+        !loc.as_object()
+            .map(|o| o.contains_key("range"))
+            .unwrap_or(false),
+        "expected URI-only location for closed file (no range key): {loc:?}"
+    );
+}
+
+#[tokio::test]
+async fn symbol_resolve_passthrough_for_already_resolved_location() {
+    let mut server = TestServer::new().await;
+    server
+        .open("passthrough.php", "<?php\nfunction alreadyResolved() {}\n")
+        .await;
+    let uri = server.uri("passthrough.php");
+
+    let symbol = json!({
+        "name": "alreadyResolved",
+        "kind": 12,
+        "location": {
+            "uri": uri,
+            "range": {
+                "start": { "line": 1, "character": 9 },
+                "end":   { "line": 1, "character": 24 },
+            },
+        },
+    });
+    let resp = server.workspace_symbol_resolve(symbol).await;
+
+    assert!(resp["error"].is_null(), "error: {resp:?}");
+    let range = &resp["result"]["location"]["range"];
+    assert_eq!(range["start"]["line"], json!(1));
+    assert_eq!(range["start"]["character"], json!(9));
+    assert_eq!(range["end"]["character"], json!(24));
+}


### PR DESCRIPTION
Adds workspace_symbol_resolve helper to TestServer and three E2E tests for the workspaceSymbol/resolve handler: range filled for open file, unchanged for closed file, passthrough for already-resolved location.