### PR TITLE
feat: attribute-aware completions for #[ context

### DIFF
--- a/src/completion/mod.rs
+++ b/src/completion/mod.rs
@@ -14,8 +14,9 @@ use member::{
 
 mod namespace;
 use namespace::{
-    collect_classes_with_ns, collect_fqns_with_prefix, current_file_namespace, typed_prefix,
-    use_completion_prefix, use_insert_position,
+    collect_attribute_classes, collect_classes_with_ns, collect_fqns_with_prefix,
+    current_file_namespace, infer_attribute_target, typed_prefix, use_completion_prefix,
+    use_insert_position,
 };
 
 use std::sync::Arc;
@@ -299,63 +300,13 @@ pub fn filtered_completions_at(
             vec![]
         }
         Some("[") => {
-            // PHP attribute: #[ — suggest attribute classes
+            // PHP attribute: #[ — suggest only #[\Attribute]-annotated classes.
             if let (Some(src), Some(pos)) = (source, position) {
                 let line = src.lines().nth(pos.line as usize).unwrap_or("");
                 let col = utf16_offset_to_byte(line, pos.character as usize);
                 let before = &line[..col];
                 if before.trim_end_matches('[').trim_end().ends_with('#') {
-                    let mut items: Vec<CompletionItem> = Vec::new();
-                    let cur_ns = current_file_namespace(&doc.program().stmts);
-                    let mut seen = std::collections::HashSet::new();
-
-                    // Current doc: no auto-import needed (same file).
-                    let mut cur_classes = Vec::new();
-                    collect_classes_with_ns(&doc.program().stmts, "", &mut cur_classes);
-                    for (label, _kind, _fqn) in cur_classes {
-                        if seen.insert(label.clone()) {
-                            items.push(CompletionItem {
-                                label,
-                                kind: Some(CompletionItemKind::CLASS),
-                                ..Default::default()
-                            });
-                        }
-                    }
-
-                    // Other docs: add `use` statement when crossing namespaces.
-                    for other in other_docs {
-                        let mut classes = Vec::new();
-                        collect_classes_with_ns(&other.program().stmts, "", &mut classes);
-                        for (label, _kind, fqn) in classes {
-                            if !seen.insert(label.clone()) {
-                                continue;
-                            }
-                            let in_same_ns =
-                                !cur_ns.is_empty() && fqn == format!("{}\\{}", cur_ns, label);
-                            let is_global = !fqn.contains('\\');
-                            let already = imports.contains_key(&label);
-                            let additional_text_edits = if !in_same_ns && !is_global && !already {
-                                let insert_pos = use_insert_position(src);
-                                Some(vec![TextEdit {
-                                    range: Range {
-                                        start: insert_pos,
-                                        end: insert_pos,
-                                    },
-                                    new_text: format!("use {};\n", fqn),
-                                }])
-                            } else {
-                                None
-                            };
-                            items.push(CompletionItem {
-                                label,
-                                kind: Some(CompletionItemKind::CLASS),
-                                detail: if fqn.contains('\\') { Some(fqn) } else { None },
-                                additional_text_edits,
-                                ..Default::default()
-                            });
-                        }
-                    }
-                    return items;
+                    return attribute_completions(src, pos, doc, other_docs, imports);
                 }
             }
             vec![]
@@ -459,6 +410,21 @@ pub fn filtered_completions_at(
                         if !items.is_empty() {
                             return items;
                         }
+                    }
+                }
+            }
+
+            // Attribute context: #[ or #[PartialName — invoked without trigger char.
+            if let (Some(src), Some(pos)) = (source, position) {
+                let line = src.lines().nth(pos.line as usize).unwrap_or("");
+                let col = utf16_offset_to_byte(line, pos.character as usize);
+                let before = &line[..col];
+                let pre_ident =
+                    before.trim_end_matches(|c: char| c.is_alphanumeric() || c == '_' || c == '\\');
+                if pre_ident.trim_end().ends_with("#[") || pre_ident.trim_end() == "#[" {
+                    let items = attribute_completions(src, pos, doc, other_docs, imports);
+                    if !items.is_empty() {
+                        return items;
                     }
                 }
             }
