### PR TITLE
fix: proactively republish diagnostics to open dependents on dependency edit

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -323,6 +323,40 @@ impl OpenFiles {
     }
 }
 
+/// Build the full diagnostic bundle for an already-open file.
+///
+/// Reuses cached parse diagnostics from `OpenFiles` (set by the file's own
+/// debounced parse) and recomputes the rest:
+/// - `duplicate_declaration_diagnostics` is intra-file (AST walk over the
+///   doc's own statements), so a dependency change does NOT change its
+///   result — but it's cheap and keeps this helper a single source of
+///   truth for "the diagnostic bundle for `uri`".
+/// - `semantic_issues` is salsa-cached; for files unaffected by the
+///   triggering change it's a cache hit.
+///
+/// Used both for the originating file (during `did_open`/`did_change`) and
+/// when proactively republishing diagnostics to other open files after a
+/// dependency edit. Salsa-blocking — call from a `spawn_blocking` if invoked
+/// off the originating file's debounce path.
+fn compute_open_file_diagnostics(
+    docs: &DocumentStore,
+    open_files: &OpenFiles,
+    uri: &Url,
+    diag_cfg: &DiagnosticsConfig,
+) -> Vec<Diagnostic> {
+    let mut out = open_files.parse_diagnostics(uri).unwrap_or_default();
+    let source = open_files.text(uri).unwrap_or_default();
+    if let Some(d) = open_files.get_doc(docs, uri) {
+        out.extend(duplicate_declaration_diagnostics(&source, &d, diag_cfg));
+    }
+    if let Some(issues) = docs.get_semantic_issues_salsa(uri) {
+        out.extend(crate::semantic_diagnostics::issues_to_diagnostics(
+            &issues, uri, diag_cfg,
+        ));
+    }
+    out
+}
+
 pub struct Backend {
     client: Client,
     docs: Arc<DocumentStore>,
@@ -952,7 +986,41 @@ impl LanguageServer for Backend {
                 &issues, &uri, &diag_cfg,
             ));
         }
-        self.client.publish_diagnostics(uri, all_diags, None).await;
+        // Publish for the opened file FIRST — see did_change for why ordering matters.
+        self.client
+            .publish_diagnostics(uri.clone(), all_diags, None)
+            .await;
+
+        // Cross-file republish: opening a file that defines new symbols can
+        // clear `UndefinedClass`/`UndefinedFunction` errors in already-open
+        // dependents. Symmetric to the loop in did_change.
+        let docs_dep = Arc::clone(&self.docs);
+        let open_files_dep = self.open_files.clone();
+        let diag_cfg_dep = diag_cfg.clone();
+        let opened_uri = uri.clone();
+        let dependents = tokio::task::spawn_blocking(move || {
+            let mut out: Vec<(Url, Vec<Diagnostic>)> = Vec::new();
+            for other in open_files_dep.urls() {
+                if other == opened_uri {
+                    continue;
+                }
+                let diags = compute_open_file_diagnostics(
+                    &docs_dep,
+                    &open_files_dep,
+                    &other,
+                    &diag_cfg_dep,
+                );
+                out.push((other, diags));
+            }
+            out
+        })
+        .await
+        .unwrap_or_default();
+        for (dep_uri, dep_diags) in dependents {
+            self.client
+                .publish_diagnostics(dep_uri, dep_diags, None)
+                .await;
+        }
     }
 
     async fn did_change(&self, params: DidChangeTextDocumentParams) {
@@ -1019,7 +1087,47 @@ impl LanguageServer for Backend {
 
                 let mut all_diags = diagnostics;
                 all_diags.extend(extra);
-                client.publish_diagnostics(uri, all_diags, None).await;
+                // Publish for the changed file FIRST. Test harnesses (and
+                // some clients) consume publishDiagnostics for unrelated
+                // URIs while waiting for one specific URI; reversing this
+                // order would silently swallow the changed file's publish.
+                client
+                    .publish_diagnostics(uri.clone(), all_diags, None)
+                    .await;
+
+                // Cross-file republish: a dependency change may invalidate
+                // diagnostics in other open files. We re-query each open
+                // file's diagnostics (salsa-cached for unaffected files,
+                // recomputed for affected ones) and publish the result.
+                //
+                // Race window: if `other` is being edited concurrently, its
+                // own debounced did_change will still fire a republish, so
+                // any briefly-stale publish here self-corrects within ~100ms.
+                let docs_dep = Arc::clone(&docs);
+                let open_files_dep = open_files.clone();
+                let diag_cfg_dep = diag_cfg.clone();
+                let changed_uri = uri.clone();
+                let dependents = tokio::task::spawn_blocking(move || {
+                    let mut out: Vec<(Url, Vec<Diagnostic>)> = Vec::new();
+                    for other in open_files_dep.urls() {
+                        if other == changed_uri {
+                            continue;
+                        }
+                        let diags = compute_open_file_diagnostics(
+                            &docs_dep,
+                            &open_files_dep,
+                            &other,
+                            &diag_cfg_dep,
+                        );
+                        out.push((other, diags));
+                    }
+                    out
+                })
+                .await
+                .unwrap_or_default();
+                for (dep_uri, dep_diags) in dependents {
+                    client.publish_diagnostics(dep_uri, dep_diags, None).await;
+                }
             }
         });
     }

