### PR TITLE
Fix didOpen deadlock during initial workspace scan

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -567,6 +567,14 @@ async fn compute_dependent_publishes_owned(
     is_laravel: bool,
 ) -> Vec<(Uri, Vec<Diagnostic>)> {
     tokio::task::spawn_blocking(move || {
+        // A dependent sweep started during the initial scan can deadlock the
+        // shared rayon pool: reanalysis retains salsa snapshots while a scan
+        // writer waits for them to drop. Defer the sweep until readiness;
+        // post-scan republishing covers every open file.
+        if !docs.is_index_ready() {
+            return Vec::new();
+        }
+
         // rust-analyzer model: we only ever publish for files the editor has
         // open, so re-analyze exactly that set and let salsa memoization make
         // the unaffected ones ~free. No dependent set is computed at all —

--- a/src/backend/tests.rs
+++ b/src/backend/tests.rs
@@ -3,7 +3,39 @@ use super::*;
 use crate::document::ast::ParsedDoc;
 use crate::editing::use_import::{build_use_import_edit, find_use_insert_line};
 use crate::lang::config::{DiagnosticsConfig, FeaturesConfig, MAX_INDEXED_FILES};
+use std::sync::Arc;
 use tower_lsp_server::ls_types::{Position, Range, Uri};
+
+#[tokio::test]
+async fn dependent_reanalysis_is_skipped_before_index_ready() {
+    // Given two open files while the workspace index is not ready.
+    let docs = Arc::new(DocumentStore::new());
+    let open_files = OpenFiles::new();
+    let changed_uri = "file:///changed.php".parse::<Uri>().unwrap();
+    let dependent_uri = "file:///dependent.php".parse::<Uri>().unwrap();
+    open_files.set_open_text(
+        &docs,
+        changed_uri.clone(),
+        "<?php\nfunction changed(): void {}\n".to_owned(),
+    );
+    open_files.set_open_text(&docs, dependent_uri, "<?php\nchanged();\n".to_owned());
+
+    // When the changed file asks for dependent diagnostic publishes.
+    let publishes = compute_dependent_publishes_owned(
+        Arc::clone(&docs),
+        open_files,
+        changed_uri,
+        DiagnosticsConfig::default(),
+        false,
+    )
+    .await;
+
+    // Then no dependent sweep starts before the initial scan completes.
+    assert!(
+        publishes.is_empty(),
+        "dependent reanalysis must wait until the workspace index is ready"
+    );
+}
 
 // DiagnosticsConfig::from_value tests
 #[test]


### PR DESCRIPTION
Opening a second file while the initial workspace scan is running can start dependent reanalysis before the index is ready. Reanalysis can retain Salsa snapshots while scan workers wait for those snapshots on the shared Rayon pool, preventing `indexReady` and later navigation requests from completing.

Defer dependent reanalysis until the index is ready. The opened file still receives diagnostics, and `republish_after_index_ready` recomputes diagnostics for open files after the scan completes.

Add a regression test for two open files before index readiness. [PHP Typing Conformance](https://zonuexe.github.io/php-typing-conformance/) uses the [PsySH](https://github.com/bobthecow/psysh) codebase as an LSP compatibility test corpus through [run-lsp-probes.php](https://github.com/zonuexe/php-typing-conformance/blob/master/conformance/src/run-lsp-probes.php). Its navigation probes now complete without timeouts.