### PR TITLE
perf: member-completion early exit and Arc-wrapped semantic-token cache

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1813,11 +1813,13 @@ impl LanguageServer for Backend {
         };
         let tokens = semantic_tokens(doc.source(), &doc);
         let result_id = token_hash(&tokens);
+        let tokens_arc = Arc::new(tokens);
         self.docs
-            .store_token_cache(uri, result_id.clone(), tokens.clone());
+            .store_token_cache(uri, result_id.clone(), Arc::clone(&tokens_arc));
+        let data = Arc::try_unwrap(tokens_arc).unwrap_or_else(|arc| (*arc).clone());
         Ok(Some(SemanticTokensResult::Tokens(SemanticTokens {
             result_id: Some(result_id),
-            data: tokens,
+            data,
         })))
     }
 
@@ -1852,7 +1854,7 @@ impl LanguageServer for Backend {
             None => return Ok(None),
         };
 
-        let new_tokens = semantic_tokens(doc.source(), &doc);
+        let new_tokens = Arc::new(semantic_tokens(doc.source(), &doc));
         let new_result_id = token_hash(&new_tokens);
         let prev_id = &params.previous_result_id;
 
@@ -1867,7 +1869,7 @@ impl LanguageServer for Backend {
             // Unknown previous result — fall back to full tokens
             None => SemanticTokensFullDeltaResult::Tokens(SemanticTokens {
                 result_id: Some(new_result_id.clone()),
-                data: new_tokens.clone(),
+                data: (*new_tokens).clone(),
             }),
         };
 

--- a/src/completion/member.rs
+++ b/src/completion/member.rs
@@ -30,11 +30,15 @@ pub(super) fn all_instance_members(
             continue;
         }
         let mut parent: Option<String> = None;
