### PR TITLE
fix: normalise leading backslash in namespace-prefix completion

### DIFF
--- a/src/completion/mod.rs
+++ b/src/completion/mod.rs
@@ -501,7 +501,7 @@ pub fn filtered_completions_at(
                 // Check we're NOT in a use statement
                 let is_use = use_completion_prefix(src, pos).is_some();
                 if !is_use {
-                    let prefix_lc = prefix.to_lowercase();
+                    let prefix_lc = prefix.trim_start_matches('\\').to_lowercase();
                     let mut ns_items: Vec<CompletionItem> = Vec::new();
                     for other in other_docs {
                         let mut classes = Vec::new();

--- a/tests/feature_completion.rs
+++ b/tests/feature_completion.rs
@@ -391,7 +391,6 @@ Reg::$0
     .assert_eq(&out);
 }
 
-#[ignore = "php-lsp gap: namespace-prefix completion returns nothing without a workspace root / PSR-4 map"]
 #[tokio::test]
 async fn completion_namespace_prefix() {
     let mut s = TestServer::new().await;


### PR DESCRIPTION
## Summary

- `typed_prefix()` returns the raw typed text including a leading `\` (e.g. `\App\`), but FQNs stored internally never carry one (`App\Greeter`).
- Feature 3 in `filtered_completions_at` was calling `prefix.to_lowercase()` directly, making the prefix-length comparison match the wrong substring — so `\App\` (5 chars) was checked against `fqn.get(..5)` = `"App\G"` instead of the correct `"App\"`.
- The late-stage filter at line 647 already called `trim_start_matches('\\')` — the fix is a one-liner that makes Feature 3 consistent with it.

No PSR-4 map or workspace root is needed: both files are in `other_docs` via `textDocument/didOpen`, and `collect_classes_with_ns` already builds the correct FQNs from parsed AST.

## Test plan

- [ ] `cargo test completion_namespace_prefix` — previously ignored, now passes
- [ ] `cargo test --test feature_completion` — all 15 tests pass, no regressions