### PR TITLE
test: E2E coverage for argument-count and type-mismatch diagnostics

### DIFF
--- a/tests/e2e_diagnostics.rs
+++ b/tests/e2e_diagnostics.rs
@@ -240,3 +240,60 @@ $fn = function() {
         )
         .await;
 }
+
+/// Passing too few arguments to a user-defined function is flagged as
+/// `InvalidArgument` (the same code used for type mismatches). The diagnostic
+/// spans the whole call expression.
+#[tokio::test]
+async fn argument_count_too_few_detected() {
+    let mut server = TestServer::new().await;
+    server
+        .check_diagnostics(
+            r#"<?php
+function needs_two(string $a, string $b): void {}
+function wrap(): void {
+    needs_two('x');
+//  ^^^^^^^^^^^^^^ error: needs_two
+}
+"#,
+        )
+        .await;
+}
+
+/// Passing a value of the wrong type to a typed parameter emits `InvalidArgument`.
+/// The diagnostic range covers the offending argument expression.
+#[tokio::test]
+async fn argument_type_mismatch_detected() {
+    let mut server = TestServer::new().await;
+    server
+        .check_diagnostics(
+            r#"<?php
+function takes_string(string $s): void {}
+function wrap(): void {
+    takes_string(42);
+//               ^^ error: takes_string
+}
+"#,
+        )
+        .await;
+}
+
+/// Passing too *many* arguments to a user-defined function — a genuine arity
+/// over-application — is not yet detected by `mir-analyzer`. Remove `#[ignore]`
+/// once the analyzer covers this case.
+#[ignore = "mir-analyzer gap: too-many-arguments not detected"]
+#[tokio::test]
+async fn argument_count_too_many_detected() {
+    let mut server = TestServer::new().await;
+    server
+        .check_diagnostics(
+            r#"<?php
+function takes_one(string $s): void {}
+function wrap(): void {
+    takes_one('a', 'b', 'c');
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^ error: takes_one
+}
+"#,
+        )
+        .await;
+}


### PR DESCRIPTION
## Summary

- Adds `argument_count_too_few_detected`: verifies that calling a function with too few arguments emits an `InvalidArgument` diagnostic spanning the whole call expression (wire-protocol test via `did_open` → `publishDiagnostics`)
- Adds `argument_type_mismatch_detected`: verifies that a wrong-typed argument emits `InvalidArgument` on the offending expression
- Adds `argument_count_too_many_detected` as `#[ignore]`: documents the known `mir-analyzer` gap where over-application (e.g. `strlen("a","b","c")` from issue #170) is not yet detected

These close the two untested cases identified during the issue #170 audit: undefined-variable and arity-mismatch were supported by `DiagnosticsConfig` but had no wire-protocol coverage. (Undefined-variable is a separate follow-up.)

## Test plan

- [x] `cargo test --test e2e_diagnostics` — 19 passed, 2 ignored, 0 failed