### PR TITLE
perf(diagnostics): use mir analyze_dependents_of for cross-file republish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1037,10 +1037,11 @@ dependencies = [
 
 [[package]]
 name = "mir-analyzer"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b253629dcdf893e5491c671995ec045fde0e6865da31ce7e58ac47513916e88"
+checksum = "9191ac36fc531c11e639955ccc3654a55c53b395362e6a718407ac5fd3b5b950"
 dependencies = [
+ "bincode 1.3.3",
  "blake3",
  "bumpalo",
  "indexmap",
@@ -1063,9 +1064,9 @@ dependencies = [
 
 [[package]]
 name = "mir-codebase"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1861f3c8baeb4f7a2c312345160694e3808be2497f6a3eb7762bd22a4ad8eee8"
+checksum = "85fbc72272a76f320cc07150f75e68fdfe60845c818dd5116204fb13fd43b351"
 dependencies = [
  "indexmap",
  "mir-types",
@@ -1075,9 +1076,9 @@ dependencies = [
 
 [[package]]
 name = "mir-issues"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eecf8dfc53c41e9c3a9b95b73d3a62d76ffd800bc0c6252811f5ab7ccd768b76"
+checksum = "c08ea602148383783487d890b640b3b300ca1ef47a32e5c46d7579ce7b44df3d"
 dependencies = [
  "mir-types",
  "owo-colors",
@@ -1087,9 +1088,9 @@ dependencies = [
 
 [[package]]
 name = "mir-types"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe2f2a152ca45b84b69fe032d9024a12cf8f2132c7f4393a965728f231721ed9"
+checksum = "4e016adc3d3732bacd58f5b48f8c7f1a079f8a868d36496539c635ed4dfa8e2e"
 dependencies = [
  "indexmap",
  "serde",
@@ -1182,9 +1183,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "php-ast"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6c3dbff56d9321b15ad0d1445b9e27748d8d9b50ccd01382830a2140a96d35e"
+checksum = "d1449c1eadaa1544447adbd2c7e88baf54bccbc5b8a67853c19f47ecd556a0a7"
 dependencies = [
  "bumpalo",
  "serde",
@@ -1192,9 +1193,9 @@ dependencies = [
 
 [[package]]
 name = "php-lexer"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a068938b56e8bf0d089c56a796a0ecec4e7d1c34071275af998558efa934cd"
+checksum = "7212a3963c694f9ee2a4f8babc1e48fceb08931c4fab04b524bfe2887b74a3a5"
 dependencies = [
  "memchr",
  "php-ast",
@@ -1235,9 +1236,9 @@ dependencies = [
 
 [[package]]
 name = "php-rs-parser"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c54757a196e8b24cc151f077272f462b2a016aee8bc55cf0b646cfac7fb5777f"
+checksum = "a83763846a9cff60d74031fe077bc07f1030a1911410c2c21f16772ee450528b"
 dependencies = [
  "bumpalo",
  "memchr",
@@ -1250,9 +1251,9 @@ dependencies = [
 
 [[package]]
 name = "phpdoc-parser"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17c10ed1ab15530f939de140081510109b35bcc45413c9ebf78c702717497af1"
+checksum = "f5534a8336d7898d52f4ba3c76988a1213b3698c92f0a9eb166fd60329cea531"
 dependencies = [
  "serde",
 ]
@@ -1369,9 +1370,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.39.3"
+version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721da970c312655cde9b4ffe0547f20a8494866a4af5ff51f18b7c633d0c870b"
+checksum = "2474bd2e5029e7ccb6abb2ba48cf2383a333851dedf495901544281590c7da7f"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,10 +40,10 @@ dhat = { version = "0.3", optional = true }
 mimalloc = { version = "0.1", default-features = false }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
-mir-analyzer = "0.25"
-mir-issues = "0.25"
-mir-codebase = "0.25"
-mir-types = "0.25"
+mir-analyzer = "0.26"
+mir-issues = "0.26"
+mir-codebase = "0.26"
+mir-types = "0.26"
 php-rs-parser = "0.12"
 php-ast = "0.12"
 bumpalo = { version = "3", features = ["collections"] }


### PR DESCRIPTION
## Summary

Replace the open-file iteration in `compute_dependent_publishes_owned` with `session.analyze_dependents_of(uri)`, and bump mir from 0.23 to 0.26 to pick up the dependency-graph fixes that made the switch safe.

### Background

`did_change` / `did_open` republishes diagnostics on every open file other than the one that changed. The previous code did so by iterating each open URL and re-running `get_semantic_issues_salsa`, an O(n_open) walk on every edit. The comment justifying the loop said mir's dependency graph only tracked `use`-imports — true historically, no longer.

### What changed in mir

The bumps landed three things that the LSP side was missing:

- **0.24** — `record_reference_location` now fires at every site that can produce a cross-file diagnostic: `instanceof`, `catch`, `::class`, `::CONST`, parameter / return / property type hints. `file_references` forward index makes `dependency_graph()` O(edges) instead of O(files × refs).
- **0.25** — `stale_defined_symbols` tracking keeps a file in the dependent set after a definition is *removed* (rename / delete). Without this, the dependent's stale `UndefinedClass` diagnostic never got republished. Caught locally by reproducing against mir 0.24 directly before opening the bug.
- **0.26** — persistent Pass-1 StubSlice cache. Targets cold-start and vendor batches; warm-state per-keystroke cost is unchanged.

### What this PR does

`compute_dependent_publishes_owned` now asks mir which files actually depend on `changed_uri`, intersects with currently-open URLs, and emits one batched `class_issues_for` call to fold workspace-level class diagnostics (circular inheritance, override violations, abstract-method gaps) into each dependent's bundle. mir runs Pass 2 in parallel via rayon.

Two `feature_incremental` regression tests adjusted to the new (stricter) semantics:

- `cross_file_republish_uses_empty_array_for_clean_dependent` — second file is now a real dependent of the first. Under the new path, files that are not dependents simply don't receive an empty publish, so the test now exercises a real cross-file edge.
- `cross_file_republish_preserves_dependent_parse_errors` — counts parse-error diagnostics specifically. The dependent's `UndefinedClass` legitimately clears once the trigger class is defined, so `total_count >=` no longer captures the invariant; what matters is that parse errors survive the republish.

### Performance

Criterion, warm cache, against the `mir-0.23` baseline (`cargo bench --bench semantic`):

| Benchmark | mir 0.23 (old loop) | mir 0.26 + new path | Δ |
|---|---|---|---|
| `semantic/single_file/medium` | 27.17 ms | 11.65 ms | **−57.1%** |
| `semantic/edit_loop/medium` | 655.7 µs | 456.8 µs | **−32.5%** |
| `semantic/laravel_scale/reanalyze_str` | 6.53 ms | 5.43 ms | **−17.0%** |

All p < 0.05. The structural LSP win (skipping the O(n_open) loop when a change has no dependents) is on top of the per-file gain shown here and is most visible with many open files and small, local edits — not captured by the microbench.

### Commits

- `e68a5c7` — `perf(diagnostics): replace open-file iteration with analyze_dependents_of`
- `a28c392` — `chore(deps): bump mir-* to 0.26`