@@ -660,6 +626,82 @@ pub fn filtered_completions_at(
             items
         }
     }
+}
+
+/// Build attribute-class completion items for a `#[` context.
+///
+/// Only classes annotated with `#[\Attribute]` are included. If the
+/// look-ahead finds a specific declaration (class / function / property),
+/// items are further filtered by the matching `TARGET_*` bitmask.
+fn attribute_completions(
+    source: &str,
+    position: Position,
+    doc: &ParsedDoc,
+    other_docs: &[Arc<ParsedDoc>],
+    imports: &HashMap<String, String>,
+) -> Vec<CompletionItem> {
+    let context_target = infer_attribute_target(source, position);
+    let cur_ns = current_file_namespace(&doc.program().stmts);
+    let mut items: Vec<CompletionItem> = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+
+    // Current doc — no auto-import needed.
+    let mut cur_entries = Vec::new();
+    collect_attribute_classes(&doc.program().stmts, "", &mut cur_entries);
+    for entry in cur_entries {
+        if entry.target & context_target == 0 {
+            continue;
+        }
+        if seen.insert(entry.label.clone()) {
+            items.push(CompletionItem {
+                label: entry.label,
+                kind: Some(CompletionItemKind::CLASS),
+                ..Default::default()
+            });
+        }
+    }
+
+    // Other docs — add `use` statement when crossing namespaces.
+    for other in other_docs {
+        let mut entries = Vec::new();
+        collect_attribute_classes(&other.program().stmts, "", &mut entries);
+        for entry in entries {
+            if entry.target & context_target == 0 {
+                continue;
+            }
+            if !seen.insert(entry.label.clone()) {
+                continue;
+            }
+            let in_same_ns =
+                !cur_ns.is_empty() && entry.fqn == format!("{}\\{}", cur_ns, entry.label);
+            let is_global = !entry.fqn.contains('\\');
+            let already = imports.contains_key(&entry.label);
+            let additional_text_edits = if !in_same_ns && !is_global && !already {
+                let insert_pos = use_insert_position(source);
+                Some(vec![TextEdit {
+                    range: Range {
+                        start: insert_pos,
+                        end: insert_pos,
+                    },
+                    new_text: format!("use {};\n", entry.fqn),
+                }])
+            } else {
+                None
+            };
+            items.push(CompletionItem {
+                label: entry.label,
+                kind: Some(CompletionItemKind::CLASS),
+                detail: if entry.fqn.contains('\\') {
+                    Some(entry.fqn)
+                } else {
+                    None
+                },
+                additional_text_edits,
+                ..Default::default()
+            });
+        }
+    }
+    items
 }
 
 fn match_arm_completions(
@@ -1479,12 +1521,13 @@ mod tests {
         );
     }
 
