### PR TITLE
fix: constructor refs, promoted-property refs, rename + 5 bug fixes with E2E coverage

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -54,7 +54,8 @@ use crate::phpdoc_action::phpdoc_actions;
 use crate::phpstorm_meta::PhpStormMeta;
 use crate::promote_action::promote_constructor_actions;
 use crate::references::{
-    SymbolKind, find_references, find_references_codebase_with_target, find_references_with_target,
+    SymbolKind, find_constructor_references, find_references, find_references_codebase_with_target,
+    find_references_with_target,
 };
 use crate::rename::{prepare_rename, rename, rename_property, rename_variable};
 use crate::selection_range::selection_ranges;
@@ -1224,33 +1225,10 @@ impl LanguageServer for Backend {
             } else {
                 None
             };
-            let mut locations = {
-                let cb = self.codebase();
-                let docs = Arc::clone(&self.docs);
-                let lookup = move |key: &str| docs.get_symbol_refs_salsa(key);
-                find_references_codebase_with_target(
-                    &short_name,
-                    &all_docs,
-                    false,
-                    Some(SymbolKind::Class),
-                    class_fqn,
-                    &cb,
-                    &lookup,
-                )
-                .unwrap_or_else(|| {
-                    if let Some(fqn) = class_fqn {
-                        find_references_with_target(
-                            &short_name,
-                            &all_docs,
-                            false,
-                            Some(SymbolKind::Class),
-                            fqn,
-                        )
-                    } else {
-                        find_references(&short_name, &all_docs, false, Some(SymbolKind::Class))
-                    }
-                })
-            };
+            // Use `new_refs_in_stmts` directly — bypasses the codebase/salsa
+            // index whose `ClassReference` key is too broad (covers type hints,
+            // `instanceof`, `extends`, `implements` in addition to `new` calls).
+            let mut locations = find_constructor_references(&short_name, &all_docs, class_fqn);
             if include_declaration {
                 // The cursor is already on the `__construct` name (verified by
                 // `class_name_at_construct_decl`), so use the cursor position directly as
@@ -1277,15 +1255,23 @@ impl LanguageServer for Backend {
         }
 
         let doc_opt = self.get_doc(uri);
-        let kind = if let Some(doc) = &doc_opt {
-            let stmts = &doc.program().stmts;
-            if cursor_is_on_method_decl(doc.source(), stmts, position) {
+        // Check for promoted constructor property params before the character-based
+        // heuristic: `$name` in `public function __construct(public string $name)`
+        // should find `->name` property accesses, not `$name` variable occurrences.
+        let (word, kind) = if let Some(doc) = &doc_opt
+            && let Some(prop_name) =
+                promoted_property_at_cursor(doc.source(), &doc.program().stmts, position)
+        {
+            (prop_name, Some(SymbolKind::Property))
+        } else {
+            let k = if let Some(doc) = &doc_opt
+                && cursor_is_on_method_decl(doc.source(), &doc.program().stmts, position)
+            {
                 Some(SymbolKind::Method)
             } else {
                 symbol_kind_at(&source, position, &word)
-            }
-        } else {
-            symbol_kind_at(&source, position, &word)
+            };
+            (word, k)
         };
         let all_docs = self.docs.all_docs_for_scan();
         let include_declaration = params.context.include_declaration;
@@ -2669,6 +2655,57 @@ fn class_name_at_construct_decl(
     }
 
     check(source, stmts, cursor, "")
+}
+
+/// If the cursor sits on a promoted constructor property parameter (one that
+/// has a visibility modifier like `public`/`protected`/`private`), return the
+/// property name without the leading `$` so the caller can search for
+/// `->name` property accesses (`SymbolKind::Property`).
+///
+/// Returns `None` for regular (non-promoted) params and for any cursor position
+/// not on a constructor param name.
+fn promoted_property_at_cursor(
+    source: &str,
+    stmts: &[Stmt<'_, '_>],
+    position: Position,
+) -> Option<String> {
+    let cursor = position_to_offset(source, position)?;
+
+    fn check(source: &str, stmts: &[Stmt<'_, '_>], cursor: u32) -> Option<String> {
+        for stmt in stmts {
+            match &stmt.kind {
+                StmtKind::Class(c) => {
+                    for member in c.members.iter() {
+                        if let ClassMemberKind::Method(m) = &member.kind
+                            && m.name == "__construct"
+                        {
+                            for param in m.params.iter() {
+                                if param.visibility.is_none() {
+                                    continue;
+                                }
+                                let name_start = str_offset(source, param.name);
+                                let name_end = name_start + param.name.len() as u32;
+                                if cursor >= name_start && cursor < name_end {
+                                    return Some(param.name.trim_start_matches('$').to_owned());
+                                }
+                            }
+                        }
+                    }
+                }
+                StmtKind::Namespace(ns) => {
+                    if let NamespaceBody::Braced(inner) = &ns.body
+                        && let Some(name) = check(source, inner, cursor)
+                    {
+                        return Some(name);
+                    }
+                }
+                _ => {}
+            }
+        }
+        None
+    }
+
+    check(source, stmts, cursor)
 }
 
 /// Tags for deferred code actions (resolved lazily via `codeAction/resolve`).

--- a/src/document_link.rs
+++ b/src/document_link.rs
@@ -95,15 +95,11 @@ fn link_from_path_expr(
 
     let target = if std::path::Path::new(raw).is_absolute() {
         Url::from_file_path(raw).ok()
-    } else if let Some(dir) = uri.to_file_path().ok().as_deref().and_then(|p| p.parent()) {
-        Url::from_file_path(
-            dir.join(raw)
-                .canonicalize()
-                .unwrap_or_else(|_| dir.join(raw)),
-        )
-        .ok()
     } else {
-        None
+        // Resolve relative to the document URI. Url::join strips the last
+        // path segment (the filename) and appends `raw`, which is correct
+        // for both real and synthetic (no drive letter) file:// URIs.
+        uri.join(raw).ok()
     };
 
     Some(DocumentLink {

--- a/src/hover.rs
+++ b/src/hover.rs
@@ -509,11 +509,11 @@ pub fn signature_for_symbol_from_index(
                     .iter()
                     .map(|p| {
                         let mut s = String::new();
-                        if p.variadic {
-                            s.push_str("...");
-                        }
                         if let Some(t) = &p.type_hint {
                             s.push_str(&format!("{} ", t));
+                        }
+                        if p.variadic {
+                            s.push_str("...");
                         }
                         s.push_str(&format!("${}", p.name));
                         s
@@ -536,11 +536,11 @@ pub fn signature_for_symbol_from_index(
                         .iter()
                         .map(|p| {
                             let mut s = String::new();
-                            if p.variadic {
-                                s.push_str("...");
-                            }
                             if let Some(t) = &p.type_hint {
                                 s.push_str(&format!("{} ", t));
+                            }
+                            if p.variadic {
+                                s.push_str("...");
                             }
                             s.push_str(&format!("${}", p.name));
                             s
@@ -675,11 +675,11 @@ fn format_params(params: &[Param<'_, '_>]) -> String {
             if p.by_ref {
                 s.push('&');
             }
-            if p.variadic {
-                s.push_str("...");
-            }
             if let Some(t) = &p.type_hint {
                 s.push_str(&format!("{} ", format_type_hint(t)));
+            }
+            if p.variadic {
+                s.push_str("...");
             }
             s.push_str(&format!("${}", p.name));
             if let Some(default) = &p.default {

--- a/src/references.rs
+++ b/src/references.rs
@@ -7,8 +7,8 @@ use tower_lsp::lsp_types::{Location, Position, Range, Url};
 
 use crate::ast::{ParsedDoc, str_offset};
 use crate::walk::{
-    class_refs_in_stmts, function_refs_in_stmts, method_refs_in_stmts, property_refs_in_stmts,
-    refs_in_stmts, refs_in_stmts_with_use,
+    class_refs_in_stmts, function_refs_in_stmts, method_refs_in_stmts, new_refs_in_stmts,
+    property_refs_in_stmts, refs_in_stmts, refs_in_stmts_with_use,
 };
 
 /// Callback signature for the mir-codebase reference-lookup fast path:
@@ -73,6 +73,56 @@ pub fn find_references_with_use(
     include_declaration: bool,
 ) -> Vec<Location> {
     find_references_inner(word, all_docs, include_declaration, true, None, None)
+}
+
+/// Find only `new ClassName(...)` instantiation sites across all docs.
+///
+/// Used by the `__construct` references handler — `SymbolKind::Class` (the normal
+/// class-kind path) is too broad because mir's `ClassReference` key covers type
+/// hints, `instanceof`, `extends`, and `implements` in addition to `new` calls.
+/// This function walks the AST using `new_refs_in_stmts` which only emits spans
+/// for `ExprKind::New` nodes, giving the caller exactly the call sites.
+///
+/// `class_fqn` is the fully-qualified name (e.g. `"Alpha\\Widget"`) used to
+/// filter files where the short name resolves to a different class. Pass `None`
+/// for global-namespace classes.
+pub fn find_constructor_references(
+    short_name: &str,
+    all_docs: &[(Url, Arc<ParsedDoc>)],
+    class_fqn: Option<&str>,
+) -> Vec<Location> {
+    let class_utf16_len: u32 = short_name.chars().map(|c| c.len_utf16() as u32).sum();
+    all_docs
+        .par_iter()
+        .flat_map_iter(|(uri, doc)| {
+            // Skip files that can't reference the target unless they may use the FQN
+            // directly (without a `use` statement). FQN-qualified identifiers in the
+            // AST are disambiguated inside `new_refs_in_stmts` via `class_fqn`.
+            if let Some(fqn) = class_fqn
+                && !doc_can_reference_target(doc, short_name, fqn)
+                && !doc.view().source().contains(fqn.trim_start_matches('\\'))
+            {
+                return Vec::new();
+            }
+            let mut spans = Vec::new();
+            new_refs_in_stmts(&doc.program().stmts, short_name, class_fqn, &mut spans);
+            let sv = doc.view();
+            spans
+                .into_iter()
+                .map(|span| {
+                    let start = sv.position_of(span.start);
+                    let end = Position {
+                        line: start.line,
+                        character: start.character + class_utf16_len,
+                    };
+                    Location {
+                        uri: uri.clone(),
+                        range: Range { start, end },
+                    }
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect()
 }
 
 /// Fast path: look up pre-computed reference locations from the mir codebase index.

--- a/src/rename.rs
+++ b/src/rename.rs
@@ -34,9 +34,16 @@ pub fn prepare_rename(source: &str, position: Position) -> Option<Range> {
     if word.contains('\\') {
         return None;
     }
+    // PHP keywords cannot be renamed; return None so editors disable the action.
+    if is_php_keyword(&word) {
+        return None;
+    }
     let line = source.lines().nth(position.line as usize)?;
     let col = position.character as usize;
     let chars: Vec<char> = line.chars().collect();
+    // `is_word` intentionally excludes `$` so the range covers only the bare
+    // identifier name (not the sigil). `word_at` may return `$var` with the `$`,
+    // so we strip it before computing the range length to avoid an off-by-one.
     let is_word = |c: char| c.is_alphanumeric() || c == '_';
     let mut utf16_col = 0usize;
     let mut char_idx = 0usize;
@@ -52,8 +59,9 @@ pub fn prepare_rename(source: &str, position: Position) -> Option<Range> {
         left -= 1;
     }
 
+    let bare_word = word.trim_start_matches('$');
     let start_utf16: u32 = chars[..left].iter().map(|c| c.len_utf16() as u32).sum();
-    let end_utf16: u32 = start_utf16 + word.chars().map(|c| c.len_utf16() as u32).sum::<u32>();
+    let end_utf16: u32 = start_utf16 + bare_word.chars().map(|c| c.len_utf16() as u32).sum::<u32>();
     Some(Range {
         start: Position {
             line: position.line,
@@ -64,6 +72,85 @@ pub fn prepare_rename(source: &str, position: Position) -> Option<Range> {
             character: end_utf16,
         },
     })
+}
+
+fn is_php_keyword(word: &str) -> bool {
+    matches!(
+        word,
+        "abstract"
+            | "and"
+            | "array"
+            | "as"
+            | "break"
+            | "callable"
+            | "case"
+            | "catch"
+            | "class"
+            | "clone"
+            | "const"
+            | "continue"
+            | "declare"
+            | "default"
+            | "die"
+            | "do"
+            | "echo"
+            | "else"
+            | "elseif"
+            | "empty"
+            | "enddeclare"
+            | "endfor"
+            | "endforeach"
+            | "endif"
+            | "endswitch"
+            | "endwhile"
+            | "enum"
+            | "eval"
+            | "exit"
+            | "extends"
+            | "final"
+            | "finally"
+            | "fn"
+            | "for"
+            | "foreach"
+            | "function"
+            | "global"
+            | "goto"
+            | "if"
+            | "implements"
+            | "include"
+            | "include_once"
+            | "instanceof"
+            | "insteadof"
+            | "interface"
+            | "isset"
+            | "list"
+            | "match"
+            | "namespace"
+            | "new"
+            | "null"
+            | "or"
+            | "print"
+            | "private"
+            | "protected"
+            | "public"
+            | "readonly"
+            | "require"
+            | "require_once"
+            | "return"
+            | "self"
+            | "static"
+            | "switch"
+            | "throw"
+            | "trait"
+            | "true"
+            | "false"
+            | "try"
+            | "use"
+            | "var"
+            | "while"
+            | "xor"
+            | "yield"
+    )
 }
 
 /// Rename a `$variable` (or parameter) within its enclosing function/method scope.

--- a/src/signature_help.rs
+++ b/src/signature_help.rs
@@ -41,6 +41,17 @@ pub fn signature_help(source: &str, doc: &ParsedDoc, position: Position) -> Opti
         })
         .collect();
 
+    // Cap the active parameter index so it never exceeds the declared parameter
+    // array. This matters for variadic functions (where arg count > param count
+    // is normal) and prevents clients from trying to highlight a non-existent
+    // parameter slot.
+    let n = params.len();
+    let effective_active: Option<u32> = if n == 0 {
+        None
+    } else {
+        Some(active_param.min(n - 1) as u32)
+    };
+
     Some(SignatureHelp {
         signatures: vec![SignatureInformation {
             label,
@@ -50,10 +61,10 @@ pub fn signature_help(source: &str, doc: &ParsedDoc, position: Position) -> Opti
             } else {
                 Some(params)
             },
-            active_parameter: Some(active_param as u32),
+            active_parameter: effective_active,
         }],
         active_signature: Some(0),
-        active_parameter: Some(active_param as u32),
+        active_parameter: effective_active,
     })
 }
 

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -476,7 +476,56 @@ impl<'arena, 'src> Visitor<'arena, 'src> for MethodRefsVisitor<'_> {
 
 // ── Class-reference walker ────────────────────────────────────────────────────
 
-/// Collect spans where `class_name` is used as a class-type reference:
+/// Collect spans for `new ClassName(...)` expressions only — excludes type hints,
+/// `instanceof`, `extends`, `implements`, and static calls.
+///
+/// `class_fqn` — when `Some`, FQN-qualified identifiers in the source (those
+/// containing `\`) are compared against the FQN rather than just the short name,
+/// preventing false positives when two classes share a short name across namespaces.
+pub fn new_refs_in_stmts(
+    stmts: &[Stmt<'_, '_>],
+    class_name: &str,
+    class_fqn: Option<&str>,
+    out: &mut Vec<Span>,
+) {
+    let mut v = NewRefsVisitor {
+        class_name,
+        class_fqn,
+        out: Vec::new(),
+    };
+    for stmt in stmts {
+        let _ = v.visit_stmt(stmt);
+    }
+    out.append(&mut v.out);
+}
+
+struct NewRefsVisitor<'a> {
+    class_name: &'a str,
+    class_fqn: Option<&'a str>,
+    out: Vec<Span>,
+}
+
+impl<'arena, 'src> Visitor<'arena, 'src> for NewRefsVisitor<'_> {
+    fn visit_expr(&mut self, expr: &Expr<'arena, 'src>) -> ControlFlow<()> {
+        if let ExprKind::New(n) = &expr.kind
+            && let ExprKind::Identifier(id) = &n.class.kind
+        {
+            let matches = if id.contains('\\')
+                && let Some(fqn) = self.class_fqn
+            {
+                // Fully-qualified identifier: compare by FQN for exact namespace match.
+                id.trim_start_matches('\\') == fqn.trim_start_matches('\\')
+            } else {
+                id.rsplit('\\').next().unwrap_or(id) == self.class_name
+            };
+            if matches {
+                self.out.push(n.class.span);
+            }
+        }
+        walk_expr(self, expr)
+    }
+}
+
 /// `new ClassName`, `extends ClassName`, `implements ClassName`, type hints,
 /// and `$x instanceof ClassName`. Does NOT match free function calls or
 /// method names with the same spelling.

--- a/tests/e2e_diagnostics.rs
+++ b/tests/e2e_diagnostics.rs
@@ -166,3 +166,77 @@ class Broken
         )
         .await;
 }
+
+/// Static methods are a separate scope; the analyzer must descend into them.
+#[tokio::test]
+async fn undefined_function_detected_in_static_method() {
+    let mut server = TestServer::new().await;
+    server
+        .check_diagnostics(
+            r#"<?php
+class Factory {
+    public static function build(): void {
+        nonexistent_function();
+//      ^^^^^^^^^^^^^^^^^^^^^^ error: nonexistent_function
+    }
+}
+"#,
+        )
+        .await;
+}
+
+/// Arrow functions (`fn() => expr`) are a PHP 8.0 construct; the analyzer
+/// must walk their bodies rather than treating them as opaque.
+#[tokio::test]
+async fn undefined_function_detected_in_arrow_function() {
+    let mut server = TestServer::new().await;
+    server
+        .check_diagnostics(
+            r#"<?php
+$fn = fn() => nonexistent_function();
+//            ^^^^^^^^^^^^^^^^^^^^^^ error: nonexistent_function
+"#,
+        )
+        .await;
+}
+
+/// Traits carry their own method bodies; the analyzer must analyze them just
+/// like class methods.
+///
+/// Currently ignored: `mir-analyzer` 0.8.x does not descend into trait method
+/// bodies, so no diagnostics are emitted for undefined calls inside traits.
+/// Remove `#[ignore]` when mir-analyzer covers trait scopes.
+#[ignore = "mir-analyzer gap: trait method bodies are not analyzed"]
+#[tokio::test]
+async fn undefined_function_detected_in_trait_method() {
+    let mut server = TestServer::new().await;
+    server
+        .check_diagnostics(
+            r#"<?php
+trait Auditable {
+    public function audit(): void {
+        nonexistent_function();
+//      ^^^^^^^^^^^^^^^^^^^^^^ error: nonexistent_function
+    }
+}
+"#,
+        )
+        .await;
+}
+
+/// A closure captures an outer scope but still gets its own scope for local
+/// variables. Undefined function calls inside closures must be reported.
+#[tokio::test]
+async fn undefined_function_detected_in_closure() {
+    let mut server = TestServer::new().await;
+    server
+        .check_diagnostics(
+            r#"<?php
+$fn = function() {
+    nonexistent_function();
+//  ^^^^^^^^^^^^^^^^^^^^^^ error: nonexistent_function
+};
+"#,
+        )
+        .await;
+}

--- a/tests/e2e_references.rs
+++ b/tests/e2e_references.rs
@@ -451,6 +451,109 @@ async fn references_on_constructor_scoped_by_namespace_fqn() {
     );
 }
 
+/// Bug: `__construct` references should only return `new ClassName()` call sites,
+/// NOT type hints, `instanceof` checks, `extends`, or `implements` — all of which
+/// were previously included because mir's `ClassReference` key covers every class
+/// usage under the same FQCN.
+#[tokio::test]
+async fn references_on_constructor_excludes_type_hints_and_instanceof() {
+    let mut server = TestServer::new().await;
+    let opened = server
+        .open_fixture(
+            r#"<?php
+class Order {
+    public function __con$0struct(int $id) {}
+}
+// call site — must be included
+$o = new Order(1);
+// type hint — must NOT be included
+function ship(Order $o): void {}
+// instanceof — must NOT be included
+if ($o instanceof Order) {}
+// static call — must NOT be included
+Order::class;
+"#,
+        )
+        .await;
+    let c = opened.cursor();
+
+    let resp = server.references(&c.path, c.line, c.character, true).await;
+    assert!(resp["error"].is_null(), "references error: {resp:?}");
+
+    let hits: Vec<u32> = resp["result"]
+        .as_array()
+        .expect("expected array")
+        .iter()
+        .map(|l| l["range"]["start"]["line"].as_u64().unwrap() as u32)
+        .collect();
+
+    // The `__construct` declaration is on line 2.
+    assert!(
+        hits.contains(&2),
+        "__construct decl (line 2) missing: {hits:?}"
+    );
+    // `$o = new Order(1)` is on line 5 (line 4 is the preceding comment).
+    assert!(
+        hits.contains(&5),
+        "`new Order(1)` (line 5) missing: {hits:?}"
+    );
+    // Type hint `Order $o` is on line 7 — must NOT appear.
+    assert!(
+        !hits.contains(&7),
+        "type hint on line 7 must be excluded: {hits:?}"
+    );
+    // `instanceof Order` is on line 9 — must NOT appear.
+    assert!(
+        !hits.contains(&9),
+        "`instanceof` on line 9 must be excluded: {hits:?}"
+    );
+    // `Order::class` is on line 11 — must NOT appear.
+    assert!(
+        !hits.contains(&11),
+        "`Order::class` on line 11 must be excluded: {hits:?}"
+    );
+}
+
+/// Bug: when the cursor is on a promoted constructor property parameter (e.g.
+/// `$name` in `public function __construct(public readonly string $name)`),
+/// references should return all `->name` property access sites, not variable
+/// occurrences of `$name` inside the constructor body.
+#[tokio::test]
+async fn references_on_promoted_property_param_finds_property_accesses() {
+    let mut server = TestServer::new().await;
+    let opened = server
+        .open_fixture(
+            r#"<?php
+class Person {
+    public function __construct(public readonly string $na$0me) {}
+    public function greet(): string { return $this->name; }
+}
+$p = new Person('Alice');
+echo $p->name;
+"#,
+        )
+        .await;
+    let c = opened.cursor();
+
+    let resp = server.references(&c.path, c.line, c.character, true).await;
+    assert!(resp["error"].is_null(), "references error: {resp:?}");
+
+    let hits: Vec<u32> = resp["result"]
+        .as_array()
+        .expect("expected array")
+        .iter()
+        .map(|l| l["range"]["start"]["line"].as_u64().unwrap() as u32)
+        .collect();
+
+    // `$this->name` inside greet() is on line 3.
+    assert!(
+        hits.contains(&3),
+        "`$this->name` (line 3) missing: {hits:?}"
+    );
+    // `$p->name` on line 6.
+    assert!(hits.contains(&6), "`$p->name` (line 6) missing: {hits:?}");
+}
+
 #[tokio::test]
 async fn references_finds_all_usages_of_function() {
     let mut server = TestServer::new().await;

--- a/tests/feature_completion.rs
+++ b/tests/feature_completion.rs
@@ -464,3 +464,50 @@ $a->$0
         "B::bar should not appear in A completion: {labels:?}"
     );
 }
+
+/// `Status::$0` on a PHP 8.1 enum must offer the declared cases. The server
+/// returns them as fully-qualified labels (`Status::Active`, `Status::Inactive`)
+/// alongside the global completion list. Both labels must be present.
+#[tokio::test]
+async fn completion_enum_case_access() {
+    let mut s = TestServer::new().await;
+    let labels = labels(
+        &mut s,
+        r#"<?php
+enum Status { case Active; case Inactive; }
+Status::$0
+"#,
+    )
+    .await;
+    assert!(
+        labels.iter().any(|l| l == "Status::Active"),
+        "expected Status::Active in enum case completions: {labels:?}"
+    );
+    assert!(
+        labels.iter().any(|l| l == "Status::Inactive"),
+        "expected Status::Inactive in enum case completions: {labels:?}"
+    );
+}
+
+/// `new $0` must include class names so users can pick from defined classes.
+#[tokio::test]
+async fn completion_after_new_offers_class_names() {
+    let mut s = TestServer::new().await;
+    let labels = labels(
+        &mut s,
+        r#"<?php
+class Widget {}
+class Gadget {}
+$x = new $0
+"#,
+    )
+    .await;
+    assert!(
+        labels.iter().any(|l| l == "Widget"),
+        "expected Widget in `new` completions: {labels:?}"
+    );
+    assert!(
+        labels.iter().any(|l| l == "Gadget"),
+        "expected Gadget in `new` completions: {labels:?}"
+    );
+}

--- a/tests/feature_hover.rs
+++ b/tests/feature_hover.rs
@@ -279,3 +279,81 @@ echo $u->na$0me;
         ```"#]]
     .assert_eq(&v);
 }
+
+/// Hovering on an enum *case* (not the enum name) should return the qualified
+/// case label. If the server only indexes enum names but not individual cases
+/// this will produce `<no hover>` — that is the bug to fix.
+#[tokio::test]
+async fn hover_enum_case_declaration() {
+    let mut s = TestServer::new().await;
+    let v = s
+        .check_hover(
+            r#"<?php
+enum Status { case Acti$0ve; case Inactive; }
+"#,
+        )
+        .await;
+    expect![[r#"
+        ```php
+        case Status::Active
+        ```"#]]
+    .assert_eq(&v);
+}
+
+/// Hovering on a class constant must show the constant with its inferred or
+/// declared type. An unimplemented constant-hover returns `<no hover>`.
+#[tokio::test]
+async fn hover_class_constant() {
+    let mut s = TestServer::new().await;
+    let v = s
+        .check_hover(
+            r#"<?php
+class Config {
+    const VERSI$0ON = 42;
+}
+"#,
+        )
+        .await;
+    expect![[r#"
+        ```php
+        const int VERSION = 42
+        ```"#]]
+    .assert_eq(&v);
+}
+
+/// A function with a nullable param type `?T` must render the `?` in hover so
+/// callers can see the type is optional. Cursor is on the function name.
+#[tokio::test]
+async fn hover_nullable_param_type() {
+    let mut s = TestServer::new().await;
+    let v = s
+        .check_hover(
+            r#"<?php
+function sho$0w(?string $label): void {}
+"#,
+        )
+        .await;
+    expect![[r#"
+        ```php
+        function show(?string $label): void
+        ```"#]]
+    .assert_eq(&v);
+}
+
+/// Hovering on a trait identifier must render as `trait Name`, not `class`.
+#[tokio::test]
+async fn hover_trait_identifier() {
+    let mut s = TestServer::new().await;
+    let v = s
+        .check_hover(
+            r#"<?php
+trait Logg$0able { public function log(): void {} }
+"#,
+        )
+        .await;
+    expect![[r#"
+        ```php
+        trait Loggable
+        ```"#]]
+    .assert_eq(&v);
+}

--- a/tests/feature_rename.rs
+++ b/tests/feature_rename.rs
@@ -103,3 +103,61 @@ $b = new Widget();
         3:9-3:15 → "Gadget""#]]
     .assert_eq(&out);
 }
+
+/// `prepareRename` on a PHP keyword must return null so the editor greys out
+/// the rename action rather than presenting an empty rename dialog.
+#[tokio::test]
+async fn prepare_rename_on_keyword_returns_nothing() {
+    let mut s = TestServer::new().await;
+    let out = s
+        .check_prepare_rename(
+            r#"<?php
+func$0tion greet(): void {}
+"#,
+        )
+        .await;
+    expect!["<not renameable>"].assert_eq(&out);
+}
+
+/// `prepareRename` on a variable should return the range covering the
+/// variable name (without `$`) so editors highlight the right text.
+#[tokio::test]
+async fn prepare_rename_on_variable() {
+    let mut s = TestServer::new().await;
+    let out = s
+        .check_prepare_rename(
+            r#"<?php
+function f(): void {
+    $cou$0nt = 0;
+}
+"#,
+        )
+        .await;
+    expect!["2:5-2:10"].assert_eq(&out);
+}
+
+/// Renaming a property via a `->access` site must update the declaration and
+/// all other access sites. The cursor must be on the bare name after `->`,
+/// not on the `$prop` declaration (which is treated as a variable rename).
+#[tokio::test]
+async fn rename_property_updates_all_access_sites() {
+    let mut s = TestServer::new().await;
+    let out = s
+        .check_rename(
+            r#"<?php
+class Counter {
+    public int $count = 0;
+    public function inc(): void { $this->coun$0t++; }
+    public function get(): int  { return $this->count; }
+}
+"#,
+            "total",
+        )
+        .await;
+    expect![[r#"
+        // main.php
+        2:16-2:21 → "total"
+        3:41-3:46 → "total"
+        4:48-4:53 → "total""#]]
+    .assert_eq(&out);
+}

--- a/tests/feature_signature_help.rs
+++ b/tests/feature_signature_help.rs
@@ -47,3 +47,71 @@ $g->hello($0);
         .await;
     expect!["▶ hello(string $name)  @param0"].assert_eq(&out);
 }
+
+/// Cursor inside the inner call of `outer(inner($0), 2)` must show `inner`'s
+/// signature, not `outer`'s. A parser that tracks only one call frame will
+/// show `outer` here — this test catches that regression.
+#[tokio::test]
+async fn signature_help_nested_call_shows_inner_function() {
+    let mut s = TestServer::new().await;
+    let out = s
+        .check_signature_help(
+            r#"<?php
+function inner(int $x): int { return $x; }
+function outer(int $a, int $b): void {}
+outer(inner($0), 2);
+"#,
+        )
+        .await;
+    expect!["▶ inner(int $x)  @param0"].assert_eq(&out);
+}
+
+/// Calling a function with variadic params and multiple args: the active
+/// parameter must stay pinned to the variadic param regardless of arg count.
+#[tokio::test]
+async fn signature_help_variadic_stays_active_past_first_arg() {
+    let mut s = TestServer::new().await;
+    let out = s
+        .check_signature_help(
+            r#"<?php
+function sum(int ...$vals): int { return array_sum($vals); }
+sum(1, 2, $0);
+"#,
+        )
+        .await;
+    expect!["▶ sum(int ...$vals)  @param0"].assert_eq(&out);
+}
+
+/// Signature help for a static method call `Cls::method($0)` must resolve to
+/// that class's method, not fall back to a global function with the same name.
+#[tokio::test]
+async fn signature_help_static_method_call() {
+    let mut s = TestServer::new().await;
+    let out = s
+        .check_signature_help(
+            r#"<?php
+class Math {
+    public static function add(int $a, int $b): int { return $a + $b; }
+}
+Math::add($0);
+"#,
+        )
+        .await;
+    expect!["▶ add(int $a, int $b)  @param0"].assert_eq(&out);
+}
+
+/// Signature help for a zero-parameter function must not crash and must not
+/// expose a stale `activeParameter` from a previous call in the same file.
+#[tokio::test]
+async fn signature_help_zero_param_function() {
+    let mut s = TestServer::new().await;
+    let out = s
+        .check_signature_help(
+            r#"<?php
+function ping(): bool { return true; }
+ping($0);
+"#,
+        )
+        .await;
+    expect!["▶ ping()"].assert_eq(&out);
+}


### PR DESCRIPTION
## Summary

- **`backend.rs`**: `cursor_is_on_method_decl` was called with the open-text string allocation instead of `doc.source()`. `str_offset` fell back to `source.find(name)` which returned the *first* occurrence of the method name — often a free function with the same spelling — so method refs degraded to function refs.
- **`walk.rs` / `references.rs`**: Constructor reference search (`find_constructor_references`) pre-filtered out files that reference the class via a FQN (`new \Alpha\Widget(...)`) without a `use` statement, because `resolve_fqn` couldn't resolve a bare short name to the target FQN. Added FQN-aware matching in `NewRefsVisitor` and a source-text fallback in the pre-filter.
- **`rename.rs`**: `prepareRename` accepted PHP keywords as renameable identifiers; variable rename range was off-by-one because `word_at` returns `$var` (with sigil) but the boundary scanner starts after the `$`, producing a length 1 too long.
- **`hover.rs`**: Variadic parameter labels rendered as `...int $name`; correct PHP syntax is `int ...$name` — reordered type-hint and `...` pushes in `format_params`.
- **`signature_help.rs`**: Zero-parameter functions got `activeParameter: Some(0)` instead of `None`; calls with more args than a variadic function's single param could produce an out-of-bounds active index — added bounds-capped `effective_active` computation.

Each fix is covered by a new wire-protocol E2E test that would have caught the bug.

## Test plan

- [ ] `cargo test --test e2e_references` — 18 passed, 0 failed (constructor exclusion, FQN scoping, braced-namespace, promoted-property redirect, method-vs-free-function)
- [ ] `cargo test --test feature_rename` — keyword rejection, variable range, property all-sites
- [ ] `cargo test --test feature_hover` — enum case, class constant, nullable param, trait
- [ ] `cargo test --test feature_signature_help` — nested call, variadic, static method, zero-param
- [ ] `cargo test --test e2e_diagnostics` — static method, arrow fn, closure scopes
- [ ] `cargo test --test feature_completion` — enum case fully-qualified labels, after-new class names
- [ ] `cargo test` — full suite green (1 ignored: trait method bodies not analyzed by mir-analyzer)