### PR TITLE
fix: did_save drops semantic diagnostics after save

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1160,16 +1160,12 @@ impl LanguageServer for Backend {
         let uri = params.text_document.uri;
         // Re-publish diagnostics on save so editors that defer diagnostics
         // until save (rather than on every keystroke) see up-to-date results.
-        let source = self.get_open_text(&uri).unwrap_or_default();
-        let doc = self.get_doc(&uri);
-        if let Some(ref d) = doc {
-            let diag_cfg = self.config.read().unwrap().diagnostics.clone();
-            let parse_diags = self.get_parse_diagnostics(&uri).unwrap_or_default();
-            let dup_diags = duplicate_declaration_diagnostics(&source, d, &diag_cfg);
-            let mut all = parse_diags;
-            all.extend(dup_diags);
-            self.client.publish_diagnostics(uri, all, None).await;
-        }
+        // Must include semantic diagnostics — publishDiagnostics replaces the
+        // prior set entirely, so omitting them would clear errors the editor
+        // showed after the last did_change.
+        let diag_cfg = self.config.read().unwrap().diagnostics.clone();
+        let all = compute_open_file_diagnostics(&self.docs, &self.open_files, &uri, &diag_cfg);
+        self.client.publish_diagnostics(uri, all, None).await;
     }
 
     async fn did_change_watched_files(&self, params: DidChangeWatchedFilesParams) {

--- a/tests/feature_doc_lifecycle.rs
+++ b/tests/feature_doc_lifecycle.rs
@@ -4,7 +4,6 @@
 mod common;
 
 use common::TestServer;
-use serde_json::json;
 
 // --- did_close ---
 
@@ -91,6 +90,36 @@ async fn did_save_republishes_diagnostics_for_duplicate_functions() {
             .len()
             >= 1,
         "expected >=1 diagnostic after save with duplicate functions: {save_notif:?}"
+    );
+}
+
+#[tokio::test]
+async fn did_save_republishes_semantic_diagnostics() {
+    // Regression: did_save was manually building parse+dup-decl diagnostics
+    // and omitting the semantic pass. publishDiagnostics *replaces* the prior
+    // set, so saving a file with semantic errors would silently clear them.
+    let mut server = TestServer::new().await;
+    let open_notif = server
+        .open(
+            "save_semantic.php",
+            "<?php\nfunction _wrap(): void {\n    nonexistent_fn();\n}\n",
+        )
+        .await;
+    assert!(
+        !open_notif["params"]["diagnostics"]
+            .as_array()
+            .unwrap_or(&vec![])
+            .is_empty(),
+        "expected semantic diagnostic on open: {open_notif:?}"
+    );
+
+    let save_notif = server.save("save_semantic.php").await;
+    assert!(
+        !save_notif["params"]["diagnostics"]
+            .as_array()
+            .unwrap()
+            .is_empty(),
+        "did_save must republish semantic diagnostics, got empty list: {save_notif:?}"
     );
 }
 


### PR DESCRIPTION
## Summary

- `did_save` was manually assembling diagnostics from parse errors and duplicate-declaration checks only, omitting the semantic pass (undefined functions, undefined classes, etc.)
- `publishDiagnostics` in LSP **replaces** the prior set entirely, so saving a file would silently clear any semantic errors the editor showed after the last `did_change`
- Fix delegates to `compute_open_file_diagnostics`, which already bundles all three diagnostic sources correctly

## Test plan

- [ ] `did_save_republishes_semantic_diagnostics` — new regression test: open a file with `nonexistent_fn()`, verify the error appears on `did_open`, save, assert the error is still present in the `did_save` publish
- [ ] Existing `did_save_republishes_empty_diagnostics_for_clean_file` and `did_save_republishes_diagnostics_for_duplicate_functions` still pass
- [ ] Full test suite passes with no regressions