-    // Feature 6: attribute bracket completions
+    // Feature 6: attribute bracket completions — only #[\Attribute]-annotated classes
     #[test]
     fn attribute_bracket_suggests_classes() {
-        let d = doc("<?php\nclass Route {}\nclass Middleware {}\n#[");
+        let src = "<?php\n#[\\Attribute]\nclass Route {}\n#[\\Attribute]\nclass Middleware {}\nclass Plain {}\n#[";
+        let d = doc(src);
         let pos = Position {
-            line: 3,
+            line: 6,
             character: 2,
         };
         let items = filtered_completions_at(
@@ -1492,7 +1535,7 @@ mod tests {
             &[],
             Some("["),
             &CompletionCtx {
-                source: Some("<?php\nclass Route {}\nclass Middleware {}\n#["),
+                source: Some(src),
                 position: Some(pos),
                 ..Default::default()
             },
@@ -1503,6 +1546,10 @@ mod tests {
             ls.contains(&"Middleware"),
             "should suggest Middleware as attribute"
         );
+        assert!(
+            !ls.contains(&"Plain"),
+            "plain class without #[Attribute] must not appear"
+        );
     }
 
     #[test]
@@ -1510,7 +1557,7 @@ mod tests {
         let current_src = "<?php\nnamespace App\\Controllers;\n\n#[";
         let d = doc(current_src);
         let other = Arc::new(ParsedDoc::parse(
-            "<?php\nnamespace App\\Attributes;\nclass Route {}".to_string(),
+            "<?php\nnamespace App\\Attributes;\n#[\\Attribute]\nclass Route {}".to_string(),
         ));
         let pos = Position {
             line: 3,
@@ -1548,7 +1595,7 @@ mod tests {
         let current_src = "<?php\nnamespace App\\Attributes;\n\n#[";
         let d = doc(current_src);
         let other = Arc::new(ParsedDoc::parse(
-            "<?php\nnamespace App\\Attributes;\nclass Route {}".to_string(),
+            "<?php\nnamespace App\\Attributes;\n#[\\Attribute]\nclass Route {}".to_string(),
         ));
         let pos = Position {
             line: 3,

--- a/src/completion/namespace.rs
+++ b/src/completion/namespace.rs
@@ -1,5 +1,184 @@
-use php_ast::{NamespaceBody, Stmt, StmtKind};
+use php_ast::{ExprKind, NamespaceBody, Stmt, StmtKind};
 use tower_lsp::lsp_types::{CompletionItem, CompletionItemKind, Position};
+
+/// An `#[\Attribute]`-annotated class with its resolved target bitmask.
+///
+/// Target bitmask uses PHP's `Attribute::TARGET_*` constants:
+/// - `TARGET_CLASS = 1`
+/// - `TARGET_FUNCTION = 2`
+/// - `TARGET_METHOD = 4`
+/// - `TARGET_PROPERTY = 8`
+/// - `TARGET_CLASS_CONSTANT = 16`
+/// - `TARGET_PARAMETER = 32`
+/// - `TARGET_ALL = 63` (default when no argument is given)
+pub(super) struct AttributeClassEntry {
+    pub label: String,
+    pub fqn: String,
+    pub target: i64,
+}
+
+/// Collect only classes annotated with `#[\Attribute]` (or `#[Attribute]`),
+/// resolving the first constructor argument as the target bitmask.
+pub(super) fn collect_attribute_classes(
+    stmts: &[Stmt<'_, '_>],
+    ns_prefix: &str,
+    out: &mut Vec<AttributeClassEntry>,
+) {
+    let mut cur_ns = ns_prefix.to_string();
+
+    let fqn_for = |short: &str, ns: &str| -> String {
+        if ns.is_empty() {
+            short.to_string()
+        } else {
+            format!("{}\\{}", ns, short)
+        }
+    };
+
+    for stmt in stmts {
+        match &stmt.kind {
+            StmtKind::Class(c) => {
+                let short = c.name.unwrap_or("");
+                if short.is_empty() {
+                    continue;
+                }
+                let target = attribute_target_from_attrs(&c.attributes);
+                if let Some(target) = target {
+                    out.push(AttributeClassEntry {
+                        label: short.to_string(),
+                        fqn: fqn_for(short, &cur_ns),
+                        target,
+                    });
+                }
+            }
+            StmtKind::Namespace(ns) => {
+                let ns_name = ns
+                    .name
+                    .as_ref()
+                    .map(|n| n.to_string_repr().to_string())
+                    .unwrap_or_default();
+                match &ns.body {
+                    NamespaceBody::Braced(inner) => {
+                        collect_attribute_classes(inner, &ns_name, out);
+                    }
+                    NamespaceBody::Simple => {
+                        cur_ns = ns_name;
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Returns `Some(target_bitmask)` if the attribute list contains an
+/// `#[Attribute]` or `#[\Attribute]` annotation, `None` otherwise.
+///
+/// The target is parsed from the first argument:
+/// - `#[\Attribute]` → `Some(63)` (TARGET_ALL)
+/// - `#[\Attribute(63)]` → `Some(63)`
+/// - `#[\Attribute(\Attribute::TARGET_CLASS)]` → `Some(1)`
+fn attribute_target_from_attrs(
+    attrs: &php_ast::ArenaVec<'_, php_ast::Attribute<'_, '_>>,
+) -> Option<i64> {
+    for attr in attrs.iter() {
+        let name = attr.name.to_string_repr();
+        if name.rsplit('\\').next() != Some("Attribute") {
+            continue;
+        }
+        // Found the `#[Attribute]` annotation; parse its target argument.
+        let target = attr
+            .args
+            .first()
+            .and_then(|arg| resolve_target_expr(&arg.value.kind))
+            .unwrap_or(63); // TARGET_ALL when no argument given
+        return Some(target);
+    }
+    None
+}
+
+fn resolve_target_expr(expr: &ExprKind<'_, '_>) -> Option<i64> {
+    match expr {
+        ExprKind::Int(v) => Some(*v),
+        ExprKind::ClassConstAccess(acc) => {
+            // `\Attribute::TARGET_CLASS` → member is an Identifier "TARGET_CLASS"
+            acc.member.name_str().and_then(target_const_to_bitmask)
+        }
+        _ => None,
+    }
+}
+
+fn target_const_to_bitmask(name: &str) -> Option<i64> {
+    match name {
+        "TARGET_CLASS" => Some(1),
+        "TARGET_FUNCTION" => Some(2),
+        "TARGET_METHOD" => Some(4),
+        "TARGET_PROPERTY" => Some(8),
+        "TARGET_CLASS_CONSTANT" => Some(16),
+        "TARGET_PARAMETER" => Some(32),
+        "TARGET_ALL" => Some(63),
+        _ => None,
+    }
+}
+
+/// Infer the attribute target context by looking ahead from `position` in
+/// `source` for the first declaration keyword (class / function / etc.).
+///
+/// Returns the appropriate `Attribute::TARGET_*` bitmask, or `63` (ALL) if
+/// no specific context can be determined.
+pub(super) fn infer_attribute_target(source: &str, position: Position) -> i64 {
+    let lines: Vec<&str> = source.lines().collect();
+    let start = (position.line as usize).saturating_add(1);
+    for line in lines.iter().skip(start).take(10) {
+        let t = line.trim();
+        if t.is_empty()
+            || t.starts_with("//")
+            || t.starts_with("/*")
+            || t.starts_with("*")
+            || t.starts_with("#[")
+        {
+            continue;
+        }
+        // Strip common visibility/modifier keywords before checking
+        let stripped = t
+            .trim_start_matches("abstract ")
+            .trim_start_matches("final ")
+            .trim_start_matches("readonly ")
+            .trim_start_matches("public ")
+            .trim_start_matches("protected ")
+            .trim_start_matches("private ")
+            .trim_start_matches("static ");
+        if stripped.starts_with("class ")
+            || stripped.starts_with("interface ")
+            || stripped.starts_with("enum ")
+            || stripped.starts_with("trait ")
+        {
+            return 1; // TARGET_CLASS
+        }
+        if stripped.starts_with("function ") {
+            return 2 | 4; // TARGET_FUNCTION | TARGET_METHOD
+        }
+        // Property: starts with a type hint or $ before any `=`
+        if stripped.starts_with('$') || is_property_declaration(stripped) {
+            return 8; // TARGET_PROPERTY
+        }
+        if stripped.starts_with("const ") {
+            return 16; // TARGET_CLASS_CONSTANT
+        }
+        break;
+    }
+    63 // TARGET_ALL — context unknown
+}
+
+fn is_property_declaration(s: &str) -> bool {
+    // Heuristic: PHP type followed by `$varname`
+    // e.g. `string $name`, `int $count`, `?Foo $bar`
+    let s = s.trim_start_matches('?');
+    if let Some(rest) = s.split_once(' ') {
+        rest.1.trim().starts_with('$')
+    } else {
+        false
+    }
+}
 
 pub(super) fn collect_classes_with_ns(
     stmts: &[Stmt<'_, '_>],

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -14,7 +14,7 @@ mod server;
 
 pub use client::TestClient;
 pub use render::{
-    canonicalize_workspace_edit, render_document_symbols, render_hover, render_inlay_hints,
-    render_locations, render_workspace_symbols,
+    canonicalize_workspace_edit, render_completion, render_document_symbols, render_hover,
+    render_inlay_hints, render_locations, render_workspace_symbols,
 };
 pub use server::{OpenedFixture, TestServer};

--- a/tests/common/render.rs
+++ b/tests/common/render.rs
@@ -261,7 +261,7 @@ pub fn render_hover(resp: &Value) -> String {
         .join("\n")
 }
 
-pub(crate) fn render_completion(resp: &Value) -> String {
+pub fn render_completion(resp: &Value) -> String {
     if let Some(err) = resp.get("error").filter(|e| !e.is_null()) {
         return format!("error: {err}");
     }

--- a/tests/feature_completion.rs
+++ b/tests/feature_completion.rs
@@ -6,7 +6,7 @@
 
 mod common;
 
-use common::TestServer;
+use common::{TestServer, render_completion};
 use expect_test::expect;
 
 async fn labels(s: &mut TestServer, src: &str) -> Vec<String> {
@@ -581,5 +581,202 @@ class Timer {
         Method      reset
         Method      run
         Method      tick"#]]
+    .assert_eq(&out);
+}
+
+// ── Attribute completion filtering ───────────────────────────────────────────
+
+/// `#[` must only offer classes that carry `#[\Attribute]` — a plain class
+/// without it must not appear.
+#[tokio::test]
+async fn completion_attribute_bracket_excludes_non_attribute_classes() {
+    let mut s = TestServer::new().await;
+    let out = s
+        .check_completion(
+            r#"<?php
+#[\Attribute]
+class MyRoute {}
+
+class PlainClass {}
+
+#[$0
+"#,
+        )
+        .await;
+    expect![[r#"
+        Class       MyRoute"#]]
+    .assert_eq(&out);
+}
+
+/// Cross-file: a class in another file that carries `#[\Attribute]` must appear,
+/// while one that doesn't must be excluded.
+#[tokio::test]
+async fn completion_attribute_bracket_cross_file_filters_non_attributes() {
+    let mut s = TestServer::new().await;
+    let out = s
+        .check_completion(
+            r#"//- /src/attrs.php
+<?php
+#[\Attribute]
+class ValidAttr {}
+
+class NotAnAttr {}
+
+//- /src/main.php
+<?php
+#[$0
+"#,
+        )
+        .await;
+    expect![[r#"
+        Class       ValidAttr"#]]
+    .assert_eq(&out);
+}
+
+/// `#[` on a class-level position must not offer method-only attributes
+/// (those with `TARGET_METHOD = 4` exclusively).
+/// The cursor is placed right after `#[`, with `class MyClass {}` on the next
+/// line, so the server can infer the attribute target context.
+#[tokio::test]
+async fn completion_attribute_bracket_target_filters_class_context() {
+    let mut s = TestServer::new().await;
+    let out = s
+        .check_completion(
+            r#"<?php
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class ClassOnlyAttr {}
+
+#[\Attribute(\Attribute::TARGET_METHOD)]
+class MethodOnlyAttr {}
+
+#[\Attribute(\Attribute::TARGET_ALL)]
+class AnyAttr {}
+
+#[$0
+class MyClass {}
+"#,
+        )
+        .await;
+    // AnyAttr (63 & 1 ≠ 0) and ClassOnlyAttr (1 & 1 ≠ 0) pass;
+    // MethodOnlyAttr (4 & 1 = 0) is excluded.
+    expect![[r#"
+        Class       AnyAttr
+        Class       ClassOnlyAttr"#]]
+    .assert_eq(&out);
+}
+
+/// `#[` completions must exclude non-class symbols: interfaces, enums, and
+/// traits cannot carry `#[\Attribute]` so they must never appear.
+#[tokio::test]
+async fn completion_attribute_bracket_excludes_non_class_types() {
+    let mut s = TestServer::new().await;
+    let out = s
+        .check_completion(
+            r#"<?php
+#[\Attribute]
+class ValidAttr {}
+
+interface MyInterface {}
+enum MyEnum {}
+trait MyTrait {}
+
+#[$0
+"#,
+        )
+        .await;
+    expect![[r#"
+        Class       ValidAttr"#]]
+    .assert_eq(&out);
+}
+
+/// `#[` before a function must show METHOD-targeted attributes but exclude
+/// CLASS-only ones. Covers the `infer_attribute_target` branch returning `2|4`.
+#[tokio::test]
+async fn completion_attribute_bracket_target_filters_function_context() {
+    let mut s = TestServer::new().await;
+    let out = s
+        .check_completion(
+            r#"<?php
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class ClassOnlyAttr {}
+
+#[\Attribute(\Attribute::TARGET_METHOD)]
+class MethodOnlyAttr {}
+
+#[\Attribute(\Attribute::TARGET_ALL)]
+class AnyAttr {}
+
+#[$0
+function doSomething(): void {}
+"#,
+        )
+        .await;
+    // AnyAttr (63 & 6 ≠ 0) and MethodOnlyAttr (4 & 6 ≠ 0) pass;
+    // ClassOnlyAttr (1 & 6 = 0) is excluded.
+    expect![[r#"
+        Class       AnyAttr
+        Class       MethodOnlyAttr"#]]
+    .assert_eq(&out);
+}
+
+/// Snapshot test: `#[` must return ONLY attribute classes — no keywords,
+/// built-ins, or plain classes leaking through.
+#[tokio::test]
+async fn completion_attribute_bracket_returns_only_attribute_classes() {
+    let mut s = TestServer::new().await;
+    let out = s
+        .check_completion(
+            r#"<?php
+#[\Attribute]
+class Middleware {}
+
+#[\Attribute]
+class MyRoute {}
+
+class PlainClass {}
+
+#[$0
+"#,
+        )
+        .await;
+    expect![[r#"
+        Class       Middleware
+        Class       MyRoute"#]]
+    .assert_eq(&out);
+}
+
+/// Trigger-character path (`triggerKind: 2`, `triggerCharacter: "["`) must
+/// also restrict completions to `#[\Attribute]`-annotated classes.
+#[tokio::test]
+async fn completion_attribute_bracket_trigger_char_filters_non_attributes() {
+    let mut s = TestServer::new().await;
+    let opened = s
+        .open_fixture(
+            r#"<?php
+#[\Attribute]
+class ValidAttr {}
+
+class NotAnAttr {}
+
+#[$0
+"#,
+        )
+        .await;
+    let c = opened.cursor().clone();
+    let uri = s.uri(&c.path);
+    let resp = s
+        .client()
+        .request(
+            "textDocument/completion",
+            serde_json::json!({
+                "textDocument": { "uri": uri },
+                "position": { "line": c.line, "character": c.character },
+                "context": { "triggerKind": 2, "triggerCharacter": "[" },
+            }),
+        )
+        .await;
+    let out = render_completion(&resp);
+    expect![[r#"
+        Class       ValidAttr"#]]
     .assert_eq(&out);
 }


### PR DESCRIPTION
## Summary

- `#[` completions now only offer classes annotated with `#[\Attribute]` — plain classes, interfaces, enums, and traits are excluded
- Completions are filtered by target bitmask: a `TARGET_CLASS`-only attribute is not offered before a function declaration, and a `TARGET_METHOD`-only attribute is not offered before a class
- Both the trigger-character path (`triggerKind: 2`, typed `[`) and the invoked path (`triggerKind: 1`, Ctrl+Space inside `#[`) go through the same filtering logic

## Test plan

- [ ] `completion_attribute_bracket_excludes_non_attribute_classes` — plain class absent, `#[\Attribute]` class present (same file)
- [ ] `completion_attribute_bracket_cross_file_filters_non_attributes` — cross-file: only attribute-annotated class offered
- [ ] `completion_attribute_bracket_target_filters_class_context` — before `class`: `TARGET_METHOD`-only attribute excluded
- [ ] `completion_attribute_bracket_target_filters_function_context` — before `function`: `TARGET_CLASS`-only attribute excluded
- [ ] `completion_attribute_bracket_excludes_non_class_types` — interfaces, enums, traits absent
- [ ] `completion_attribute_bracket_returns_only_attribute_classes` — full snapshot: no keywords or builtins leak through
- [ ] `completion_attribute_bracket_trigger_char_filters_non_attributes` — `triggerKind: 2` path also filters correctly