--- a/tests/common/client.rs
+++ b/tests/common/client.rs
@@ -160,6 +160,82 @@ impl TestClient {
         .unwrap_or_else(|_| panic!("timed out waiting for publishDiagnostics for {uri}"))
     }
 
+    /// Wait for `textDocument/publishDiagnostics` for each of `uris`, in any
+    /// order. Discards messages for other URIs encountered along the way.
+    /// Returns a map keyed by URI. Replies to any server→client requests
+    /// with `null` so the server isn't blocked while we're draining.
+    ///
+    /// Use when a single LSP event triggers publishes for multiple files
+    /// (e.g., cross-file republish after a dependency change) and the test
+    /// needs to assert against each independently.
+    pub async fn wait_for_diagnostics_multi(
+        &mut self,
+        uris: &[&str],
+    ) -> std::collections::HashMap<String, Value> {
+        let mut remaining: std::collections::HashSet<String> =
+            uris.iter().map(|s| s.to_string()).collect();
+        let mut collected: std::collections::HashMap<String, Value> =
+            std::collections::HashMap::new();
+        let expected = remaining.clone();
+        tokio::time::timeout(tokio::time::Duration::from_secs(5), async {
+            while !remaining.is_empty() {
+                let msg = read_msg(&mut self.read).await;
+                if msg.get("method") == Some(&json!("textDocument/publishDiagnostics")) {
+                    if let Some(uri) = msg["params"]["uri"].as_str() {
+                        if remaining.remove(uri) {
+                            collected.insert(uri.to_string(), msg);
+                        }
+                    }
+                } else if msg.get("method").is_some() {
+                    if let Some(id) = msg.get("id") {
+                        let response = json!({
+                            "jsonrpc": "2.0",
+                            "id": id,
+                            "result": null,
+                        });
+                        self.write.write_all(&frame(&response)).await.unwrap();
+                    }
+                }
+            }
+        })
+        .await
+        .unwrap_or_else(|_| {
+            panic!("timed out; expected publishDiagnostics for {expected:?}, got {collected:?}")
+        });
+        collected
+    }
+
+    /// Drain incoming messages for `duration`, returning every
+    /// `publishDiagnostics` URI seen. Used to assert the *absence* of a
+    /// publish (e.g., closed file must not receive cross-file republishes).
+    pub async fn drain_publish_diagnostics_uris(
+        &mut self,
+        duration: tokio::time::Duration,
+    ) -> Vec<String> {
+        let mut uris = Vec::new();
+        let _ = tokio::time::timeout(duration, async {
+            loop {
+                let msg = read_msg(&mut self.read).await;
+                if msg.get("method") == Some(&json!("textDocument/publishDiagnostics")) {
+                    if let Some(uri) = msg["params"]["uri"].as_str() {
+                        uris.push(uri.to_string());
+                    }
+                } else if msg.get("method").is_some() {
+                    if let Some(id) = msg.get("id") {
+                        let response = json!({
+                            "jsonrpc": "2.0",
+                            "id": id,
+                            "result": null,
+                        });
+                        self.write.write_all(&frame(&response)).await.unwrap();
+                    }
+                }
+            }
+        })
+        .await;
+        uris
+    }
+
     /// Read messages until a server→client request with the given `method` arrives.
     /// Returns `(id, params)`. Skips notifications and client responses.
     /// Panics after 5 seconds.