+        // PHP defines a class in exactly one file, so stop scanning once the
+        // defining doc is hit. Without the early break, member completion
+        // walks every workspace doc for every class in the inheritance chain.
         for d in &all {
             let members = members_of_class(d, &current);
-            if parent.is_none() {
-                parent = members.parent.clone();
+            if !members.found {
+                continue;
             }
+            parent = members.parent.clone();
             for (name, is_static) in members.methods {
                 if !is_static && seen_names.insert(name.clone()) {
                     // Method params unknown here; use has_params=true so
@@ -88,6 +92,7 @@ pub(super) fn all_instance_members(
             for trait_name in members.trait_uses {
                 queue.push(trait_name);
             }
+            break;
         }
         // Fall back to built-in stubs if the class wasn't found in any user doc
         if let Some(stub) = builtin_class_members(&current) {
@@ -147,9 +152,10 @@ pub(super) fn all_static_members(
         let mut parent: Option<String> = None;
         for d in &all {
             let members = members_of_class(d, &current);
-            if parent.is_none() {
-                parent = members.parent.clone();
+            if !members.found {
+                continue;
             }
+            parent = members.parent.clone();
             for (name, is_static) in members.methods {
                 if is_static && seen_names.insert(name.clone()) {
                     items.push(callable_item(&name, CompletionItemKind::METHOD, true));
@@ -180,6 +186,7 @@ pub(super) fn all_static_members(
             for trait_name in members.trait_uses {
                 queue.push(trait_name);
             }
+            break;
         }
         // Fall back to built-in stubs for static members
         if let Some(stub) = builtin_class_members(&current) {

--- a/src/document_store.rs
+++ b/src/document_store.rs
@@ -20,7 +20,9 @@ const PARSED_CACHE_CAP: usize = 2048;
 pub struct DocumentStore {
     /// Cached semantic tokens per document: (result_id, tokens).
     /// Used to compute incremental deltas for `textDocument/semanticTokens/full/delta`.
-    token_cache: DashMap<Url, (String, Vec<SemanticToken>)>,
+    /// Tokens are stored in an `Arc` so the delta-path lookup can hand the
+    /// previous snapshot back without cloning the inner Vec.
+    token_cache: DashMap<Url, (String, Arc<Vec<SemanticToken>>)>,
 
     // ── Salsa-input storage ────────────────────────────────────────────────
     // Phase E4: `DocumentStore` is now a pure salsa-input wrapper. Open-file
@@ -473,16 +475,16 @@ impl DocumentStore {
 
     /// Cache the semantic tokens computed for a delta response.
     /// `result_id` is an opaque string (a hash of the token data) returned to the client.
-    pub fn store_token_cache(&self, uri: &Url, result_id: String, tokens: Vec<SemanticToken>) {
+    pub fn store_token_cache(&self, uri: &Url, result_id: String, tokens: Arc<Vec<SemanticToken>>) {
         self.token_cache.insert(uri.clone(), (result_id, tokens));
     }
 
     /// Return the cached tokens if `result_id` matches the stored one.
-    pub fn get_token_cache(&self, uri: &Url, result_id: &str) -> Option<Vec<SemanticToken>> {
+    pub fn get_token_cache(&self, uri: &Url, result_id: &str) -> Option<Arc<Vec<SemanticToken>>> {
         self.token_cache
             .get(uri)
             .filter(|e| e.0.as_str() == result_id)
-            .map(|e| e.1.clone())
+            .map(|e| Arc::clone(&e.1))
     }
 
     /// Before running semantic analysis for `uri`, resolve every `use`-imported
@@ -778,7 +780,7 @@ mod tests {
         let store = DocumentStore::new();
         let u = uri("/a.php");
         open(&store, u.clone(), "<?php".to_string());
-        store.store_token_cache(&u, "id1".to_string(), vec![]);
+        store.store_token_cache(&u, "id1".to_string(), Arc::new(vec![]));
         assert!(store.get_token_cache(&u, "id1").is_some());
         store.evict_token_cache(&u);
         assert!(store.get_token_cache(&u, "id1").is_none());

--- a/src/type_map.rs
+++ b/src/type_map.rs
@@ -871,6 +871,10 @@ pub struct ClassMembers {
     pub parent: Option<String>,
     /// Trait names used by this class (`use Foo, Bar;`).
     pub trait_uses: Vec<String>,
+    /// True when a class/enum/trait with this name was found in the doc.
+    /// Lets workspace-wide loops short-circuit once the defining doc is hit
+    /// instead of continuing to scan every file.
+    pub found: bool,
 }
 
 /// Return all members (methods, properties, constants) of `class_name`.
@@ -890,6 +894,7 @@ fn collect_members_stmts(
     for stmt in stmts {
         match &stmt.kind {
             StmtKind::Class(c) if c.name == Some(class_name) => {
+                out.found = true;
                 // Check docblock for @property and @method tags
                 if let Some(raw) = docblock_before(source, stmt.span.start) {
                     let db = parse_docblock(&raw);
@@ -940,6 +945,7 @@ fn collect_members_stmts(
                 return c.extends.as_ref().map(|n| n.to_string_repr().to_string());
             }
             StmtKind::Enum(e) if e.name == class_name => {
+                out.found = true;
                 let is_backed = e.scalar_type.is_some();
                 // Every enum instance exposes `->name`; backed enums also expose `->value`.
                 out.properties.push(("name".to_string(), false));
@@ -970,6 +976,7 @@ fn collect_members_stmts(
                 return None; // enums have no parent class
             }
             StmtKind::Trait(t) if t.name == class_name => {
+                out.found = true;
                 for member in t.members.iter() {
                     match &member.kind {
                         ClassMemberKind::Method(m) => {


### PR DESCRIPTION
## Summary

Two independent perf fixes from the open `perf:` issues:

- **#137** — `all_instance_members` / `all_static_members` walk every workspace doc for every class in the inheritance chain even though PHP defines a class in exactly one file. Adds a `found` flag on `ClassMembers` and breaks the inner loop on the first matching doc.
- **#194** — the semantic-tokens delta lookup currently clones the full token `Vec` from the cache on every `semanticTokens/full/delta` request. Wraps the cache value in `Arc<Vec<SemanticToken>>` so the delta lookup is a cheap `Arc::clone`. The full-tokens response still produces an owned `Vec` for the wire reply.

Closes #137, closes #194.