--- a/tests/e2e_incremental.rs
+++ b/tests/e2e_incremental.rs
@@ -192,12 +192,9 @@ async fn cross_file_diagnostics_refresh_on_next_didchange() {
     );
 }
 
-/// IDEAL behavior (tracked gap): when a dependency changes, the server
-/// should proactively republish diagnostics for every dependent file — no
-/// extra didChange required. rust-analyzer does this via its notification
-/// pump. php-lsp currently does not; flip this test on once it does.
+/// When a dependency changes, the server proactively republishes
+/// diagnostics for every open dependent file — no extra didChange required.
 #[tokio::test]
-#[ignore = "server does not proactively republish diagnostics when a dependency changes"]
 async fn cross_file_diagnostics_republish_on_dependency_change() {
     let mut server = TestServer::new().await;
     server.open("dep2.php", "<?php\nclass Widget2 {}\n").await;
@@ -287,5 +284,192 @@ async fn reopen_does_not_duplicate_symbols() {
         refs.len(),
         2,
         "expected declaration + 1 call, not duplicates after reopen: {refs:?}"
+    );
+}
+
+// ── cross-file diagnostic republish: edge cases ─────────────────────────────
+
+/// Symmetric to the rename case: when a dependency *appears* (did_open of a
+/// file that defines a previously-missing symbol), the dependent's
+/// UndefinedClass must clear without re-editing the dependent.
+#[tokio::test]
+async fn cross_file_diagnostic_clears_when_dependency_opened() {
+    let mut server = TestServer::new().await;
+    let notif = server
+        .open("user_open.php", "<?php\n$w = new ProvidedClass();\n")
+        .await;
+    assert!(
+        has_code(&notif, "UndefinedClass"),
+        "expected UndefinedClass before dep is opened: {:?}",
+        notif["params"]["diagnostics"]
+    );
+
+    // Opening a file that defines ProvidedClass should clear the error in user_open.php.
+    server
+        .open("provider.php", "<?php\nclass ProvidedClass {}\n")
+        .await;
+
+    let user_uri = server.uri("user_open.php");
+    let notif = server.client().wait_for_diagnostics(&user_uri).await;
+    assert!(
+        !has_code(&notif, "UndefinedClass"),
+        "expected UndefinedClass cleared after dep opened: {:?}",
+        notif["params"]["diagnostics"]
+    );
+}
+
+/// Two open dependents must both receive proactive republishes after a
+/// dependency change. Order of dependent publishes is not guaranteed.
+#[tokio::test]
+async fn cross_file_republish_fans_out_to_multiple_dependents() {
+    let mut server = TestServer::new().await;
+    server
+        .open("dep_fan.php", "<?php\nclass FanWidget {}\n")
+        .await;
+    server
+        .open("u1_fan.php", "<?php\n$w = new FanWidget();\n")
+        .await;
+    server
+        .open("u2_fan.php", "<?php\n$w = new FanWidget();\n")
+        .await;
+
+    // Each open() above triggers cross-file republishes for already-open
+    // files; those leftover publishes sit in the queue with stale (pre-
+    // rename) content. Drain them so the assertion below only inspects
+    // publishes triggered by the change.
+    let _ = server
+        .client()
+        .drain_publish_diagnostics_uris(tokio::time::Duration::from_millis(200))
+        .await;
+
+    // Trigger: rename FanWidget away. server.change() consumes dep_fan's
+    // publish; the dependent publishes for u1/u2 stay queued.
+    server
+        .change("dep_fan.php", 2, "<?php\nclass FanGadget {}\n")
+        .await;
+
+    let u1 = server.uri("u1_fan.php");
+    let u2 = server.uri("u2_fan.php");
+    let notifs = server
+        .client()
+        .wait_for_diagnostics_multi(&[&u1, &u2])
+        .await;
+
+    for (label, uri) in [("u1", &u1), ("u2", &u2)] {
+        let notif = notifs
+            .get(uri)
+            .unwrap_or_else(|| panic!("missing publish for {label} ({uri})"));
+        assert!(
+            has_code(notif, "UndefinedClass"),
+            "{label}: expected UndefinedClass after FanWidget rename, got: {:?}",
+            notif["params"]["diagnostics"]
+        );
+    }
+}
+
+/// A closed file must NOT receive proactive republishes — the server should
+/// only push to currently-open documents. Editing a published-only file
+/// would violate the LSP open-document contract.
+#[tokio::test]
+async fn cross_file_republish_skips_closed_files() {
+    let mut server = TestServer::new().await;
+    server
+        .open("dep_closed.php", "<?php\nclass ClosedDep {}\n")
+        .await;
+    server
+        .open("user_closed.php", "<?php\n$w = new ClosedDep();\n")
+        .await;
+
+    // Close user_closed.php. did_close itself sends one final empty publish
+    // to clear the editor — drain any pending publish for that URI here.
+    let user_uri = server.uri("user_closed.php");
+    server.close("user_closed.php").await;
+    let _ = server
+        .client()
+        .drain_publish_diagnostics_uris(tokio::time::Duration::from_millis(200))
+        .await;
+
+    // Now mutate dep so it WOULD have caused a republish if user_closed.php
+    // were still open.
+    server
+        .change("dep_closed.php", 2, "<?php\nclass ClosedDepRenamed {}\n")
+        .await;
+
+    // No publish should arrive for the closed file. Wait briefly to confirm.
+    let seen = server
+        .client()
+        .drain_publish_diagnostics_uris(tokio::time::Duration::from_millis(300))
+        .await;
+    assert!(
+        !seen.iter().any(|u| u == &user_uri),
+        "closed file received an unexpected publishDiagnostics: {seen:?}"
+    );
+}
+
+/// Editing a file with no dependents still sends republishes to other open
+/// files (for simplicity — Salsa caches make this cheap), and those
+/// republishes must use `[]` not `null` for the diagnostics field, since
+/// `null` would violate the LSP spec.
+#[tokio::test]
+async fn cross_file_republish_uses_empty_array_for_clean_dependent() {
+    let mut server = TestServer::new().await;
+    // Two independent files, both clean. They don't reference each other.
+    server
+        .open("clean_a.php", "<?php\nfunction aa(): void {}\n")
+        .await;
+    server
+        .open("clean_b.php", "<?php\nfunction bb(): void {}\n")
+        .await;
+
+    // Edit clean_a; clean_b is unaffected but receives a cache-hit republish.
+    server
+        .change("clean_a.php", 2, "<?php\nfunction aaaa(): void {}\n")
+        .await;
+
+    let b_uri = server.uri("clean_b.php");
+    let notif = server.client().wait_for_diagnostics(&b_uri).await;
+    let diags = &notif["params"]["diagnostics"];
+    assert!(
+        diags.is_array(),
+        "diagnostics must be an array (LSP requires the field), got: {diags:?}"
+    );
+    assert!(
+        diags.as_array().unwrap().is_empty(),
+        "clean_b is independent — expected empty diagnostics, got: {diags:?}"
+    );
+}
+
+/// A dependent with a parse error must keep its parse diagnostics through
+/// a cross-file republish — the republish path uses cached parse diagnostics
+/// rather than re-parsing, so the error must not silently drop.
+#[tokio::test]
+async fn cross_file_republish_preserves_dependent_parse_errors() {
+    let mut server = TestServer::new().await;
+    let notif = server.open("broken.php", "<?php\nbroken(;\n").await;
+    let original_count = notif["params"]["diagnostics"]
+        .as_array()
+        .map(|a| a.len())
+        .unwrap_or(0);
+    assert!(
+        original_count > 0,
+        "expected parse error in broken.php on open"
+    );
+
+    // Open an unrelated file; this triggers a cross-file republish loop that
+    // recomputes broken.php's diagnostics. Parse errors must be preserved.
+    server
+        .open("trigger.php", "<?php\nclass Triggered {}\n")
+        .await;
+
+    let broken_uri = server.uri("broken.php");
+    let notif = server.client().wait_for_diagnostics(&broken_uri).await;
+    let count = notif["params"]["diagnostics"]
+        .as_array()
+        .map(|a| a.len())
+        .unwrap_or(0);
+    assert!(
+        count >= original_count,
+        "cross-file republish dropped parse diagnostics: had {original_count}, now {count}: {:?}",
+        notif["params"]["diagnostics"]
     );
 }


### PR DESCRIPTION
## Summary

Closes the cross-file diagnostic gap that was previously documented as an `#[ignore]`d test in `tests/e2e_incremental.rs`. When `dep.php` changes, the server now proactively republishes diagnostics for every open dependent — `user.php` with `new Widget()` immediately gets `UndefinedClass` after Widget is renamed, without re-editing.

### Implementation

- **`src/backend.rs`** — new helper `compute_open_file_diagnostics` builds the full diagnostic bundle for an open file using cached parse diagnostics (no re-parse) + intra-file duplicate detection + Salsa-cached semantic issues. Called from both `did_open` and `did_change` after the originating file's publish, iterating every other open file.
- **Order is load-bearing**: the changed file MUST publish first. Test harnesses' `wait_for_diagnostics(uri)` discards publishes for other URIs along the way, so reversing this order silently swallows the changed file's notification. Documented inline.
- **No reverse-dependency tracking**: Salsa already caches per-file analysis; unaffected files are cache hits. Computing an explicit dependent set is premature optimization.
- **Race window**: a concurrent edit on a dependent may briefly see stale parse diagnostics from this path; the dependent's own debounce republishes within ~100 ms. Documented.

### Tests

Un-ignored the original `cross_file_diagnostics_republish_on_dependency_change` plus 5 new edge cases:

| Test | Asserts |
|------|---------|
| `cross_file_diagnostic_clears_when_dependency_opened` | Symmetric direction: `did_open` of a defining file clears errors in dependents |
| `cross_file_republish_fans_out_to_multiple_dependents` | Multi-dependent fan-out, order-agnostic |
| `cross_file_republish_skips_closed_files` | Closed files MUST NOT receive a publish (LSP open-document contract) |
| `cross_file_republish_uses_empty_array_for_clean_dependent` | Republish with no diagnostics uses `[]` not `null` (LSP spec) |
| `cross_file_republish_preserves_dependent_parse_errors` | Cached parse diagnostics survive a cross-file republish — no silent drop |

Two test-plumbing helpers added to `tests/common/client.rs`:
- `wait_for_diagnostics_multi(&[uri])` — collects publishes for several URIs in any order, replying `null` to interleaved server requests
- `drain_publish_diagnostics_uris(duration)` — drains the queue for a duration, used to clear stale publishes between setup and assertion, and to assert the *absence* of a publish

### Bug discovered while writing the tests

The fan-out test initially failed with `u1: expected UndefinedClass, got Array []`. Root cause was test queue contamination: each `did_open` triggers cross-file republishes for already-open files, which sit in the message queue with stale (pre-rename) content. `wait_for_diagnostics_multi` was matching the stale `u1` publish before the fresh one. Fixed by draining stale messages between setup and the trigger event. This is a test-design issue, not a server bug — the server was correctly republishing.

## Test plan

- [ ] `cargo test --test e2e_incremental` — 19 tests pass (was 14 with 1 ignored)
- [ ] `cargo test` — full suite, 0 failures
- [ ] Manually verify in editor: open `user.php` with reference to undefined class, then open the file defining it — diagnostic clears without re-editing